### PR TITLE
Dedupe dependencies

### DIFF
--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -39,7 +39,7 @@
     "@lion/icon": "^0.1.8",
     "@lion/input": "^0.1.13",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "@polymer/iron-test-helpers": "^3.0.1",
     "sinon": "^7.2.2"
   }

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@lion/button": "^0.1.16",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -40,7 +40,7 @@
     "@lion/form": "^0.1.15",
     "@lion/localize": "^0.3.4",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -38,6 +38,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/choice-input/package.json
+++ b/packages/choice-input/package.json
@@ -38,6 +38,6 @@
   "devDependencies": {
     "@lion/input": "^0.1.13",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@lion/localize": "^0.3.4",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -40,7 +40,7 @@
     "@lion/input": "^0.1.13",
     "@lion/localize": "^0.3.4",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/form-system/package.json
+++ b/packages/form-system/package.json
@@ -46,6 +46,6 @@
     "@lion/radio-group": "^0.1.15",
     "@lion/textarea": "^0.1.13",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -41,7 +41,7 @@
     "@lion/textarea": "^0.1.13",
     "@lion/validate": "^0.2.4",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -36,6 +36,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@lion/button": "^0.1.16",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "@polymer/iron-test-helpers": "^3.0.1",
     "sinon": "^7.2.2"
   }

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -38,7 +38,7 @@
     "@lion/calendar": "^0.1.11",
     "@lion/core": "^0.1.8",
     "@lion/input-date": "^0.1.13",
-    "@lion/localize": "^0.1.6",
+    "@lion/localize": "^0.3.4",
     "@lion/overlays": "^0.2.4",
     "@lion/validate": "^0.2.4"
   },

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -40,6 +40,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -41,6 +41,6 @@
   "devDependencies": {
     "@lion/validate": "^0.2.4",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -39,6 +39,6 @@
     "@lion/localize": "^0.3.4",
     "@lion/validate": "^0.2.4",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@bundled-es-modules/fetch-mock": "^6.5.2",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "@polymer/iron-test-helpers": "^3.0.1",
     "sinon": "^7.2.2"
   }

--- a/packages/popup/package.json
+++ b/packages/popup/package.json
@@ -39,6 +39,6 @@
     "@lion/button": "^0.1.16",
     "@lion/icon": "^0.1.8",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -39,6 +39,6 @@
     "@lion/form": "^0.1.15",
     "@lion/radio": "^0.1.13",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -38,6 +38,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -38,6 +38,6 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -39,6 +39,6 @@
     "@lion/button": "^0.1.16",
     "@lion/icon": "^0.1.8",
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1"
+    "@open-wc/testing": "^0.12.5"
   }
 }

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@open-wc/demoing-storybook": "^0.2.0",
-    "@open-wc/testing": "^0.11.1",
+    "@open-wc/testing": "^0.12.5",
     "sinon": "^7.2.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1737,14 +1737,6 @@
     npmlog "^4.1.2"
     write-file-atomic "^2.3.0"
 
-"@lion/localize@^0.1.6":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@lion/localize/-/localize-0.1.7.tgz#2f0eb725fbe5fa8842985140ae3a6f0dfbd732d6"
-  integrity sha512-6ayWBoBI6W9pwOS6qUKBo3lUltniv8v9/xcRGm3IH5+7tbeR6/3mWILwz69MvNaoj7MQhHEF7Ox746o0qIgbFw==
-  dependencies:
-    "@bundled-es-modules/message-format" "6.0.4"
-    "@lion/core" "^0.1.4"
-
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@marionebl/sander/-/sander-0.6.1.tgz#1958965874f24bc51be48875feb50d642fc41f7b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,14 +1823,6 @@
     lru-cache "^5.1.1"
     minimatch "^3.0.4"
 
-"@open-wc/chai-dom-equals@^0.11.5":
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/@open-wc/chai-dom-equals/-/chai-dom-equals-0.11.5.tgz#146b7b47874e1b3457dc5bd7ed37b9878eb3b5b5"
-  integrity sha512-eR/YEfzM+LUO4BZfZQvLfrOvddKYMXVVWHjMpDFNQ3AkvSjQkoJDn5iqiGn0THkNou8b/vgc4ZC+rmVxL05eSQ==
-  dependencies:
-    "@open-wc/semantic-dom-diff" "^0.10.5"
-    "@types/chai" "^4.1.7"
-
 "@open-wc/chai-dom-equals@^0.12.5":
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/@open-wc/chai-dom-equals/-/chai-dom-equals-0.12.5.tgz#bf883c2403b8cf282c63a2f44a7c1eb38331be76"
@@ -1906,20 +1898,10 @@
     eslint-config-prettier "^3.3.0"
     prettier "^1.15.0"
 
-"@open-wc/semantic-dom-diff@^0.10.5":
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.10.5.tgz#c3ead8d0f8adc4b26e12b3077692e254f7d98c98"
-  integrity sha512-CB9DVjy5nQjRA1A4S7qRTnZvR1tUvHGsLwih29diU3UiGULrmkFqS9NZii/YgyORAAAPhq0rD23DWn4QTLehbg==
-
 "@open-wc/semantic-dom-diff@^0.11.5":
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.11.5.tgz#7e028a15ea74d758b8e5593d11d0abb945d51bf8"
   integrity sha512-+IQ8o64Z+voxn5807+YTN9GjIEfPsdZ6Zb1O04fGL2w1/qjWAKMFZa+G0r1UuFyEUP3LU+5XGGmCXPefWmSbhA==
-
-"@open-wc/testing-helpers@^0.8.9":
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-0.8.9.tgz#c3f17cfb5338ed77b5349d712025ba6b85bec413"
-  integrity sha512-nej/k+s1EL8ynnSlkkafFCxCw51IIfzJjND1lmFFw2x0B+qAinAsILf7o4Bewm+OlKTpQs4zg6vHnTQBq1Vg3g==
 
 "@open-wc/testing-helpers@^0.9.5":
   version "0.9.5"
@@ -1973,19 +1955,6 @@
   dependencies:
     wallaby-webpack "^3.0.0"
     webpack "^4.28.0"
-
-"@open-wc/testing@^0.11.1":
-  version "0.11.5"
-  resolved "https://registry.yarnpkg.com/@open-wc/testing/-/testing-0.11.5.tgz#3783c257921901111e9289a5fe3a2840e9b986bb"
-  integrity sha512-6+P8bu7ASs/cBnswDTamoYWspJJOLamu9lYEP3HTEFDXAoNW/rdS6AlvjSOmhuEjrBZGwu8tL7BYkPGOdiRiHA==
-  dependencies:
-    "@bundled-es-modules/chai" "^4.2.0"
-    "@open-wc/chai-dom-equals" "^0.11.5"
-    "@open-wc/semantic-dom-diff" "^0.10.5"
-    "@open-wc/testing-helpers" "^0.8.9"
-    "@types/chai" "^4.1.7"
-    "@types/mocha" "^5.0.0"
-    mocha "^5.0.0"
 
 "@open-wc/testing@^0.12.5":
   version "0.12.5"


### PR DESCRIPTION
I found 2 issues in our production dependencies which makes them non-flat:

1. input-datepicker somehow uses an old localize version, probably due to a mistake during merging/rebasing
2. I forgot to update @open-wc/testing in all subpackages, which breaks legacy karma setup