### PR TITLE
fix(calendar): init centralDate from selectedDate when today is disabled

### DIFF
--- a/packages/calendar/src/LionCalendar.js
+++ b/packages/calendar/src/LionCalendar.js
@@ -374,7 +374,9 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
   }
 
   __disableDatesChanged() {
-    this.__ensureValidCentralDate();
+    if (this.__connectedCallbackDone) {
+      this.__ensureValidCentralDate();
+    }
   }
 
   __dateSelectedByUser(selectedDate) {

--- a/packages/calendar/test/lion-calendar.test.js
+++ b/packages/calendar/test/lion-calendar.test.js
@@ -306,6 +306,22 @@ describe('<lion-calendar>', () => {
           expect(new DayObject(d).isDisabled).to.equal(shouldBeDisabled);
         });
       });
+
+      it('does not prevent initializing "centralDate" from "selectedDate" when today is disabled', async () => {
+        const clock = sinon.useFakeTimers({ now: new Date('2019/06/03').getTime() });
+
+        const el = await fixture(html`
+          <lion-calendar
+            .selectedDate="${new Date('2001/01/08')}"
+            .disableDates=${day => day.getDate() === 3}
+          ></lion-calendar>
+        `);
+        const elObj = new CalendarObject(el);
+        expect(isSameDate(el.centralDate, new Date('2001/01/08'))).to.be.true;
+        expect(elObj.activeMonthAndYear).to.equal('January 2001');
+
+        clock.restore();
+      });
     });
   });
 


### PR DESCRIPTION
The test is failing here https://circleci.com/gh/ing-bank/lion/488 because we have month day 4 disabled in that test and today is June 4, this causes a side effect where `centralDate` is not initialised from `selectedDate`. This side effect is a bug on its own and I'm fixing it here.