### PR TITLE
fix(field): formats value after validation update

### DIFF
--- a/packages/field/src/LionField.js
+++ b/packages/field/src/LionField.js
@@ -28,9 +28,9 @@ import { FormatMixin } from './FormatMixin.js';
 // TODO: Consider exporting as FieldMixin
 // eslint-disable-next-line max-len, no-unused-vars
 export class LionField extends FormControlMixin(
-  ValidateMixin(
-    InteractionStateMixin(
-      FormatMixin(
+  InteractionStateMixin(
+    FormatMixin(
+      ValidateMixin(
         CssClassMixin(ElementMixin(DelegateMixin(SlotMixin(ObserverMixin(LionLitElement))))),
       ),
     ),

--- a/packages/field/test/lion-field.test.js
+++ b/packages/field/test/lion-field.test.js
@@ -327,6 +327,31 @@ describe('<lion-field>', () => {
       lionField.modelValue = 'cat';
       expect(lionField.error.required).to.be.undefined;
     });
+
+    it('will only update formattedValue the value when valid', async () => {
+      const formatterSpy = sinon.spy(value => `foo: ${value}`);
+      function isBarValidator(value) {
+        return { isBar: value === 'bar' };
+      }
+      const lionField = await fixture(html`
+        <${tag}
+          .modelValue=${'init-string'}
+          .formatter=${formatterSpy}
+          .errorValidators=${[[isBarValidator]]}
+        >${inputSlot}</${tag}>
+      `);
+
+      expect(formatterSpy.callCount).to.equal(0);
+      expect(lionField.formattedValue).to.equal('init-string');
+
+      lionField.modelValue = 'bar';
+      expect(formatterSpy.callCount).to.equal(1);
+      expect(lionField.formattedValue).to.equal('foo: bar');
+
+      lionField.modelValue = 'foo';
+      expect(formatterSpy.callCount).to.equal(1);
+      expect(lionField.formattedValue).to.equal('foo: bar');
+    });
   });
 
   describe(`Content projection${nameSuffix}`, () => {


### PR DESCRIPTION
As explained [here](https://github.com/ing-bank/lion/issues/22) changing the order of `ValidationMixin` and `FormatMixin` fixed the problem.

The `InteractionStateMixin` has to be done after the `FormatMixin` otherwise the field(set)s will falsy be set to `dirty`.