### PR TITLE
feat(overlays): allow adding invoker nodes to GlobalOverlayController

### DIFF
--- a/packages/overlays/src/GlobalOverlayController.js
+++ b/packages/overlays/src/GlobalOverlayController.js
@@ -40,6 +40,10 @@ export class GlobalOverlayController {
     this._isShown = false;
     this._data = {};
     this._container = null;
+
+    if (finalParams.invokerNodes) {
+      this.addInvokerNodes(finalParams.invokerNodes);
+    }
   }
 
   get isShown() {
@@ -48,7 +52,7 @@ export class GlobalOverlayController {
 
   /**
    * Syncs shown state and data.
-   * @param {object} options optioons to sync
+   * @param {object} options options to sync
    * @param {boolean} [options.isShown] whether the overlay should be shown
    * @param {object} [options.data] data to pass to the content template function
    * @param {HTMLElement} [options.elementToFocusAfterHide] element to return focus when hiding
@@ -78,7 +82,22 @@ export class GlobalOverlayController {
    * Hides the overlay.
    */
   hide() {
+    if (this._expandedInvokerNode) {
+      this._expandedInvokerNode.setAttribute('aria-expanded', 'false');
+    }
     this._createOrUpdateOverlay(false, this._data);
+  }
+
+  addInvokerNodes(nodes) {
+    nodes.forEach(node => {
+      node.addEventListener('click', () => {
+        node.setAttribute('aria-expanded', 'true');
+        this._expandedInvokerNode = node;
+        this.show(node);
+      });
+      node.setAttribute('aria-haspopup', 'dialog');
+      node.setAttribute('aria-expanded', 'false');
+    });
   }
 
   /**

--- a/packages/overlays/stories/global-overlay.stories.js
+++ b/packages/overlays/stories/global-overlay.stories.js
@@ -26,6 +26,35 @@ const globalOverlayDemoStyle = css`
 
 storiesOf('Global Overlay System|Global Overlay', module)
   .add('Default', () => {
+    const buttonEl = document.createElement('button');
+    buttonEl.innerText = 'Open overlay';
+
+    const overlayCtrl = overlays.add(
+      new GlobalOverlayController({
+        contentTemplate: () => html`
+          <div class="demo-overlay">
+            <p>Simple overlay</p>
+            <button @click="${() => overlayCtrl.hide()}">Close</button>
+          </div>
+        `,
+        invokerNodes: [buttonEl],
+      }),
+    );
+    return html`
+      <style>
+        ${globalOverlayDemoStyle}
+      </style>
+      <a href="#">Anchor 1</a>
+      ${buttonEl}
+      <a href="#">Anchor 2</a>
+      ${Array(50).fill(
+        html`
+          <p>Lorem ipsum</p>
+        `,
+      )}
+    `;
+  })
+  .add('Adding invoker node later', () => {
     const overlayCtrl = overlays.add(
       new GlobalOverlayController({
         contentTemplate: () => html`
@@ -41,15 +70,16 @@ storiesOf('Global Overlay System|Global Overlay', module)
       <style>
         ${globalOverlayDemoStyle}
       </style>
-      <a href="#">Anchor 1</a>
       <button
-        @click="${event => overlayCtrl.show(event.target)}"
-        aria-haspopup="dialog"
-        aria-expanded="false"
+        @click=${event => {
+          const buttonEl = document.createElement('button');
+          buttonEl.innerText = 'Open overlay';
+          overlayCtrl.addInvokerNodes([buttonEl]);
+          event.target.insertAdjacentElement('afterend', buttonEl);
+        }}
       >
-        Open overlay
+        Click here to generate an invoker to your overlay
       </button>
-      <a href="#">Anchor 2</a>
       ${Array(50).fill(
         html`
           <p>Lorem ipsum</p>

--- a/packages/overlays/test/GlobalOverlayController.test.js
+++ b/packages/overlays/test/GlobalOverlayController.test.js
@@ -220,6 +220,67 @@ describe('GlobalOverlayController', () => {
       controller.sync({ isShown: false, data: { text: 'goodbye world' } });
       expect(getRenderedContainers().length).to.equal(0);
     });
+
+    it('supports setting the invoker to HTML node(s)', () => {
+      const buttonEl = document.createElement('button');
+      const buttonEl2 = document.createElement('button');
+      const controller = new GlobalOverlayController({
+        contentTemplate: () =>
+          html`
+            <p>Hello, World!</p>
+          `,
+        invokerNodes: [buttonEl, buttonEl2],
+      });
+
+      buttonEl.click();
+      expect(getRenderedOverlay(0).innerText).to.be.equal('Hello, World!');
+      controller.hide();
+      expect(getRenderedOverlay(0)).to.be.null;
+      buttonEl2.click();
+      expect(getRenderedOverlay(0).innerText).to.be.equal('Hello, World!');
+    });
+
+    it('supports adding an invoker node later', () => {
+      const controller = new GlobalOverlayController({
+        contentTemplate: () =>
+          html`
+            <p>Hello, World!</p>
+          `,
+      });
+
+      const buttonEl = document.createElement('button');
+      controller.addInvokerNodes([buttonEl]);
+
+      buttonEl.click();
+      expect(getRenderedOverlay(0).innerText).to.be.equal('Hello, World!');
+    });
+
+    it('sets default aria roles for the invoker if a node is supplied', () => {
+      const buttonEl = document.createElement('button');
+      const buttonEl2 = document.createElement('button');
+      const controller = new GlobalOverlayController({
+        contentTemplate: () =>
+          html`
+            <p>Hello, World!</p>
+          `,
+        invokerNodes: [buttonEl, buttonEl2],
+      });
+
+      expect(buttonEl.getAttribute('aria-haspopup')).to.be.equal('dialog');
+      expect(buttonEl2.getAttribute('aria-haspopup')).to.be.equal('dialog');
+
+      expect(buttonEl.getAttribute('aria-expanded')).to.be.equal('false');
+      expect(buttonEl2.getAttribute('aria-expanded')).to.be.equal('false');
+      buttonEl.click();
+      expect(buttonEl.getAttribute('aria-expanded')).to.be.equal('true');
+      expect(buttonEl2.getAttribute('aria-expanded')).to.be.equal('false');
+      controller.hide();
+      expect(buttonEl.getAttribute('aria-expanded')).to.be.equal('false');
+      expect(buttonEl2.getAttribute('aria-expanded')).to.be.equal('false');
+      buttonEl2.click();
+      expect(buttonEl.getAttribute('aria-expanded')).to.be.equal('false');
+      expect(buttonEl2.getAttribute('aria-expanded')).to.be.equal('true');
+    });
   });
 
   describe('elementToFocusAfterHide', () => {


### PR DESCRIPTION
From https://github.com/ing-bank/lion/issues/36

Adds the following features for our users:

- Allow to pass invoker nodes (one or multiple) in the GlobalOverlayController constructor
- Allow to add invoker nodes (one or multiple) at a later stage directly on the controller instance
- In both cases click event listeners and a11y will be automatically set up for you :)!