### PR TITLE
chore: fix date construction for consistency across different envs

### DIFF
--- a/packages/field/docs/FormatMixin.md
+++ b/packages/field/docs/FormatMixin.md
@@ -12,7 +12,7 @@ or a float). The modelValue can(and is recommended to) be used as both input val
 output value of the `<lion-field>`
 
 Examples:
-- For a date input: a String '20/01/1999' will be converted to new Date('1999-01-20')
+- For a date input: a String '20/01/1999' will be converted to new Date('1999/01/20')
 - For a number input: a formatted String '1.234,56' will be converted to a Number: 1234.56
 
 ### formattedValue

--- a/packages/field/docs/FormattingAndParsing.md
+++ b/packages/field/docs/FormattingAndParsing.md
@@ -15,7 +15,7 @@ output value of the `<lion-field>`.
 
 Examples:
 
-- For a date input: a String '20/01/1999' will be converted to new Date('1999-01-20')
+- For a date input: a String '20/01/1999' will be converted to new Date('1999/01/20')
 - For a number input: a formatted String '1.234,56' will be converted to a Number: 1234.56
 
 ### formattedValue

--- a/packages/field/src/FormatMixin.js
+++ b/packages/field/src/FormatMixin.js
@@ -25,7 +25,7 @@ export const FormatMixin = dedupeMixin(
            * output value of the <lion-field>
            *
            * Examples:
-           * - For a date input: a String '20/01/1999' will be converted to new Date('1999-01-20')
+           * - For a date input: a String '20/01/1999' will be converted to new Date('1999/01/20')
            * - For a number input: a formatted String '1.234,56' will be converted to a Number: 1234.56
            */
           modelValue: {

--- a/packages/validate/test/validators.test.js
+++ b/packages/validate/test/validators.test.js
@@ -130,23 +130,23 @@ describe('LionValidate', () => {
     });
 
     it('provides minDate() to allow only dates earlier then min', () => {
-      expect(minDate(new Date('2018-02-03'), new Date('2018-02-02'))).to.be.true;
-      expect(minDate(new Date('2018-02-01'), new Date('2018-02-02'))).to.be.false;
+      expect(minDate(new Date('2018-02-03'), new Date('2018/02/02'))).to.be.true;
+      expect(minDate(new Date('2018-02-01'), new Date('2018/02/02'))).to.be.false;
     });
 
     it('provides maxDate() to allow only dates before max', () => {
-      expect(maxDate(new Date('2018-02-01'), new Date('2018-02-02'))).to.be.true;
-      expect(maxDate(new Date('2018-02-03'), new Date('2018-02-02'))).to.be.false;
+      expect(maxDate(new Date('2018-02-01'), new Date('2018/02/02'))).to.be.true;
+      expect(maxDate(new Date('2018-02-03'), new Date('2018/02/02'))).to.be.false;
     });
 
     it('provides minMaxDate() to allow only dates between min and max', () => {
       const minMaxSetting = {
-        min: new Date('2018-02-02'),
-        max: new Date('2018-02-04'),
+        min: new Date('2018/02/02'),
+        max: new Date('2018/02/04'),
       };
-      expect(minMaxDate(new Date('2018-02-03'), minMaxSetting)).to.be.true;
-      expect(minMaxDate(new Date('2018-02-01'), minMaxSetting)).to.be.false;
-      expect(minMaxDate(new Date('2018-02-05'), minMaxSetting)).to.be.false;
+      expect(minMaxDate(new Date('2018/02/03'), minMaxSetting)).to.be.true;
+      expect(minMaxDate(new Date('2018/02/01'), minMaxSetting)).to.be.false;
+      expect(minMaxDate(new Date('2018/02/05'), minMaxSetting)).to.be.false;
     });
 
     it('provides {isDate, minDate, maxDate, minMaxDate}Validator factory function for all types', () => {
@@ -155,20 +155,20 @@ describe('LionValidate', () => {
       smokeTestValidator(
         'minDate',
         minDateValidator,
-        new Date('2018-02-03'),
-        new Date('2018-02-02'),
+        new Date('2018/02/03'),
+        new Date('2018/02/02'),
       );
       smokeTestValidator(
         'maxDate',
         maxDateValidator,
-        new Date('2018-02-01'),
-        new Date('2018-02-02'),
+        new Date('2018/02/01'),
+        new Date('2018/02/02'),
       );
       const minMaxSetting = {
-        min: new Date('2018-02-02'),
-        max: new Date('2018-02-04'),
+        min: new Date('2018/02/02'),
+        max: new Date('2018/02/04'),
       };
-      smokeTestValidator('minMaxDate', minMaxDateValidator, new Date('2018-02-03'), minMaxSetting);
+      smokeTestValidator('minMaxDate', minMaxDateValidator, new Date('2018/02/03'), minMaxSetting);
     });
   });
 


### PR DESCRIPTION
We construct dates like `new Date('YYYY/MM/DD')` (in this order with slashes) for consistency, otherwise it might be interpreted differently in some environments.