### PR TITLE
chore: poc for select as radio group

### DIFF
--- a/packages/radio-group/stories/index.stories.js
+++ b/packages/radio-group/stories/index.stories.js
@@ -2,13 +2,18 @@ import { storiesOf, html } from '@open-wc/demoing-storybook';
 // just a POC
 // eslint-disable-next-line
 import { overlays, LocalOverlayController } from '@lion/overlays';
+import { LitElement } from '@lion/core';
 
 import '../lion-radio-group.js';
 import '@lion/radio/lion-radio.js';
 import '@lion/form/lion-form.js';
 import { LionRadioGroup } from '../src/LionRadioGroup.js';
 
-export class LionSelectRich extends LionRadioGroup {
+export class LionSelectRich extends LitElement {
+  get modelValue() {
+    return this.contentNode.modelValue;
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.contentNode = this.querySelector('[slotpoc="content"]');
@@ -33,7 +38,7 @@ export class LionSelectRich extends LionRadioGroup {
     };
 
     this.invokerNode.addEventListener('click', this._toggle);
-    this.addEventListener('checked-value-changed', ev => {
+    this.contentNode.addEventListener('checked-value-changed', ev => {
       this.invokerNode.innerText = ev.target.checkedValue;
     });
   }
@@ -42,9 +47,19 @@ export class LionSelectRich extends LionRadioGroup {
     super.disconnectedCallback();
     this.invokerNode.removeEventListener('click', this._toggle);
   }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
 }
 
 customElements.define('lion-select-rich', LionSelectRich);
+
+export class LionListbox extends LionRadioGroup {}
+
+customElements.define('lion-listbox', LionListbox);
 
 storiesOf('Forms|Radio Group', module)
   .add(
@@ -54,7 +69,7 @@ storiesOf('Forms|Radio Group', module)
         <form>
           <lion-select-rich name="dinosGroup" label="What are your favourite dinosaurs?">
             <button slotpoc="invoker">click</button>
-            <div slotpoc="content">
+            <lion-listbox slotpoc="content" name="foo">
               <lion-radio
                 name="dinos[]"
                 label="allosaurus"
@@ -70,7 +85,7 @@ storiesOf('Forms|Radio Group', module)
                 label="diplodocus"
                 .modelValue=${{ value: 'diplodocus', checked: true }}
               ></lion-radio>
-            </div>
+            </lion-listbox>
           </lion-select-rich>
         </form>
       </lion-form>

--- a/packages/radio-group/stories/index.stories.js
+++ b/packages/radio-group/stories/index.stories.js
@@ -1,10 +1,81 @@
 import { storiesOf, html } from '@open-wc/demoing-storybook';
+// just a POC
+// eslint-disable-next-line
+import { overlays, LocalOverlayController } from '@lion/overlays';
 
 import '../lion-radio-group.js';
 import '@lion/radio/lion-radio.js';
 import '@lion/form/lion-form.js';
+import { LionRadioGroup } from '../src/LionRadioGroup.js';
+
+export class LionSelectRich extends LionRadioGroup {
+  connectedCallback() {
+    super.connectedCallback();
+    this.contentNode = this.querySelector('[slotpoc="content"]');
+    this.invokerNode = this.querySelector('[slotpoc="invoker"]');
+
+    this._popup = overlays.add(
+      new LocalOverlayController({
+        hidesOnEsc: true,
+        hidesOnOutsideClick: false,
+        placement: this.position,
+        contentNode: this.contentNode,
+        invokerNode: this.invokerNode,
+      }),
+    );
+    this._show = () => this._popup.show();
+    this._hide = () => {
+      this._popup.hide();
+    };
+
+    this._toggle = () => {
+      this._popup.toggle();
+    };
+
+    this.invokerNode.addEventListener('click', this._toggle);
+    this.addEventListener('checked-value-changed', ev => {
+      this.invokerNode.innerText = ev.target.checkedValue;
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.invokerNode.removeEventListener('click', this._toggle);
+  }
+}
+
+customElements.define('lion-select-rich', LionSelectRich);
 
 storiesOf('Forms|Radio Group', module)
+  .add(
+    'SELECT',
+    () => html`
+      <lion-form>
+        <form>
+          <lion-select-rich name="dinosGroup" label="What are your favourite dinosaurs?">
+            <button slotpoc="invoker">click</button>
+            <div slotpoc="content">
+              <lion-radio
+                name="dinos[]"
+                label="allosaurus"
+                .choiceValue=${'allosaurus'}
+              ></lion-radio>
+              <lion-radio
+                name="dinos[]"
+                label="brontosaurus"
+                .choiceValue=${'brontosaurus'}
+              ></lion-radio>
+              <lion-radio
+                name="dinos[]"
+                label="diplodocus"
+                .modelValue=${{ value: 'diplodocus', checked: true }}
+              ></lion-radio>
+            </div>
+          </lion-select-rich>
+        </form>
+      </lion-form>
+    `,
+  )
   .add(
     'Default',
     () => html`


### PR DESCRIPTION
This is intended to show that a "rich" select is basically the same as the RadioGroup.
We already have all the ways of grouping and setting options/values on children - we should reuse that.
- the `lion-option` would just be a special version of lion-radio (e.g. visually select the full line instead of only the radio)
- doing so should give a lot of a11y out of the box 🤗 
- and with the LocalOverlay and the focustrap it seems to work pretty nicely
- still aria attributes needs to be adjusted
- the wrapping div of the options will need to become a `lion-listbox` (which is only needed for visual and a11y as far as I can see - e.g. no extra logic or grouping)

The multi select would probably be a separate element `lion-select-rich-multiple`
- the `lion-option-multiple` would just be a special version of lion-checkbox
- ...


adding additional features like `lion-option-group` (an extension of LionField to already get the grouping) or `lion-option-separator` should be possible at a later stage as well