### PR TITLE
feat(field): add preprocessor for blocking invalid input

### DIFF
--- a/packages/field/src/FormatMixin.js
+++ b/packages/field/src/FormatMixin.js
@@ -133,6 +133,19 @@ export const FormatMixin = dedupeMixin(
       }
 
       /**
+       * === Formatting and parsing ====
+       * To understand all concepts below, please consult the flow diagrams in the documentation.
+       */
+
+      /**
+       * @param {String} value - the raw value from the <input> after keyUp/Down event
+       * @returns {String} preprocessedValue: the result of preprocessing for invalid input
+       */
+      preprocessor(v) {
+        return v;
+      }
+
+      /**
        * Converts formattedValue to modelValue
        * For instance, a localized date to a Date Object
        * @param {String} value - formattedValue: the formatted value inside <input>
@@ -206,6 +219,10 @@ export const FormatMixin = dedupeMixin(
         }
         this._reflectBackFormattedValueToUser();
         this.__preventRecursiveTrigger = false;
+      }
+
+      __callPreprocessor(value = this.value) {
+        return this.preprocessor(value, this.preprocessOptions);
       }
 
       __callParser(value = this.formattedValue) {
@@ -309,11 +326,14 @@ export const FormatMixin = dedupeMixin(
 
       /**
        * Synchronization from `.inputElement.value` to `LionField` (flow [2])
+       * Downwards syncing should only happen for `LionField`.value changes from 'above'.
+       * This triggers _onModelValueChanged and connects user input
+       * to the parsing/formatting/serializing loop.
        */
       _syncValueUpwards() {
-        // Downwards syncing should only happen for `LionField`.value changes from 'above'
-        // This triggers _onModelValueChanged and connects user input to the
-        // parsing/formatting/serializing loop
+        // Preprocess the changed <input> value before passing it to the parser.
+        this.value = this.__callPreprocessor(this.value);
+
         this.modelValue = this.__callParser(this.value);
       }
 

--- a/packages/input-amount/src/LionInputAmount.js
+++ b/packages/input-amount/src/LionInputAmount.js
@@ -6,6 +6,7 @@ import { FieldCustomMixin } from '@lion/field';
 import { isNumberValidator } from '@lion/validate';
 import { parseAmount } from './parsers.js';
 import { formatAmount } from './formatters.js';
+import { preprocessAmount } from './preprocessors.js';
 
 /**
  * `LionInputAmount` is a class for an amount custom form element (`<lion-input-amount>`).
@@ -48,6 +49,7 @@ export class LionInputAmount extends FieldCustomMixin(LocalizeMixin(ObserverMixi
     super();
     this.parser = parseAmount;
     this.formatter = formatAmount;
+    this.preprocessor = preprocessAmount;
   }
 
   connectedCallback() {

--- a/packages/input-amount/src/preprocessors.js
+++ b/packages/input-amount/src/preprocessors.js
@@ -1,0 +1,9 @@
+/**
+ * Formats a number considering the default fraction digits provided by Intl
+ *
+ * @param {float} modelValue Number to format
+ * @param {object} givenOptions Options for Intl
+ */
+export function preprocessAmount(value) {
+  return value.replace(/[^0-9,. ]/g, '');
+}

--- a/packages/input-amount/test/preprocessors.test.js
+++ b/packages/input-amount/test/preprocessors.test.js
@@ -1,0 +1,16 @@
+import { expect } from '@open-wc/testing';
+
+import { preprocessAmount } from '../src/preprocessors.js';
+
+describe('preprocessAmount()', () => {
+  it('preprocesses numbers to filter out non-digits', async () => {
+    expect(preprocessAmount('123as@dh2^!#')).to.equal('1232');
+  });
+
+  it('does not filter out separator characters', async () => {
+    expect(preprocessAmount('123 456,78.90')).to.equal(
+      '123 456,78.90',
+      'Dot, comma and space should not be filtered out.',
+    );
+  });
+});


### PR DESCRIPTION
### Rationale
Have a preprocessor for manipulating or processing user input before it gets reflected back as a view value. The parser is not supposed to change the view-value, it should only parse, hence why the suggested "preprocessor" is its own function. I considered the polymer way (prevent-invalid-input with allowed-pattern) where you give a regex pattern, but this is more flexible and alligned with how we do our formatters, parsers, and serializers.

Useful feature for easily disallowing / blocking the user from invalid input. Saves the user from having to do a bunch of rendering logic to get the same behavior, if we do it under the hood in LionField.

### Use cases
- Max length in textarea:
```js
this.preprocessor = v => v.slice(0, this.maxChars);
```
- Only digits + separators in input-amount:
```js
this.preprocessor = v => (v.match(/[0-9,\ .]+/g) || []).join('');
```
There's probably more.

### Usage / Public API
Main way to use it is by applying FormatMixin (or extending a component which has applied it) and then setting `this.preprocessor` in the constructor.

Currently without extending you can simply do this: 
```js
const lionInput = document.createElement('lion-input');
lionInput.label = 'No vowels allowed';
lionInput.preprocessor = v => (v.match(/[^aeoiuy]+/g) || []).join('');
return html`${lionInput}`;
```
Or this:
```js
<lion-input .preprocessor=${v => (v.match(/[^aeoiuy]+/g) || []).join('')}></lion-input>
```

### TODO:
- [x] Implementation
- [x] Tests
- [x] Apply to input-amount

### Future / other PRs
- Also preprocesses modelValue when imperatively set (In a separate PR https://github.com/ing-bank/lion/pull/55)
- Documentation (In a separate PR for FormatMixin docs https://github.com/ing-bank/lion/pull/149)