### PR TITLE
fix(input-iban): allow formatting empty IBAN model values

### DIFF
--- a/packages/input-iban/src/formatters.js
+++ b/packages/input-iban/src/formatters.js
@@ -7,5 +7,9 @@ import { friendlyFormatIBAN } from '@bundled-es-modules/ibantools';
  * @return {string} formatted value
  */
 export function formatIBAN(modelValue) {
+  // defensive code because of ibantools
+  if (modelValue === '') {
+    return '';
+  }
   return friendlyFormatIBAN(modelValue);
 }

--- a/packages/input-iban/test/formatters.test.js
+++ b/packages/input-iban/test/formatters.test.js
@@ -6,4 +6,8 @@ describe('formatIBAN', () => {
   it('formats the IBAN', () => {
     expect(formatIBAN('NL17INGB0002822608')).to.equal('NL17 INGB 0002 8226 08');
   });
+
+  it('returns `` if no value is given', () => {
+    expect(formatIBAN('')).to.equal('');
+  });
 });


### PR DESCRIPTION
This was extracted from this MR https://github.com/ing-bank/lion/pull/15

'lion-input-iban' error occurs when field is cleared and then focus is changed to anything else. After that happen user cannot put anything into the field because everything is removed.