### PR TITLE
docs: specify alternative for the deprecated LionLitElement

### DIFF
--- a/packages/core/src/LionLitElement.js
+++ b/packages/core/src/LionLitElement.js
@@ -5,6 +5,6 @@ export { css } from 'lit-element';
 export { html } from './lit-html.js';
 
 /**
- * @deprecated
+ * @deprecated use LitElement instead.
  */
 export class LionLitElement extends ElementMixin(LitElement) {}


### PR DESCRIPTION
It's useful to specify alternatives when something is deprecated. This could also allow IDEs to show the hint.