### PR TITLE
fix(format amount): sign should be before the number

### DIFF
--- a/packages/localize/src/formatNumber.js
+++ b/packages/localize/src/formatNumber.js
@@ -225,7 +225,7 @@ function normalizeIntl(formattedParts, options, _locale) {
   let normalize = forceNormalSpaces(formattedParts, options);
   // Dutch and Belgian currency must be moved to end of number
   if (options && options.style === 'currency') {
-    if (_locale === 'nl-NL' || _locale.slice(-2) === 'BE') {
+    if (options.currencyDisplay === 'code' && (_locale === 'nl-NL' || _locale.slice(-2) === 'BE')) {
       normalize = forceCurrencyToEnd(normalize);
     }
     // Add group separator for Bulgarian locale

--- a/packages/localize/test/formatNumber.test.js
+++ b/packages/localize/test/formatNumber.test.js
@@ -29,7 +29,7 @@ describe('formatNumber', () => {
     expect(formatNumber(123456.789, { currency: 'EUR', ...currencyCode })).to.equal(
       '123.456,79 EUR',
     );
-    expect(formatNumber(123456.789, { currency: 'JPY', ...currencySymbol })).to.equal('123.457 ¥');
+    expect(formatNumber(123456.789, { currency: 'JPY', ...currencySymbol })).to.equal('¥ 123.457');
     localize.locale = 'fr-FR';
     expect(formatNumber(123456.789, { currency: 'EUR', ...currencyCode })).to.equal(
       '123 456,79 EUR',
@@ -57,10 +57,10 @@ describe('formatNumber', () => {
     const currencySymbol = { style: 'currency', currencyDisplay: 'symbol' };
     localize.locale = 'nl-NL';
     expect(formatNumber(123456.789, { currency: 'EUR', ...currencySymbol })).to.equal(
-      '123.456,79 €',
+      '€ 123.456,79',
     );
     expect(formatNumber(123456.789, { currency: 'USD', ...currencySymbol })).to.equal(
-      '123.456,79 $',
+      '$ 123.456,79',
     );
   });
 
@@ -333,13 +333,13 @@ describe('formatNumberToParts', () => {
       currencyDisplay: 'symbol',
     });
     expect(formattedToParts).to.eql([
+      { type: 'currency', value: '€' },
+      { type: 'literal', value: ' ' },
       { type: 'integer', value: '3' },
       { type: 'group', value: '.' },
       { type: 'integer', value: '500' },
       { type: 'decimal', value: ',' },
       { type: 'fraction', value: '00' },
-      { type: 'literal', value: ' ' },
-      { type: 'currency', value: '€' },
     ]);
   });
 


### PR DESCRIPTION
This merge request fixes this issue: https://github.com/ing-bank/lion/issues/117