### PR TITLE
fix: add prepublish step to make links absolute for npm docs

### DIFF
--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/ajax"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/button"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/checkbox-group"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/checkbox"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/choice-input/package.json
+++ b/packages/choice-input/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/choice-input"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/core"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/field/docs/FormatMixin.md
+++ b/packages/field/docs/FormatMixin.md
@@ -12,7 +12,7 @@ or a float). The modelValue can(and is recommended to) be used as both input val
 output value of the `<lion-field>`
 
 Examples:
-- For a date input: a String '20/01/1999' will be converted to new Date('1999-01-20')
+- For a date input: a String '20/01/1999' will be converted to new Date('1999/01/20')
 - For a number input: a formatted String '1.234,56' will be converted to a Number: 1234.56
 
 ### formattedValue

--- a/packages/field/docs/FormattingAndParsing.md
+++ b/packages/field/docs/FormattingAndParsing.md
@@ -15,7 +15,7 @@ output value of the `<lion-field>`.
 
 Examples:
 
-- For a date input: a String '20/01/1999' will be converted to new Date('1999-01-20')
+- For a date input: a String '20/01/1999' will be converted to new Date('1999/01/20')
 - For a number input: a formatted String '1.234,56' will be converted to a Number: 1234.56
 
 ### formattedValue

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/field"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/field/src/FormatMixin.js
+++ b/packages/field/src/FormatMixin.js
@@ -25,7 +25,7 @@ export const FormatMixin = dedupeMixin(
            * output value of the <lion-field>
            *
            * Examples:
-           * - For a date input: a String '20/01/1999' will be converted to new Date('1999-01-20')
+           * - For a date input: a String '20/01/1999' will be converted to new Date('1999/01/20')
            * - For a number input: a formatted String '1.234,56' will be converted to a Number: 1234.56
            */
           modelValue: {

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/fieldset"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/form-system/package.json
+++ b/packages/form-system/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/form-system"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/form"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/icon"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/input-amount"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/input-date"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/input-email"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/input-iban"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/input"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/localize"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/overlays"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/popup"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/radio-group"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/radio"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/select"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/steps"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/textarea"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/tooltip"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -14,7 +14,7 @@
     "directory": "packages/validate"
   },
   "scripts": {
-    "prepublishOnly": "../../scripts/insert-header.js"
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
   },
   "keywords": [
     "lion",

--- a/packages/validate/test/validators.test.js
+++ b/packages/validate/test/validators.test.js
@@ -137,23 +137,23 @@ describe('LionValidate', () => {
     });
 
     it('provides minDate() to allow only dates earlier then min', () => {
-      expect(minDate(new Date('2018-02-03'), new Date('2018-02-02'))).to.be.true;
-      expect(minDate(new Date('2018-02-01'), new Date('2018-02-02'))).to.be.false;
+      expect(minDate(new Date('2018-02-03'), new Date('2018/02/02'))).to.be.true;
+      expect(minDate(new Date('2018-02-01'), new Date('2018/02/02'))).to.be.false;
     });
 
     it('provides maxDate() to allow only dates before max', () => {
-      expect(maxDate(new Date('2018-02-01'), new Date('2018-02-02'))).to.be.true;
-      expect(maxDate(new Date('2018-02-03'), new Date('2018-02-02'))).to.be.false;
+      expect(maxDate(new Date('2018-02-01'), new Date('2018/02/02'))).to.be.true;
+      expect(maxDate(new Date('2018-02-03'), new Date('2018/02/02'))).to.be.false;
     });
 
     it('provides minMaxDate() to allow only dates between min and max', () => {
       const minMaxSetting = {
-        min: new Date('2018-02-02'),
-        max: new Date('2018-02-04'),
+        min: new Date('2018/02/02'),
+        max: new Date('2018/02/04'),
       };
-      expect(minMaxDate(new Date('2018-02-03'), minMaxSetting)).to.be.true;
-      expect(minMaxDate(new Date('2018-02-01'), minMaxSetting)).to.be.false;
-      expect(minMaxDate(new Date('2018-02-05'), minMaxSetting)).to.be.false;
+      expect(minMaxDate(new Date('2018/02/03'), minMaxSetting)).to.be.true;
+      expect(minMaxDate(new Date('2018/02/01'), minMaxSetting)).to.be.false;
+      expect(minMaxDate(new Date('2018/02/05'), minMaxSetting)).to.be.false;
     });
 
     it('provides {isDate, minDate, maxDate, minMaxDate}Validator factory function for all types', () => {
@@ -162,20 +162,20 @@ describe('LionValidate', () => {
       smokeTestValidator(
         'minDate',
         minDateValidator,
-        new Date('2018-02-03'),
-        new Date('2018-02-02'),
+        new Date('2018/02/03'),
+        new Date('2018/02/02'),
       );
       smokeTestValidator(
         'maxDate',
         maxDateValidator,
-        new Date('2018-02-01'),
-        new Date('2018-02-02'),
+        new Date('2018/02/01'),
+        new Date('2018/02/02'),
       );
       const minMaxSetting = {
-        min: new Date('2018-02-02'),
-        max: new Date('2018-02-04'),
+        min: new Date('2018/02/02'),
+        max: new Date('2018/02/04'),
       };
-      smokeTestValidator('minMaxDate', minMaxDateValidator, new Date('2018-02-03'), minMaxSetting);
+      smokeTestValidator('minMaxDate', minMaxDateValidator, new Date('2018/02/03'), minMaxSetting);
     });
   });
 

--- a/scripts/insert-header.js
+++ b/scripts/insert-header.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /* eslint-disable consistent-return, no-console */
 const fs = require('fs');
 

--- a/scripts/npm-prepublish.js
+++ b/scripts/npm-prepublish.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+// insert headers in README.md
+require('./insert-header.js');
+
+// rewrite relative markdown documentation links to absolute Github links
+require('./rewrite-links.js')();

--- a/scripts/rewrite-links.js
+++ b/scripts/rewrite-links.js
@@ -1,0 +1,122 @@
+/**
+ * Before we publish to npm, we want to rewrite all relative links inside markdown files to
+ * absolute github paths, so that documentation hosted on npmjs.com never contains broken links.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const rewriteLinksConfig = {
+  githubPath: 'https://github.com/ing-bank/lion/blob/master/',
+  monorepoRootPath: path.resolve(__dirname, '../'),
+};
+
+const gatherFilesConfig = {
+  extension: '.md',
+  excludeFiles: ['CHANGELOG.md'],
+  excludeFolders: ['node_modules', '.history'],
+};
+
+/**
+ * Gets an array of files for given extension
+ * @param {string} startPath - local filesystem path
+ * @param {object} cfg - configuration object
+ * @param {string} cfg.extension - file extension like '.md'
+ * @param {array} cfg.excludeFiles - file names filtered out
+ * @param {array} cfg.excludeFolders - folder names filtered out
+ * @param {array} result - list of file paths
+ * @returns {array} result list of file paths
+ */
+function gatherFilesFromDir(startPath, cfg = gatherFilesConfig, result = []) {
+  const files = fs.readdirSync(startPath);
+  files.forEach(file => {
+    const filePath = path.join(startPath, file);
+    const stat = fs.lstatSync(filePath);
+    if (stat.isDirectory()) {
+      const folderName = filePath.replace(/.*\/([^/]+)$/, '$1');
+      if (!cfg.excludeFolders.includes(folderName)) {
+        gatherFilesFromDir(filePath, cfg, result); // search recursively
+      }
+    } else if (filePath.endsWith(cfg.extension)) {
+      const fileName = filePath.replace(/.*\/([^/]+)$/, '$1');
+      if (!cfg.excludeFiles.includes(fileName)) {
+        result.push(filePath);
+      }
+    }
+  });
+  return result;
+}
+
+/**
+ * Rewrites all relative links of markdown content to absolute links.
+ * Also includes images. See: https://github.com/tcort/markdown-link-extractor/blob/master/index.js
+ * @param {string} mdContent - contents of .md file to parse
+ * @param {string} filePath - local filesystem path of md file,
+ * like '/path/to/lion/packages/my-component/docs/myClass.md'
+ * @param {object} cfg - configurantion object
+ * @param {string} cfg.githubPath - root github url for the absolute result links
+ * @param {string} cfg.monorepoRootPath - local filesystem root path of the monorepo
+ * @returns {string} adjusted contents of input md file (mdContent)
+ */
+function rewriteLinksInMdContent(mdContent, filePath, cfg = rewriteLinksConfig) {
+  const rewrite = href => {
+    let newHref = href;
+    const isRelativeUrlPattern = /^(\.\/|\.\.\/)/; // starts with './' or '../'
+    if (href.match(isRelativeUrlPattern)) {
+      const fileFolder = filePath.replace(/(.*\/).*/g, '$1');
+      const absoluteLocalPath = path.resolve(fileFolder, href);
+      // relativeFromRootPath: for instance 'packages/my-component/docs/' when
+      // filePath is 'path/to/repo/packages/my-component/docs/myDoc.md'
+      const relativeFromRootPath = absoluteLocalPath.replace(cfg.monorepoRootPath, '').slice(1);
+      // newRoot: https://github.com/ing-bank/lion/blob/master/packages/my-component/docs/
+      newHref = cfg.githubPath + relativeFromRootPath;
+    }
+    return newHref;
+  };
+
+  const mdLink = (href, title, text) => {
+    return `[${text}](${rewrite(href)}${title ? ` ${title}` : ''})`;
+  };
+
+  const resultLinks = [];
+  // /^!?\[(label)\]\(href(?:\s+(title))?\s*\)/
+  const linkPattern = '!?\\[(.*)\\]\\(([^|\\s]*)( +(.*))?\\s*\\)'; // eslint-disable-line
+  const matches = mdContent.match(new RegExp(linkPattern, 'g')) || [];
+
+  matches.forEach(link => {
+    let newLink = '';
+    const parts = link.match(new RegExp(linkPattern));
+    if (parts) {
+      newLink = mdLink(parts[2], parts[3], parts[1]);
+    }
+    resultLinks.push(newLink);
+  });
+
+  // Now that we have our rewritten links, stitch back together the desired result
+  const tokenPattern = /!?\[.*\]\([^|\s]*(?: +.*)?\s*\)/;
+  const tokens = mdContent.split(new RegExp(tokenPattern, 'g'));
+  const resultTokens = [];
+  tokens.forEach((token, i) => {
+    resultTokens.push(token + (resultLinks[i] || ''));
+  });
+  const resultContent = resultTokens.join('');
+  return resultContent;
+}
+
+/**
+ * Main code
+ */
+function main({ dryRun } = { dryRun: false }) {
+  const mdFilePaths = gatherFilesFromDir(process.cwd()); // [path.resolve(__dirname, '../', 'packages/field/README.md')];
+  mdFilePaths.forEach(filePath => {
+    const content = fs.readFileSync(filePath).toString();
+    const rewrittenContent = rewriteLinksInMdContent(content, filePath);
+    if (dryRun) {
+      console.log(`== output for filePath '${filePath}' ===`); // eslint-disable-line no-console
+      console.log(rewrittenContent); // eslint-disable-line no-console
+    } else {
+      fs.writeFileSync(filePath, rewrittenContent);
+    }
+  });
+}
+module.exports = main;


### PR DESCRIPTION
Fixes https://github.com/ing-bank/lion/issues/13

> Note: still Work in Progress

I wrote a script that can be added to the script already running on 'prepublishOnly'.
The 'npm-prepublish-index.js' file can be used to assemble all prepublish tasks ('insert-header.js' and 'rewrite-links.js' right now). 

`package.json` of all individual packages should still be changed to:
```json
  "scripts": {
    "prepublishOnly": "../../npm-prepublish-index.js"
  },
```

@daKmoR : 
- could you give some hints on how to test this locally without publishing?
- could we do a cleanup or something (restore of links) on postPublish? 

For testing locally, please do: 
```js
require('./rewrite-links.js')({ dryRun: true });
```
