### PR TITLE
fix(field): move `_registerFormElement` to `firstUpdated`

### DIFF
--- a/packages/field/src/FormControlMixin.js
+++ b/packages/field/src/FormControlMixin.js
@@ -92,12 +92,10 @@ export const FormControlMixin = dedupeMixin(
         super.connectedCallback();
         this._enhanceLightDomClasses();
         this._enhanceLightDomA11y();
-        this._requestParentFormGroupUpdateOfResetModelValue();
-      }
-
-      firstUpdated(changedProperties) {
-        super.firstUpdated(changedProperties);
-        this._registerFormElement();
+        this.updateComplete.then(() => {
+          this._registerFormElement();
+          this._requestParentFormGroupUpdateOfResetModelValue();
+        });
       }
 
       /**

--- a/packages/field/src/FormControlMixin.js
+++ b/packages/field/src/FormControlMixin.js
@@ -92,8 +92,12 @@ export const FormControlMixin = dedupeMixin(
         super.connectedCallback();
         this._enhanceLightDomClasses();
         this._enhanceLightDomA11y();
-        this._registerFormElement();
         this._requestParentFormGroupUpdateOfResetModelValue();
+      }
+
+      firstUpdated(changedProperties) {
+        super.firstUpdated(changedProperties);
+        this._registerFormElement();
       }
 
       /**

--- a/packages/fieldset/test/lion-fieldset.test.js
+++ b/packages/fieldset/test/lion-fieldset.test.js
@@ -150,6 +150,7 @@ describe('<lion-fieldset>', () => {
     expect(Object.keys(fieldset.formElements).length).to.equal(3);
 
     fieldset.appendChild(newField);
+    await fieldset.updateComplete;
     await nextFrame();
     expect(Object.keys(fieldset.formElements).length).to.equal(4);
 
@@ -721,6 +722,9 @@ describe('<lion-fieldset>', () => {
               <!-- group referred by: #msg_l1_g (local) -->
             </lion-fieldset>
           `);
+          const domElement = await dom;
+          await domElement.updateComplete;
+          await domElement.querySelector('[name=l2_g]').updateComplete;
           await nextFrame();
           return dom;
         };


### PR DESCRIPTION
Fixes #50.

Moved the form element registration to the `firstUpdated` event. This allows its parents to receive the event  in Edge.

Not 100% happy with it, as it seems to be a workaround for Edge. I would prefer knowing why Edge is not getting the events.