### PR TITLE
feat: add select-rich

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,2 +1,4 @@
+
+ <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <meta name="viewport"
       content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">

--- a/packages/listbox/README.md
+++ b/packages/listbox/README.md
@@ -1,0 +1,10 @@
+# Listbox
+
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
+
+`lion-listbox` is ...
+
+## Features
+- offers...
+
+## How to use

--- a/packages/listbox/index.js
+++ b/packages/listbox/index.js
@@ -1,0 +1,2 @@
+export { LionListbox } from './src/LionListbox.js';
+export { LionOption } from './src/LionOption.js';

--- a/packages/listbox/lion-listbox.js
+++ b/packages/listbox/lion-listbox.js
@@ -1,0 +1,3 @@
+import { LionListbox } from './src/LionListbox.js';
+
+customElements.define('lion-listbox', LionListbox);

--- a/packages/listbox/lion-option.js
+++ b/packages/listbox/lion-option.js
@@ -1,0 +1,3 @@
+import { LionOption } from './src/LionOption.js';
+
+customElements.define('lion-option', LionOption);

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lion/listbox",
+  "version": "0.0.0",
+  "description": "Provide a way for users to select (multiple) options",
+  "author": "ing-bank",
+  "homepage": "https://github.com/ing-bank/lion/",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ing-bank/lion.git",
+    "directory": "packages/listbox"
+  },
+  "scripts": {
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
+  },
+  "keywords": [
+    "lion",
+    "web-components",
+    "listbox",
+    "option",
+    "optgroup",
+    "separator"
+  ],
+  "main": "index.js",
+  "module": "index.js",
+  "files": [
+    "docs",
+    "src",
+    "stories",
+    "test",
+    "translations",
+    "*.js"
+  ],
+  "dependencies": {
+    "@lion/core": "^0.1.6",
+    "@lion/radio": "^0.1.21"
+  },
+  "devDependencies": {
+    "@open-wc/demoing-storybook": "^0.2.0",
+    "@open-wc/testing": "^0.11.1",
+    "@polymer/iron-test-helpers": "^3.0.1"
+  }
+}

--- a/packages/listbox/src/LionListbox.js
+++ b/packages/listbox/src/LionListbox.js
@@ -1,0 +1,34 @@
+import { html, css, LitElement } from '@lion/core';
+
+export class LionListbox extends LitElement {
+  static get properties() {
+    return {
+      role: { type: String, reflect: true },
+      tabIndex: { type: String, reflect: true, attribute: 'tabindex' },
+    };
+  }
+
+  static get styles() {
+    return [
+      css`
+        :host {
+          display: block;
+          background: #fff;
+          border: 1px solid #ccc;
+        }
+      `,
+    ];
+  }
+
+  constructor() {
+    super();
+    this.role = 'listbox';
+    // this.tabIndex = -1;
+  }
+
+  render() {
+    return html`
+      <slot></slot>
+    `;
+  }
+}

--- a/packages/listbox/src/LionOption.js
+++ b/packages/listbox/src/LionOption.js
@@ -1,0 +1,47 @@
+import { css } from '@lion/core';
+import { LionRadio } from '@lion/radio';
+
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option
+ * Can be a child of datalist/select, or role="listbox"
+ *
+ * Element gets state supplied externally, reflects this to attributes,
+ * enabling Subclassers to style based on those states
+ */
+export class LionOption extends LionRadio {
+  static get styles() {
+    return [
+      css`
+        :host {
+          display: block;
+          padding: 4px;
+        }
+
+        :host([selected]) {
+          background: lightblue;
+        }
+
+        :host([disabled]) {
+          color: lightgray;
+        }
+      `,
+    ];
+  }
+
+  static get syncObservers() {
+    return {
+      ...super.syncObservers,
+      __syncAriaSelected: ['modelValue'],
+    };
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.setAttribute('role', 'option');
+  }
+
+  __syncAriaSelected() {
+    const string = this.modelValue.checked === true ? 'true' : 'false';
+    this.setAttribute('aria-selected', string);
+  }
+}

--- a/packages/listbox/src/reference/ListBoxBehavior.js
+++ b/packages/listbox/src/reference/ListBoxBehavior.js
@@ -1,0 +1,540 @@
+/* eslint-disable */
+
+/*
+ *   This content is licensed according to the W3C Software License at
+ *   https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ */
+
+export class ListboxBehavior {
+  /**
+   * @constructor
+   *
+   * @desc
+   *  Listbox object representing the state and interactions for a listbox widget
+   *
+   * @param listboxNode
+   *  The DOM node pointing to the listbox
+   */
+  constructor(listboxNode) {
+    this.listboxNode = listboxNode;
+    this.activeDescendant = this.listboxNode.getAttribute('aria-activedescendant');
+    this.multiselectable = this.listboxNode.hasAttribute('aria-multiselectable');
+    this.moveUpDownEnabled = false;
+    this.siblingList = null;
+    this.upButton = null;
+    this.downButton = null;
+    this.moveButton = null;
+    this.keysSoFar = '';
+    this.handleFocusChange = () => {};
+    this.handleItemChange = (event, items) => {};
+    this.registerEvents();
+  }
+
+  /**
+   * @desc
+   *  Register events for the listbox interactions
+   */
+  registerEvents() {
+    this.listboxNode.addEventListener('focus', this.setupFocus.bind(this));
+    this.listboxNode.addEventListener('keydown', this.checkKeyPress.bind(this));
+    this.listboxNode.addEventListener('click', this.checkClickItem.bind(this));
+  }
+
+  /**
+   * @desc
+   *  If there is no activeDescendant, focus on the first option
+   */
+  setupFocus() {
+    if (this.activeDescendant) {
+      return;
+    }
+
+    this.focusFirstItem();
+  }
+
+  /**
+   * @desc
+   *  Focus on the first option
+   */
+  focusFirstItem() {
+    const firstItem = this.listboxNode.querySelector('[role="option"]');
+
+    if (firstItem) {
+      this.focusItem(firstItem);
+    }
+  }
+
+  /**
+   * @desc
+   *  Focus on the last option
+   */
+  focusLastItem() {
+    const itemList = this.listboxNode.querySelectorAll('[role="option"]');
+
+    if (itemList.length) {
+      this.focusItem(itemList[itemList.length - 1]);
+    }
+  }
+
+  /**
+   * @desc
+   *  Handle various keyboard controls; UP/DOWN will shift focus; SPACE selects
+   *  an item.
+   *
+   * @param evt
+   *  The keydown event object
+   */
+  checkKeyPress(evt) {
+    const { key } = evt;
+    let nextItem = this.listboxNode.querySelector(`#${this.activeDescendant}`);
+
+    // TODO: // get info from context, no need for expensive queries every keypress
+    const itemList = [].slice.call(this.listboxNode.querySelectorAll('[role="option"]'));
+    const nextItemIndex = itemList.indexOf(nextItem);
+
+    if (!nextItem) {
+      return;
+    }
+
+    switch (key) {
+      case 'PageUp':
+      case 'PageDown':
+        if (this.moveUpDownEnabled) {
+          evt.preventDefault();
+
+          if (key === 'PageUp') {
+            this.moveUpItems();
+          } else {
+            this.moveDownItems();
+          }
+        }
+
+        break;
+      case 'ArrowUp':
+      case 'ArrowDown':
+        evt.preventDefault();
+
+        if (this.moveUpDownEnabled && evt.altKey) {
+          if (key === 'ArrowUp') {
+            this.moveUpItems();
+          } else {
+            this.moveDownItems();
+          }
+          return;
+        }
+
+        if (key === 'ArrowUp') {
+          nextItem = itemList[nextItemIndex - 1];
+        } else {
+          nextItem = itemList[nextItemIndex + 1];
+        }
+
+        if (nextItem) {
+          this.focusItem(nextItem);
+        }
+
+        break;
+      case 'Home':
+        evt.preventDefault();
+        this.focusFirstItem();
+        break;
+      case 'End':
+        evt.preventDefault();
+        this.focusLastItem();
+        break;
+      case ' ':
+      case 'Spacebar':
+        evt.preventDefault();
+        this.toggleSelectItem(nextItem);
+        break;
+      case 'Backspace':
+      case 'Delete':
+      case 'Enter':
+        if (!this.moveButton) {
+          return;
+        }
+
+        const keyshortcuts = this.moveButton.getAttribute('aria-keyshortcuts');
+        if (key === 'Enter' && keyshortcuts.indexOf('Enter') === -1) {
+          return;
+        }
+        if ((key === 'Backspace' || key === 'Delete') && keyshortcuts.indexOf('Delete') === -1) {
+          return;
+        }
+
+        evt.preventDefault();
+
+        let nextUnselected = nextItem.nextElementSibling;
+        while (nextUnselected) {
+          if (nextUnselected.getAttribute('aria-selected') != 'true') {
+            break;
+          }
+          nextUnselected = nextUnselected.nextElementSibling;
+        }
+        if (!nextUnselected) {
+          nextUnselected = nextItem.previousElementSibling;
+          while (nextUnselected) {
+            if (nextUnselected.getAttribute('aria-selected') != 'true') {
+              break;
+            }
+            nextUnselected = nextUnselected.previousElementSibling;
+          }
+        }
+
+        this.moveItems();
+
+        if (!this.activeDescendant && nextUnselected) {
+          this.focusItem(nextUnselected);
+        }
+        break;
+      default:
+        const itemToFocus = this.findItemToFocus(key);
+        if (itemToFocus) {
+          this.focusItem(itemToFocus);
+        }
+        break;
+    }
+  }
+
+  findItemToFocus(key) {
+    const itemList = this.listboxNode.querySelectorAll('[role="option"]');
+    const character = String.fromCharCode(key);
+
+    if (!this.keysSoFar) {
+      for (let i = 0; i < itemList.length; i += 1) {
+        if (itemList[i].getAttribute('id') === this.activeDescendant) {
+          this.searchIndex = i;
+        }
+      }
+    }
+    this.keysSoFar += character;
+    this.clearKeysSoFarAfterDelay();
+
+    let nextMatch = this.findMatchInRange(itemList, this.searchIndex + 1, itemList.length);
+    if (!nextMatch) {
+      nextMatch = this.findMatchInRange(itemList, 0, this.searchIndex);
+    }
+    return nextMatch;
+  }
+
+  clearKeysSoFarAfterDelay() {
+    if (this.keyClear) {
+      clearTimeout(this.keyClear);
+      this.keyClear = null;
+    }
+    this.keyClear = setTimeout(
+      function() {
+        this.keysSoFar = '';
+        this.keyClear = null;
+      }.bind(this),
+      500,
+    );
+  }
+
+  findMatchInRange(list, startIndex, endIndex) {
+    // Find the first item starting with the keysSoFar substring, searching in
+    // the specified range of items
+    for (let n = startIndex; n < endIndex; n += 1) {
+      const label = list[n].innerText;
+      if (label && label.toUpperCase().indexOf(this.keysSoFar) === 0) {
+        return list[n];
+      }
+    }
+    return null;
+  }
+
+  /**
+   * @desc
+   *  Check if an item is clicked on. If so, focus on it and select it.
+   *
+   * @param evt
+   *  The click event object
+   */
+  checkClickItem(evt) {
+    if (evt.target.getAttribute('role') === 'option') {
+      this.focusItem(evt.target);
+      this.toggleSelectItem(evt.target);
+    }
+  }
+
+  /**
+   * @desc
+   *  Toggle the aria-selected value
+   *
+   * @param element
+   *  The element to select
+   */
+  toggleSelectItem(element) {
+    if (this.multiselectable) {
+      element.setAttribute(
+        'aria-selected',
+        element.getAttribute('aria-selected') === 'true' ? 'false' : 'true',
+      );
+
+      if (this.moveButton) {
+        if (this.listboxNode.querySelector('[aria-selected="true"]')) {
+          this.moveButton.setAttribute('aria-disabled', 'false');
+        } else {
+          this.moveButton.setAttribute('aria-disabled', 'true');
+        }
+      }
+    }
+  }
+
+  /**
+   * @desc
+   *  Defocus the specified item
+   *
+   * @param element
+   *  The element to defocus
+   */
+  defocusItem(element) {
+    if (!element) {
+      return;
+    }
+    if (!this.multiselectable) {
+      element.removeAttribute('aria-selected');
+    }
+    element.removeAttribute('focused');
+  }
+
+  /**
+   * @desc
+   *  Focus on the specified item
+   *
+   * @param element
+   *  The element to focus
+   */
+  focusItem(element) {
+    this.defocusItem(this.listboxNode.querySelector(`#${this.activeDescendant}`));
+    if (!this.multiselectable) {
+      element.setAttribute('aria-selected', 'true');
+    }
+    element.setAttribute('focused', '');
+    this.listboxNode.setAttribute('aria-activedescendant', element.id);
+    this.activeDescendant = element.id;
+
+    if (this.listboxNode.scrollHeight > this.listboxNode.clientHeight) {
+      const scrollBottom = this.listboxNode.clientHeight + this.listboxNode.scrollTop;
+      const elementBottom = element.offsetTop + element.offsetHeight;
+      if (elementBottom > scrollBottom) {
+        this.listboxNode.scrollTop = elementBottom - this.listboxNode.clientHeight;
+      } else if (element.offsetTop < this.listboxNode.scrollTop) {
+        this.listboxNode.scrollTop = element.offsetTop;
+      }
+    }
+
+    if (!this.multiselectable && this.moveButton) {
+      this.moveButton.setAttribute('aria-disabled', false);
+    }
+
+    this.checkUpDownButtons();
+    this.handleFocusChange(element);
+  }
+
+  /**
+   * @desc
+   *  Enable/disable the up/down arrows based on the activeDescendant.
+   */
+  checkUpDownButtons() {
+    const activeElement = this.listboxNode.querySelector(`#${this.activeDescendant}`);
+
+    if (!this.moveUpDownEnabled) {
+      return false;
+    }
+
+    if (!activeElement) {
+      this.upButton.setAttribute('aria-disabled', 'true');
+      this.downButton.setAttribute('aria-disabled', 'true');
+      return undefined;
+    }
+
+    if (this.upButton) {
+      if (activeElement.previousElementSibling) {
+        this.upButton.setAttribute('aria-disabled', false);
+      } else {
+        this.upButton.setAttribute('aria-disabled', 'true');
+      }
+    }
+
+    if (this.downButton) {
+      if (activeElement.nextElementSibling) {
+        this.downButton.setAttribute('aria-disabled', false);
+      } else {
+        this.downButton.setAttribute('aria-disabled', 'true');
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * @desc
+   *  Add the specified items to the listbox. Assumes items are valid options.
+   *
+   * @param items
+   *  An array of items to add to the listbox
+   */
+  addItems(items) {
+    if (!items || !items.length) {
+      return false;
+    }
+
+    items.forEach(item => {
+      this.defocusItem(item);
+      this.toggleSelectItem(item);
+      this.listboxNode.append(item);
+    });
+
+    if (!this.activeDescendant) {
+      this.focusItem(items[0]);
+    }
+
+    this.handleItemChange('added', items);
+
+    return undefined;
+  }
+
+  /**
+   * @desc
+   *  Remove all of the selected items from the listbox; Removes the focused items
+   *  in a single select listbox and the items with aria-selected in a multi
+   *  select listbox.
+   *
+   * @returns items
+   *  An array of items that were removed from the listbox
+   */
+  deleteItems() {
+    let itemsToDelete;
+
+    if (this.multiselectable) {
+      itemsToDelete = this.listboxNode.querySelectorAll('[aria-selected="true"]');
+    } else if (this.activeDescendant) {
+      itemsToDelete = [this.listboxNode.querySelector(`#${this.activeDescendant}`)];
+    }
+
+    if (!itemsToDelete || !itemsToDelete.length) {
+      return [];
+    }
+
+    itemsToDelete.forEach(item => {
+      item.remove();
+
+      if (item.id === this.activeDescendant) {
+        this.clearActiveDescendant();
+      }
+    });
+
+    this.handleItemChange('removed', itemsToDelete);
+
+    return itemsToDelete;
+  }
+
+  clearActiveDescendant() {
+    this.activeDescendant = null;
+    this.listboxNode.setAttribute('aria-activedescendant', null);
+
+    if (this.moveButton) {
+      this.moveButton.setAttribute('aria-disabled', 'true');
+    }
+
+    this.checkUpDownButtons();
+  }
+
+  /**
+   * @desc
+   *  Shifts the currently focused item up on the list. No shifting occurs if the
+   *  item is already at the top of the list.
+   */
+  moveUpItems() {
+    if (!this.activeDescendant) {
+      return;
+    }
+
+    const currentItem = this.listboxNode.querySelector(`#${this.activeDescendant}`);
+    const previousItem = currentItem.previousElementSibling;
+
+    if (previousItem) {
+      this.listboxNode.insertBefore(currentItem, previousItem);
+      this.handleItemChange('moved_up', [currentItem]);
+    }
+
+    this.checkUpDownButtons();
+  }
+
+  /**
+   * @desc
+   *  Shifts the currently focused item down on the list. No shifting occurs if
+   *  the item is already at the end of the list.
+   */
+  moveDownItems() {
+    if (!this.activeDescendant) {
+      return;
+    }
+
+    const currentItem = this.listboxNode.querySelector(`#${this.activeDescendant}`);
+    const nextItem = currentItem.nextElementSibling;
+
+    if (nextItem) {
+      this.listboxNode.insertBefore(nextItem, currentItem);
+      this.handleItemChange('moved_down', [currentItem]);
+    }
+
+    this.checkUpDownButtons();
+  }
+
+  /**
+   * @desc
+   *  Delete the currently selected items and add them to the sibling list.
+   */
+  moveItems() {
+    if (!this.siblingList) {
+      return;
+    }
+
+    const itemsToMove = this.deleteItems();
+    this.siblingList.addItems(itemsToMove);
+  }
+
+  /**
+   * @desc
+   *  Enable Up/Down controls to shift items up and down.
+   *
+   * @param upButton
+   *   Up button to trigger up shift
+   *
+   * @param downButton
+   *   Down button to trigger down shift
+   */
+  enableMoveUpDown(upButton, downButton) {
+    this.moveUpDownEnabled = true;
+    this.upButton = upButton;
+    this.downButton = downButton;
+    upButton.addEventListener('click', this.moveUpItems.bind(this));
+    downButton.addEventListener('click', this.moveDownItems.bind(this));
+  }
+
+  /**
+   * @desc
+   *  Enable Move controls. Moving removes selected items from the current
+   *  list and adds them to the sibling list.
+   *
+   * @param button
+   *   Move button to trigger delete
+   *
+   * @param siblingList
+   *   Listbox to move items to
+   */
+  setupMove(button, siblingList) {
+    this.siblingList = siblingList;
+    this.moveButton = button;
+    button.addEventListener('click', this.moveItems.bind(this));
+  }
+
+  setHandleItemChange(handlerFn) {
+    this.handleItemChange = handlerFn;
+  }
+
+  setHandleFocusChange(focusChangeHandler) {
+    this.handleFocusChange = focusChangeHandler;
+  }
+}

--- a/packages/listbox/stories/index.stories.js
+++ b/packages/listbox/stories/index.stories.js
@@ -1,0 +1,113 @@
+import { storiesOf, html } from '@open-wc/demoing-storybook';
+import { css } from '@lion/core';
+
+import '@lion/form/lion-form.js';
+import '../lion-option.js';
+import '../lion-listbox.js';
+
+const selectRichDemoStyle = css`
+  .demo-listbox {
+    background-color: white;
+  }
+
+  .demo-option[focused] {
+    background-color: lightgray;
+  }
+`;
+
+storiesOf('Forms|Listbox', module)
+  .add(
+    'Default',
+    () => html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-listbox name="color">
+        <lion-option .modelValue=${{ value: 'red', checked: false }}>Red</lion-option>
+        <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>Hotpink</lion-option>
+        <lion-option .modelValue=${{ value: 'teal', checked: false }}>Teal</lion-option>
+      </lion-listbox>
+    `,
+  )
+  .add(
+    'Options with HTML',
+    () => html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-listbox name="color" class="demo-listbox">
+        <lion-option .modelValue=${{ value: 'red', checked: false }}>
+          <p style="color: red;">I am red</p>
+          <p>and multi Line</p>
+        </lion-option>
+        <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>
+          <p style="color: hotpink;">I am hotpink</p>
+          <p>and multi Line</p>
+        </lion-option>
+        <lion-option .modelValue=${{ value: 'teal', checked: false }}>
+          <p style="color: teal;">I am teal</p>
+          <p>and multi Line</p>
+        </lion-option>
+      </lion-listbox>
+    `,
+  )
+  .add(
+    'Disabled',
+    () => html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-listbox name="color">
+        <lion-option .modelValue=${{ value: 'red', checked: false }}>Red</lion-option>
+        <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>Hotpink</lion-option>
+        <lion-option .modelValue=${{ value: 'teal', checked: false }}>Teal</lion-option>
+      </lion-listbox>
+
+      <lion-listbox name="color">
+        <lion-option .modelValue=${{ value: 'red', checked: false }}>Red</lion-option>
+        <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>Hotpink</lion-option>
+        <lion-option .modelValue=${{ value: 'teal', checked: false }} disabled>Teal</lion-option>
+      </lion-listbox>
+    `,
+  )
+  .add('Validation', () => {
+    const submit = () => {
+      const form = document.querySelector('#form');
+      if (form.errorState === false) {
+        console.log(form.serializeGroup());
+      }
+    };
+    return html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-form id="form" @submit="${submit}">
+        <form>
+          <lion-listbox name="color" class="demo-listbox" .errorValidators="${[['required']]}">
+            <lion-option value="red" class="demo-option">Red</lion-option>
+            <lion-option value="hotpink" class="demo-option">Hotpink</lion-option>
+            <lion-option value="teal" class="demo-option">Teal</lion-option>
+          </lion-listbox>
+          <lion-button type="submit">Submit</lion-button>
+        </form>
+      </lion-form>
+    `;
+  })
+  .add('Render Options', () => {
+    const objs = [
+      { type: 'mastercard', label: 'Master Card', amount: 12000, active: true },
+      { type: 'visacard', label: 'Visa Card', amount: 0, active: false },
+    ];
+    return html`
+      <lion-listbox name="color">
+        ${objs.map(
+          obj => html`
+            <lion-option .modelValue=${{ value: obj, checked: false }}>${obj.label}</lion-option>
+          `,
+        )}
+      </lion-listbox>
+    `;
+  });

--- a/packages/listbox/test/lion-listbox.test.js
+++ b/packages/listbox/test/lion-listbox.test.js
@@ -1,0 +1,275 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../lion-option.js';
+import '../lion-listbox.js';
+
+describe('lion-listbox', () => {
+  describe('values', () => {
+    it('requires a set name', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.modelValue).to.equal([{ value: 10, checked: true }, { value: 20, checked: false }]);
+      expect(el.choiceValue).to.equal(10);
+    });
+
+    it('has the first element as default selection', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.modelValue).to.equal([{ value: 10, checked: true }, { value: 20, checked: false }]);
+      expect(el.choiceValue).to.equal(10);
+    });
+
+    it('allows null choiceValue', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${null}>Please select value</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.modelValue).to.equal([
+        { value: null, checked: true },
+        { value: 20, checked: false },
+      ]);
+      expect(el.checkedValue).to.be.null;
+    });
+
+    it('has the checked option as modelValue', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20} checked>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.modelValue).to.equal([{ value: 10, checked: false }, { value: 20, checked: true }]);
+      expect(el.checkedValue).to.equal(20);
+    });
+  });
+
+  describe('Disabled', () => {
+    it('can not be focused if disabled', async () => {
+      const el = await fixture(html`
+        <lion-select-rich disabled> </lion-select-rich>
+      `);
+      expect(el.tabIndex).to.equal('-1');
+    });
+
+    it('can not be navigated with keyboard if disabled', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('navigates through list with [arrow up] [arrow down] keys', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+          <lion-option .choiceValue=${30}>Item 3</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.choiceValue).to.equal(10);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(20);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+    });
+
+    it('navigates to first and last option with [home] [end] keys', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+          <lion-option .choiceValue=${30} checked>Item 3</lion-option>
+          <lion-option .choiceValue=${40}>Item 4</lion-option>
+        </lion-listbox>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(40);
+    });
+
+    // TODO: nice to have
+    it.skip('selects a value with single [character] key', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${'a'}>A</lion-option>
+          <lion-option .choiceValue=${'b'}>B</lion-option>
+          <lion-option .choiceValue=${'c'}>C</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.choiceValue).to.equal('a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'C' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal('c');
+    });
+
+    it.skip('selects a value with multiple [character] keys', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${'bar'}>Bar</lion-option>
+          <lion-option .choiceValue=${'far'}>Far</lion-option>
+          <lion-option .choiceValue=${'foo'}>Foo</lion-option>
+        </lion-listbox>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'F' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal('far');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'O' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal('foo');
+    });
+  });
+
+  // TODO: nice to have
+  describe.skip('Read only', () => {
+    it('can be focused if readonly', async () => {
+      const el = await fixture(html`
+        <lion-listbox readonly> </lion-listbox>
+      `);
+      expect(el.tabIndex).to.equal('-1');
+    });
+
+    it('can not be navigated with keyboard if readonly', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+    });
+  });
+
+  describe('Interaction states', () => {
+    it('becomes dirty if valued changed once', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.dirty).to.be.false;
+      el.checkedValue = 20;
+      await el.updateComplete;
+      expect(el.dirty).to.be.true;
+    });
+
+    it('becomes touched if becomes focused once', async () => {
+      const el = await fixture(html``);
+      expect(el.touched).to.be.false;
+      el._invokerNode.focus();
+      expect(el.touched).to.be.true;
+    });
+
+    it('is prefilled if there is a value on init', async () => {
+      const el = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.prefilled).to.be.true;
+
+      const elEmpty = await fixture(html`
+        <lion-listbox name="foo">
+          <lion-option .choiceValue=${null}>Please select a value</lion-option>
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+        </lion-listbox>
+      `);
+      expect(elEmpty.prefilled).to.be.false;
+    });
+  });
+
+  describe('Validation', () => {
+    it('can be required', async () => {
+      const lionSelect = await fixture(html`
+        <lion-listbox name="foo" .errorValidators=${['required']}>
+          <lion-option .choiceValue=${null}>Please select a value</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(lionSelect.error.required).to.be.true;
+      lionSelect.choiceValue = 20;
+      expect(lionSelect.error.required).to.be.undefined;
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('creates unique ids for all children', async () => {
+      const el = await fixture(html`
+        <lion-listbox>
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20} selected>Item 2</lion-option>
+          <lion-option .choiceValue=${30} id="prededefined">Item 3</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.querySelectorAll('lion-option')[0].id).to.exist;
+      expect(el.querySelectorAll('lion-option')[1].id).to.exist;
+      expect(el.querySelectorAll('lion-option')[2].id).to.equal('predefined');
+    });
+
+    it('has a reference to the selected option', async () => {
+      const el = await fixture(html`
+        <lion-listbox>
+          <lion-option .choiceValue=${10} id="first">Item 1</lion-option>
+          <lion-option .choiceValue=${20} selected id="second">Item 2</lion-option>
+        </lion-listbox>
+      `);
+      expect(el.getAttribute('aria-activedescendant')).to.equal('first');
+      keyUpOn(el, keyCodes.arrowDown);
+      expect(el.getAttribute('aria-activedescendant')).to.equal('second');
+    });
+
+    it('puts "aria-setsize" on all options to indicate the total amount of options', async () => {
+      const el = await fixture(html`
+        <lion-listbox>
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+          <lion-option .choiceValue=${30}>Item 3</lion-option>
+        </lion-listbox>
+      `);
+      const optionEls = [].slice.call(el.querySelectorAll('lion-option'));
+      optionEls.forEach(oEl => {
+        expect(oEl.getAttribute('aria-setsize')).to.equal('3');
+      });
+    });
+
+    it('puts "aria-posinset" on all options to indicate their position in the listbox', async () => {
+      const el = await fixture(html`
+        <lion-listbox>
+          <lion-option .choiceValue=${10}>Item 1</lion-option>
+          <lion-option .choiceValue=${20}>Item 2</lion-option>
+          <lion-option .choiceValue=${30}>Item 3</lion-option>
+        </lion-listbox>
+      `);
+      const optionEls = [].slice.call(el.querySelectorAll('lion-option'));
+      optionEls.forEach((oEl, i) => {
+        expect(oEl.getAttribute('aria-posinset')).to.equal(`${i + 1}`);
+      });
+    });
+  });
+});

--- a/packages/listbox/test/lion-option.test.js
+++ b/packages/listbox/test/lion-option.test.js
@@ -1,0 +1,48 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '../lion-base-listbox.js';
+
+describe('lion-option', () => {
+  describe('Accessibility', () => {
+    it('has the "option" role', async () => {
+      const el = await fixture(html`
+        <lion-option></lion-option>
+      `);
+      expect(el.getAttribute('role')).to.equal('option');
+    });
+
+    it('has "aria-selected" attribute when selected', async () => {
+      const el1 = await fixture(html`
+        <lion-option .choiceValue=${10}>Item 1</lion-option>
+      `);
+      const el2 = await fixture(html`
+        <lion-option .choiceValue=${20} selected>Item 2</lion-option>
+      `);
+
+      expect(el1.getAttribute('aria-selected')).to.equal('false');
+      expect(el2.getAttribute('aria-selected')).to.equal('true');
+
+      el1.selected = true;
+      el2.selected = false;
+      expect(el1.getAttribute('aria-selected')).to.equal('true');
+      expect(el2.getAttribute('aria-selected')).to.equal('false');
+    });
+
+    it('has "aria-disabled" attribute when disabled', async () => {
+      const el1 = await fixture(html`
+        <lion-option .choiceValue=${10}>Item 1</lion-option>
+      `);
+      const el2 = await fixture(html`
+        <lion-option .choiceValue=${20} disabled>Item 2</lion-option>
+      `);
+
+      expect(el1.getAttribute('aria-disabled')).to.equal('false');
+      expect(el2.getAttribute('aria-disabled')).to.equal('true');
+
+      el1.disabled = true;
+      el2.disabled = false;
+      expect(el1.getAttribute('aria-disabled')).to.equal('true');
+      expect(el2.getAttribute('aria-disabled')).to.equal('false');
+    });
+  });
+});

--- a/packages/overlays/src/GlobalOverlayController.js
+++ b/packages/overlays/src/GlobalOverlayController.js
@@ -12,8 +12,17 @@ export class GlobalOverlayController {
   static _createRoot() {
     if (!this._rootNode) {
       this._rootNode = document.createElement('div');
+      // TODO: create a shadow dom root here. Currently, the only way this works with shadyCSS is
+      // by creating webcomponent, so create <lion-overlay-root> instead of <div>
+      // Also, make this root configurable, so:
+      // - it supports all viewport placements:
+      //     - v-align : 'center' | 'bottom' | 'top' | 'left' | 'right' | 'fullheight'
+      //     - h-align: 'middle' | 'start' | 'end' | 'fullwidth'
+      // - allow to style backdrop (opacity, color, animation(?))
+      // - allow to animate overlay
       this._rootNode.classList.add('global-overlays');
       document.body.appendChild(this._rootNode);
+      // TODO: add part to web component described above, and parts to body
       document.head.appendChild(styleTag);
     }
   }

--- a/packages/overlays/src/LocalOverlayController.js
+++ b/packages/overlays/src/LocalOverlayController.js
@@ -5,6 +5,8 @@ import { keyCodes } from './utils/key-codes.js';
 
 export class LocalOverlayController {
   constructor(params = {}) {
+    this._fakeExtendsEventTarget();
+
     const finalParams = {
       placement: 'top',
       position: 'absolute',
@@ -88,7 +90,11 @@ export class LocalOverlayController {
 
     this.invokerNode.setAttribute('aria-expanded', this.isShown);
     this.invokerNode.setAttribute('aria-controls', this.contentId);
+    // [a11y] TODO: this is only needed for tooltips, I assume?
+    // Also, we should allow to configure tooltips in such a way that we can use
+    // aria-labelledby instead: https://inclusive-components.design/tooltips-toggletips/
     this.invokerNode.setAttribute('aria-describedby', this.contentId);
+    // Also, we should add role="tooltip" on this.contentNode ?
   }
 
   /**
@@ -96,6 +102,7 @@ export class LocalOverlayController {
    */
   show() {
     this._createOrUpdateOverlay(true, this._prevData);
+    this.dispatchEvent(new Event('show'));
   }
 
   /**
@@ -103,6 +110,7 @@ export class LocalOverlayController {
    */
   hide() {
     this._createOrUpdateOverlay(false, this._prevData);
+    this.dispatchEvent(new Event('hide'));
   }
 
   /**
@@ -213,5 +221,14 @@ export class LocalOverlayController {
     if (e.keyCode === keyCodes.escape) {
       this.hide();
     }
+  }
+
+  // TODO: this method has to be removed when EventTarget polyfill is available on IE11
+  // issue: https://gitlab.ing.net/TheGuideComponents/lion-element/issues/12
+  _fakeExtendsEventTarget() {
+    const delegate = document.createDocumentFragment();
+    ['addEventListener', 'dispatchEvent', 'removeEventListener'].forEach(funcName => {
+      this[funcName] = (...args) => delegate[funcName](...args);
+    });
   }
 }

--- a/packages/overlays/test/DropdownConfig.test.js
+++ b/packages/overlays/test/DropdownConfig.test.js
@@ -1,0 +1,43 @@
+import { expect } from '@open-wc/testing';
+// import { OverlayController } from '../index.js';
+// import { withDropdownConfig } from '../src/DropdownConfig.js';
+
+const OverlayController = null; // wrapper around Global and LocalOverlayController
+
+const withDropdownConfig = () => ({
+  isGlobal: false,
+  placement: 'bottom',
+  hidesOnOutsideClick: true,
+  hidesOnEsc: true,
+  modifiers: {
+    flip: {
+      behavior: ['bottom', 'top'],
+    },
+    offset: {
+      enabled: false,
+    },
+  },
+});
+
+// Integration tests for expected defaults
+describe('withDropdownConfig', () => {
+  it('is a function returning an object', () => {
+    expect(typeof withDropdownConfig).to.be('function');
+    expect(typeof withDropdownConfig()).to.be('object');
+  });
+
+  it('has correct defaults', () => {
+    const controller = new OverlayController(withDropdownConfig());
+    expect(controller.isGlobal).to.equal(false);
+    expect(controller.placement).to.equal('bottom');
+    expect(controller.hidesOnOutsideClick).to.equal(true);
+    expect(controller.hidesOnEsc).to.equal(true);
+    expect(controller.modifiers.flip.behavior).to.equal(['bottom', 'top']);
+    expect(controller.modifiers.offset.enabled).to.equal(false);
+  });
+
+  it('has the same contentNode width as the invokerNode', () => {
+    const controller = new OverlayController(withDropdownConfig());
+    expect(controller.contentNode.style.width).to.equal(controller.invokerNode.style.width);
+  });
+});

--- a/packages/select-rich/README.md
+++ b/packages/select-rich/README.md
@@ -1,0 +1,84 @@
+# Select Rich
+
+[//]: # (AUTO INSERT HEADER PREPUBLISH)
+
+`lion-select-rich` component is a 'rich' version of the native `<select>` element.
+It allows to provide fully customized options and a fully customized invoker button.
+The component is meant to be used whenever the native `<select>` doesn't provide enough
+styling/theming/user interaction opportunities.
+
+Its implementation is based on the following Design pattern:
+https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
+
+
+## Features
+- fully accessible
+- flexible api
+- fully customizable option elements
+- fully customizable invoker element
+
+## How to use
+
+### Installation
+```
+npm i --save @lion/select-rich
+```
+
+```js
+import '@lion/select-rich/lion-select-rich.js';
+```
+
+### Example
+
+```html
+<lion-select-rich
+  name="favoriteColor"
+  .errorValidators=${[['required']]}
+>
+  <div slot="label">Favorite color</div>
+  <lion-button slot="invoker">Please select</lion-button>
+  <lion-listbox slot="input">
+    <lion-option value="red">Red</lion-option>
+    <lion-option value="hotpink" disabled>Hotpink</lion-option>
+    <lion-optgroup>
+      <lion-option value="teal">Teal</lion-option>
+      <lion-separator></lion-separator>
+      <lion-option value="green">Green</lion-option>
+    </lion-optgroup>
+  </lion-listbox>
+</lion-select-rich>
+```
+
+You can preselect an option by setting the property modelValue.
+ ```html
+<lion-select-rich
+  name="favoriteColor"
+  .modelValue="${'<value of option 2>'}"
+>
+  ...
+</lion-select-rich>
+ ```
+
+You can set multiple values.
+ ```html
+<lion-select-rich
+  name="favoriteColor"
+  multi
+  .modelValue="${['<value of option 2>', '<value of option 2>']}"
+>
+  ...
+</lion-select-rich>
+ ```
+
+You can provide an invoker rendering a custom invoker that gets the selected value(s) as an
+input property `.selectionData`
+ ```html
+<lion-select-rich
+  ...
+>
+  <my-invoker-button slot="invoker">
+    <!-- rendered content based on selected value(s) -->
+  </my-invoker-button>
+  ...
+</lion-select-rich>
+ ```

--- a/packages/select-rich/docs/DesignConsiderations.md
+++ b/packages/select-rich/docs/DesignConsiderations.md
@@ -1,0 +1,316 @@
+# Design considerations for new Custom Fields (draft)
+
+Whenever a new type of Form component is made, a list of questions needs to be addressed:
+- How can we build an accessible form component?
+- How can we build a flexible fundament layer that can be extended in multiple ways?
+- How can we deliver a predictable/consistent Developer Experience?
+
+This document is meant to illustrate how all of the above mentioned factors are taken
+into account and prioritized.
+It does so by going through the design process of the concept 'listbox',
+step by step.
+
+The listbox concept will end up in several web components:
+- lion-listbox: a listbox implementation agnostic of Lion form system
+- lion-field-listbox: a Field wrapping lion-listbox
+- lion-field-listbox-collapsible(current working name lion-select-rich): extension of Lion-field
+listbox with collapsible dropdown
+- lion-field-combobox: a Field wrapping lion-listbox, but with a text field as the input element.
+
+## The need for a listbox
+The reason we need a non platform, custom built version of a listbox component,
+is very well explained on MDN:
+
+> The `<select>` element is notoriously difficult to style productively with CSS. You can affect
+ certain aspects like any element — for example, manipulating the box model, the displayed
+ font, etc., and you can use the appearance property to remove the default system appearance.
+
+On top of this, a listbox is allows us to create advanced user experiences that are not :
+- create an autocomplete/autosuggest combobox
+- create advanced user interaction like explained here: https://www.w3.org/TR/wai-aria-practices/#Listbox
+
+## Creating a Form Control
+The goal of every form web component we build is to end up as a [FormControl]((https://github.com/ing-bank/lion/tree/master/packages/field)).
+More specific: either as a Field or a Fieldset.
+In short, a FormControl provides a normalized api, a modelValue, validation, formatting,
+interaction states, an accessible html structure for labels, feedback, help texts and addons.
+Please see the [Custom Fields tutorial](https://github.com/ing-bank/lion/blob/master/packages/field/docs/CustomFieldsTutorial.md)
+to get an idea of how to build a custom FormControl (a range slider in this particular case).
+
+A FormControl is meant to be the single point of interaction for Application Developers.
+All relevant form data are specified on this layer by him/her.
+Everything that is specified _within_ a field(being slotted content), has a _**presentational**_
+purpose only.
+
+> Reasons for this are outlined in a document written before(by Misha, Thomas and me) about
+predictability, SSOT and data flow. TODO: add that document later.
+
+
+## Getting the right api: accessibility
+As far as the api is concerned, the ideal api for our rich select would be:
+
+```html
+<lion-select-rich>
+  <lion-option></lion-option>
+  <lion-option></lion-option>
+</lion-select-rich>
+```
+The difference with our api is the lack of a `<lion-listbox>` around `<lion-option>`s
+In order to transform the ideal api into an accessible solution, it needs to be transformed into
+something like this:
+
+```html
+<div role=“button” aria-haspopup=“listbox” aria-expanded=“true/false”>
+<div role=“listbox” aria-activedescendant=“two”>
+  <div role=“option” id=“one” aria-posinset="1" aria-setsize="2"></div>
+  <div role=“option” id=“two” aria-posinset="2" aria-setsize="2"></div>
+</div>
+```
+The element with [role=listbox] and [aria-activedescendant] needs to be in the same dom as the
+elements with [role=option].
+Attempting to provide the ‘ideal api’ as suggested above poses a challenge:
+since we would have two different doms (shadow and light), the aforementioned elements would not
+find each other<sup>(1)</sup>.
+
+A slight alteration of the api (moving [role=listbox] element to the light dom as well) solves
+this problem:
+```html
+<lion-select-rich>
+  <lion-listbox slot="input">
+    <lion-option></lion-option>
+    <lion-option></lion-option>
+  </lion-listbox>
+</lion-select-rich>
+```
+
+The api is conceptually identical to that of the already existing native select:
+
+```html
+<lion-select>
+  <select slot=“input”>
+    <option></option>
+    <option></option>
+  </select>
+</lion-select>
+```
+
+
+## Getting the right api: presentational content
+
+Let’s first revisit our main Fields: `lion-input`, `lion-textarea`, `lion-select`, `lion-radio` and
+`lion-checkbox`.
+For the sake of clarity and to get a good grasp of conceptual differences between different layers in
+our system, the names of our LionField extensions will be changed to these within this document:
+- field-text (instead of lion-input, wraps input[type=“text”])
+- field-textarea (instead of lion-textarea, wraps textarea)
+- field-select (instead of lion-select, wraps select)
+- field-radio (instead of lion-radio, wraps input[type=“radio”])
+- field-checkbox  (instead of lion-checkbox, wraps input[type=“checkbox”])
+
+The field-text, field-textarea and field-radio/field-checkbox have an api roughly resembling this:
+```html
+<field-x name=“x” .label=“${labels.x}” .modelValue=“${model.x}”></field-x>
+```
+Whenever a _presentational_ component used within those fields needs to be changed, content
+projection is the right approach for this. In the example below, the label can’t be provided as a
+String:
+```html
+<field-x name=“x” .modelValue=“${model.x}”>
+  <label slot=“label”>
+    <lion-icon .svg=“${assets.x}”></lion-icon>
+    ${labels.x}
+  </label>
+</field-x>
+```
+
+Similarly, the Field for native select provides a `[slot=input]` for presentational purposes.
+The selected option is reflected in the `.modelValue`.
+The presentational part<sup>(2)</sup>, the options, should be defined by the Application Developer.
+
+Notice that contrary to the example above, an Application Developer has two places to get/set
+his/her value:
+- on the [slot=input] level as a 'value' property
+- on the Field level as a '.modelValue' property
+
+Using [slot=input] directly is not recommended and should be considered an anti
+pattern: it doesn't have the normalized Field api and it creates an unpredictable data flow/DX
+on top of this.
+Again, [slot=input] should be considered as being presentational only...
+```html
+<field-select name=“x” .label=“${labels.x}” .modelValue=“${model.x}”>
+  <select slot=“input”>
+    <option value=“a”>${translations.optionALabel}</option>
+    <option value=“b”>${translations.optionBLabel}</option>
+  </select>
+</field-select>
+```
+
+Summarized: what all of the different field types above have in common is this api for the
+Application Developer:
+```html
+<field-x name="x" .modelValue=“${model.x}” @model-value-changed=“${() => this.xHandler.bind(this)}”>
+  ...
+</field-x>
+```
+All the relevant interaction with regard to form state happens (and should happen) on the Field layer.
+
+
+## Field or Fieldset?
+For most FormControls, the answer to this question is really simple: a LionField wraps just one
+input, a LionFieldset wraps many.
+
+For a listbox, the question arises: ‘is a sole option an autonomous input or not?’.
+As always, the platform should provide us the answer: https://www.w3.org/TR/wai-aria-practices/examples/listbox/listbox-collapsible.html
+Put in other words, a `listbox` equals `<select>` (with size attribute other than "1").
+
+A listbox can semantically be seen as a select. A select on its turn can be seen as
+a radiogroup and a select with option [multiple] can be seen as a checkbox group.
+Although both of these currently are wrapped in LionFieldset (with [role=group]), the proper
+semantics are now already communicated via [role=listbox].
+Thus, the lion-listbox (which has [role=listbox]) will be wrapped in a Field (which has no role
+set by default).
+
+Now, considering the fact that our `<lion-listbox>` component is an equivalent of a `<select>`,
+but with advanced styling possibilities, it follows that their apis should be similar as well.
+
+So, we would end up with <sup>(3)</sup>:
+
+```html
+<lion-field-listbox .name=“{‘x’}” .modelValue=${model.x}>
+  <lion-listbox slot=“input”>
+    <lion-option value=“x”>x</lion-option>
+  </lion-listbox>
+</lion-field-listbox>
+```
+
+### ChoiceInput or not?
+Options have a lot in common with radio inputs and checkboxes(multiselect). There main difference
+seems to be [aria-selected] for option (having possible values of true and false) and
+[aria-checked] for radio buttons and checkboxes (having a tristate, including indeterminate).
+Another difference is the fact that input[type="radio/checkbox"] can be used on its own, whereas
+an option can't.
+Since ChoiceInput adds `.choiceValue` for complex data, we can consider aligning with the
+ChoiceInput. Since we already deliver the `.value` property on the ChoiceInputs, we could
+add `.choiceValue` later in a non breaking way.
+
+
+
+### Complex values on lion-listbox level?
+As of now, we never needed our `<select>` options to have a `.modelValue`; our main assumption for
+the listbox should be the same.
+Adding a modelValue on option level (or lion-listbox/select level) is thus not needed.
+It would also be confusing, because modelValues are a concept exclusive to FormControls(Fields or Fieldsets):
+the lion-listbox and lion-option are none of those.
+There might be a need for complex values, they can be added on Field level by writing a `parser`.
+
+
+## Extrapolation to combobox
+What the above brings to light, is that the `<lion-listbox>` is now a reusable construct (on the
+level of `<select>`, `input`, `<textarea>` etc) that can be reused by different Fields.
+One such field is the combobox, which has an input and a listbox as children.
+As opposed to the `<field-listbox>/<field-select>`, the [slot=“input”] is the `<input>` element
+here. Since in this constellation, it is the `input` element that synchronizes its `.value` with
+its parent Field. The input element on its turn drives the dropdown listbox.
+
+An api would come down to:
+```html
+<field-combobox has-autocomplete name=“x” .modelValue=“model.x”>
+  <!-- the input + invoker button would be placed here in private slots -->
+  <lion-listbox  slot=“list”>
+    <!-- in theory, [slot=“list”] could also be a grid -->
+    ${listOptions.map(opt => html`
+    <lion-option value=“${opt.value}”>${opt.a}${opt.b}</lion-option>
+    `)}
+  </lion-listbox>
+</field-combobox>
+```
+
+## Subclassers api enhancements
+Keep in mind all Lion components are flexible layers, allowing the Application Developer to fully
+control the presentational part.
+A subclasser might alter the api by do something like this for a listbox Field:
+```html
+<my-field-listbox .options=“${optionArray}”></my-field-listbox>
+```
+Or, for a combobox Field:
+```html
+<my-field-combobox .options=“${optionArray}”></my-field-combobox>
+```
+Under the hood it uses a cloneable node as option template and generates the “input”/"list" slot.
+How the provided data in `.options` and the generated `<my-option>` elements work together,
+should be specified on this level.
+See https://vaadin.com/components/vaadin-select/html-examples for a comparable api.
+
+
+
+
+## Not perfect (yet...)
+Since our current namings can lead to questions (why does a `<lion-listbox>` not have a
+`modelValue`), I would opt for a rename to:
+- All Field extensions as suggested above, but then prefixed with ‘lion’.
+- The [slot=“input”] could be renamed to slot=“presentation-input”?
+Would avoid mistakes and confusion for Application Developers. However, input (or
+[interactive element](https://github.com/ing-bank/lion/blob/master/packages/field/docs/CustomFieldsTutorial.md))
+would make more sense for Subclassers.
+
+More public/api changes for forms in general:
+- Rename modelValue/model-value-changed to “.model/model” for better DX
+- Improve validators:
+    - Make them class instances
+    - Instances can respond to param changes
+    - Instance can bridge to platform functionality -> required validator can set
+    [aria-required=true] to [slot=input]
+    - Allow to add translation to validator instance
+    - Async validators
+    - Better integration between platform validators and ours
+    - ... many more small improvements possible for validator api
+
+Most of these are breaking and should be done in our next milestone.
+
+
+
+## Summarized
+
+Summarized, most of the api choices are a compromise of:
+- Accessibility
+    - We have no access to https://github.com/WICG/aom/blob/gh-pages/explainer.md yet
+- DX/Predictability
+    - one ‘form state’ layer to interact with, one presentational layer to define advanced UI
+    - when an Application Developer considers elements put in light dom his/her own, leads to unpredictable behaviour when moving them around<sup>(4)</sup>
+- Performance
+    - no trickery with moving around elements in light dom that are glued together with mutation observers etc.
+
+
+
+
+
+
+
+
+<sub>
+1. Transferring the `lion-option`s to a part of the light dom that already has the listbox, would be
+a technically possible, but hacky solution.
+Putting [role=“listbox”] on the host(like suggested before) is not a solution either: it causes the button to be a child of the listbox and this would confuse
+screen reader users.
+</sub>
+
+<sub>
+2. The part here that could be considered non presentational here is the “value” provided to option. It kind of reflects ‘potential form state’. In this api we’ve chosen alignment with the platform, but
+One could argue that ‘the lack of selection’ is also part of form state, and should be covered in the modelValue.
+Something worth discussing. We currently apply this to the ChoiceGroups (radioGroup, checkboxGroup),
+Although my personal opinion, in retrospect is that it complicates DX and something like Vue(appreciated for its DX in general) does might be easier: https://vuejs.org/v2/guide/forms.html
+</sub>
+
+<sub>
+3. What could be open for discussion is whether we can’t just say 'field-select .modelValue=${myArray}'.
+The main reason not to do this, is because you would end up with a situation where you would have an intermangling
+Between form state (this is what the .modelValue is supposed to be about) and presentation (you could end up with logic about
+whether an icon needs to be displayed or not inside your modelValue)
+</sub>
+
+<sub>
+4. An alternative can possibly be accomplished by creating some kind of DSL like the vaadin-grid does for instance: https://vaadin.com/components/vaadin-grid/html-examples
+- It makes a distinction between presentation and values
+- the api has no connection with actual dom created.
+But, it has the same drawbacks as pointed out already
+</sub>

--- a/packages/select-rich/lion-listbox-invoker.js
+++ b/packages/select-rich/lion-listbox-invoker.js
@@ -1,0 +1,3 @@
+import { LionListboxInvoker } from './src/LionListboxInvoker.js';
+
+customElements.define('lion-listbox-invoker', LionListboxInvoker);

--- a/packages/select-rich/lion-listbox-select.js
+++ b/packages/select-rich/lion-listbox-select.js
@@ -1,0 +1,3 @@
+import { LionListboxSelect } from './src/LionListboxSelect.js';
+
+customElements.define('lion-listbox-select', LionListboxSelect);

--- a/packages/select-rich/lion-select-rich.js
+++ b/packages/select-rich/lion-select-rich.js
@@ -1,0 +1,3 @@
+import { LionSelectRich } from './src/LionSelectRich.js';
+
+customElements.define('lion-select-rich', LionSelectRich);

--- a/packages/select-rich/package.json
+++ b/packages/select-rich/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@lion/select-rich",
+  "version": "0.0.0",
+  "description": "Provide a set of [role=option]s and select one",
+  "author": "ing-bank",
+  "homepage": "https://github.com/ing-bank/lion/",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ing-bank/lion.git",
+    "directory": "packages/select"
+  },
+  "scripts": {
+    "prepublishOnly": "../../scripts/npm-prepublish.js"
+  },
+  "keywords": [
+    "lion",
+    "web-components",
+    "select",
+    "listbox",
+    "field",
+    "form",
+    "option"
+  ],
+  "main": "index.js",
+  "module": "index.js",
+  "files": [
+    "docs",
+    "src",
+    "stories",
+    "test",
+    "translations",
+    "*.js"
+  ],
+  "dependencies": {
+    "@lion/core": "^0.1.6",
+    "@lion/radio-group": "^0.1.11",
+    "@lion/overlays": "^0.2.5",
+    "@lion/button": "^0.1.11",
+    "@lion/listbox": "^0.0.0"
+  },
+  "devDependencies": {
+    "@open-wc/demoing-storybook": "^0.2.0",
+    "@open-wc/testing": "^0.11.1",
+    "@lion/form": "^0.1.21"
+  }
+}

--- a/packages/select-rich/src/LionListboxInvoker.js
+++ b/packages/select-rich/src/LionListboxInvoker.js
@@ -1,0 +1,77 @@
+import { LionButton } from '@lion/button';
+import { html, css } from '@lion/core';
+
+/**
+ * LionListboxInvoker: invoker button consuming seleceted state of listbox
+ *
+ * @customElement
+ * @extends LionButton
+ */
+// eslint-disable-next-line no-unused-vars
+export class LionListboxInvoker extends LionButton {
+  static get styles() {
+    return [
+      // ...super.styles,
+      css`
+        :host {
+          background-color: lightgray;
+          display: block;
+          padding: 8px;
+        }
+
+        /* sr-only */
+        :host ::slotted(button) {
+          position: absolute;
+          visibility: hidden;
+          top: 0;
+        }
+      `,
+    ];
+  }
+
+  static get properties() {
+    return {
+      selectedElement: {
+        type: Object,
+      },
+    };
+  }
+
+  get contentWrapper() {
+    return this.shadowRoot.getElementById('content-wrapper');
+  }
+
+  constructor() {
+    super();
+    this.selectedElement = document.createElement('span');
+  }
+
+  // eslint-disable-next-line
+  __clickDelegationHandler() {
+    // no delegate here, just the original click
+  }
+
+  _contentTemplate() {
+    const labelNode = this.selectedElement.querySelector('*');
+    if (labelNode) {
+      return labelNode.cloneNode(true);
+    }
+
+    const labelText = this.selectedElement.label;
+    if (labelText) {
+      return labelText;
+    }
+
+    return this.selectedElement.cloneNode(true);
+  }
+
+  render() {
+    return html`
+      <div id="content-wrapper">
+        ${this._contentTemplate()}
+      </div>
+      <slot name="_button"></slot>
+      <div class="click-area" @click="${this.__clickDelegationHandler}"></div>
+    `;
+  }
+}

--- a/packages/select-rich/src/LionListboxSelect.js
+++ b/packages/select-rich/src/LionListboxSelect.js
@@ -1,0 +1,3 @@
+import { LionListboxBase } from '@lion/listbox';
+
+export class LionListboxSelect extends LionListboxBase {}

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -1,0 +1,194 @@
+import { LionRadioGroup } from '@lion/radio-group';
+import { html, css } from '@lion/core';
+import { LocalOverlayController, overlays } from '@lion/overlays';
+
+import '../lion-listbox-invoker.js';
+
+/**
+ * LionSelectRich: wraps the <lion-listbox> element
+ *
+ * @customElement
+ * @extends LionField
+ */
+export class LionSelectRich extends LionRadioGroup {
+  static get styles() {
+    return [
+      css`
+        .input-group__input {
+          display: block;
+        }
+      `,
+    ];
+  }
+
+  static get properties() {
+    return {
+      ...super.properties,
+      opened: {
+        type: Boolean,
+        reflect: true,
+      },
+    };
+  }
+
+  get modelValue() {
+    const parentValue = super.modelValue;
+    return parentValue[`${this.name}-option[]`];
+  }
+
+  set modelValue(values) {
+    const valuesForParent = {};
+    valuesForParent[`${this.name}-option[]`] = values;
+    super.modelValue = valuesForParent;
+  }
+
+  get selectElements() {
+    return this.formElements[`${this.name}-option[]`];
+  }
+
+  get slots() {
+    return {
+      ...super.slots,
+      invoker: () => {
+        return document.createElement('lion-listbox-invoker');
+      },
+    };
+  }
+
+  constructor() {
+    super();
+    this.opened = false;
+    this.toggle = this.toggle.bind(this);
+    this._overlayOnShow = this._overlayOnShow.bind(this);
+    this._overalyOnHide = this._overalyOnHide.bind(this);
+    this.__updateInvokerContent = this.__updateInvokerContent.bind(this);
+    this.__onKeyUp = this.__onKeyUp.bind(this);
+  }
+
+  get _listboxNode() {
+    return this.querySelector('[slot=input]');
+  }
+
+  get _invokerNode() {
+    return this.querySelector('[slot=invoker]');
+  }
+
+  connectedCallback() {
+    super.connectedCallback(); // eslint-disable-line
+    this.__createDropdownSelect();
+    this._invokerNode.setAttribute('aria-haspopup', 'listbox');
+  }
+
+  updated(changedProps) {
+    super.updated(changedProps);
+    if (changedProps.has('opened')) {
+      if (this.opened) {
+        this.__overlay.show();
+      } else {
+        this.__overlay.hide();
+      }
+    }
+  }
+
+  toggle() {
+    this.opened = !this.opened;
+  }
+
+  __onFormElementRegister(event) {
+    const child = event.detail.element;
+    if (child === this) return; // as we fire and listen - don't handle ourselve
+    child.name = `${this.name}-option[]`;
+
+    super.__onFormElementRegister(event);
+  }
+
+  __createDropdownSelect() {
+    this.__overlay = overlays.add(
+      new LocalOverlayController({
+        hidesOnEsc: false,
+        hidesOnOutsideClick: true,
+        contentNode: this._listboxNode,
+        invokerNode: this._invokerNode,
+      }),
+    );
+
+    this._invokerNode.addEventListener('click', this.toggle);
+    this.__overlay.addEventListener('show', this._overlayOnShow);
+    this.__overlay.addEventListener('hide', this._overalyOnHide);
+    this._invokerNode.addEventListener('keydown', this.__onKeyUp, true);
+
+    this.addEventListener('checked-value-changed', this.__updateInvokerContent);
+  }
+
+  _overlayOnShow() {
+    this.opened = true;
+    // TODO set aria-expaneded?
+  }
+
+  _overalyOnHide() {
+    this.opened = false;
+    // this._invokerNode.focus(); // not needed as focus never leaves the button?
+  }
+
+  __updateInvokerContent() {
+    this._invokerNode.selectedElement = this._getCheckedRadioElement();
+  }
+
+  /**
+   * @override
+   */
+  // eslint-disable-next-line
+  inputGroupInputTemplate() {
+    return html`
+      <div class="input-group__input">
+        <slot name="invoker"></slot>
+        <slot name="input"></slot>
+      </div>
+    `;
+  }
+
+  /**
+   * A select should NOT have a role
+   *
+   * @override
+   */
+  // eslint-disable-next-line class-methods-use-this
+  _setRole() {}
+
+  inputGroupTemplate() {
+    return html`
+      <div class="input-group">
+        ${this.inputGroupBeforeTemplate()}
+        <div class="input-group__container">
+          ${this.inputGroupPrefixTemplate()} ${this.inputGroupInputTemplate()}
+          ${this.inputGroupSuffixTemplate()}
+        </div>
+        ${this.inputGroupAfterTemplate()}
+      </div>
+    `;
+  }
+
+  __onKeyUp(ev) {
+    const index = this.modelValue.findIndex(el => el.checked === true);
+    ev.preventDefault();
+    switch (ev.key) {
+      case 'ArrowUp':
+        if (index !== 0) {
+          this.selectElements[index - 1].choiceChecked = true;
+        }
+        break;
+      case 'ArrowDown':
+        if (index !== this.selectElements.length - 1) {
+          this.selectElements[index + 1].choiceChecked = true;
+        }
+        break;
+      case 'Enter':
+        this.toggle();
+        break;
+      case 'Escape':
+        this.opened = false;
+        break;
+      /* no default */
+    }
+  }
+}

--- a/packages/select-rich/stories/index.stories.js
+++ b/packages/select-rich/stories/index.stories.js
@@ -1,0 +1,138 @@
+import { storiesOf, html } from '@open-wc/demoing-storybook';
+import { css } from '@lion/core';
+
+import '@lion/form/lion-form.js';
+import '@lion/listbox/lion-option.js';
+import '@lion/listbox/listbox.js';
+
+import '../lion-select-rich.js';
+
+const selectRichDemoStyle = css`
+  .demo-listbox {
+    background-color: white;
+  }
+
+  .demo-option[focused] {
+    background-color: lightgray;
+  }
+`;
+
+storiesOf('Forms|Select Rich', module)
+  .add(
+    'Default',
+    () => html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-select-rich label="Favorite color" name="color">
+        <lion-listbox slot="input">
+          <lion-option .modelValue=${{ value: 'red', checked: false }}>Red</lion-option>
+          <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>Hotpink</lion-option>
+          <lion-option .modelValue=${{ value: 'teal', checked: false }}>Teal</lion-option>
+        </lion-listbox>
+      </lion-select-rich>
+    `,
+  )
+  .add(
+    'Options with HTML',
+    () => html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-select-rich label="Favorite color" name="color">
+        <lion-listbox slot="input" class="demo-listbox">
+          <lion-option .modelValue=${{ value: 'red', checked: false }}>
+            <p style="color: red;">I am red</p>
+            <p>and multi Line</p>
+          </lion-option>
+          <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>
+            <p style="color: hotpink;">I am hotpink</p>
+            <p>and multi Line</p>
+          </lion-option>
+          <lion-option .modelValue=${{ value: 'teal', checked: false }}>
+            <p style="color: teal;">I am teal</p>
+            <p>and multi Line</p>
+          </lion-option>
+        </lion-listbox>
+      </lion-select-rich>
+    `,
+  )
+  .add(
+    'Disabled',
+    () => html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-select-rich label="Disabled select" disabled name="color">
+        <lion-listbox slot="input">
+          <lion-option .modelValue=${{ value: 'red', checked: false }}>Red</lion-option>
+          <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>Hotpink</lion-option>
+          <lion-option .modelValue=${{ value: 'teal', checked: false }}>Teal</lion-option>
+        </lion-listbox>
+      </lion-select-rich>
+
+      <lion-select-rich label="Disabled options" name="color">
+        <lion-listbox slot="input">
+          <lion-option .modelValue=${{ value: 'red', checked: false }}>Red</lion-option>
+          <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>Hotpink</lion-option>
+          <lion-option .modelValue=${{ value: 'teal', checked: false }} disabled>Teal</lion-option>
+        </lion-listbox>
+      </lion-select-rich>
+    `,
+  )
+  .add('Validation', () => {
+    const submit = () => {
+      const form = document.querySelector('#form');
+      if (form.errorState === false) {
+        console.log(form.serializeGroup());
+      }
+    };
+    return html`
+      <style>
+        ${selectRichDemoStyle}
+      </style>
+      <lion-form id="form" @submit="${submit}">
+        <form>
+          <lion-select-rich
+            id="color"
+            name="color"
+            label="Favorite color"
+            .errorValidators="${[['required']]}"
+          >
+            <lion-listbox slot="input" class="demo-listbox">
+              <lion-option value="red" class="demo-option">Red</lion-option>
+              <lion-option value="hotpink" class="demo-option">Hotpink</lion-option>
+              <lion-option value="teal" class="demo-option">Teal</lion-option>
+            </lion-listbox>
+          </lion-select-rich>
+          <lion-button type="submit">Submit</lion-button>
+        </form>
+      </lion-form>
+    `;
+  })
+  .add('Render Options', () => {
+    const objs = [
+      { type: 'mastercard', label: 'Master Card', amount: 12000, active: true },
+      { type: 'visacard', label: 'Visa Card', amount: 0, active: false },
+    ];
+    return html`
+      <lion-form>
+        <form>
+          <lion-select-rich label="Favorite color" name="color">
+            <lion-listbox slot="input">
+              ${objs.map(
+                obj => html`
+                  <lion-option .modelValue=${{ value: obj, checked: false }}
+                    >${obj.label}</lion-option
+                  >
+                `,
+              )}
+            </lion-listbox>
+          </lion-select-rich>
+        </form>
+      </lion-form>
+    `;
+  });

--- a/packages/select-rich/test/lion-listbox-invoker.test.js
+++ b/packages/select-rich/test/lion-listbox-invoker.test.js
@@ -1,0 +1,75 @@
+import { expect, fixture, html, defineCE } from '@open-wc/testing';
+import { LionButton } from '@lion/button';
+import { LionListboxInvoker } from '../src/LionListboxInvoker.js';
+
+import '../lion-listbox-invoker.js';
+
+describe('lion-listbox-invoker', () => {
+  it('should behave as a button', async () => {
+    const el = await fixture(html`
+      <lion-listbox-invoker></lion-listbox-invoker>
+    `);
+    expect(el instanceof LionButton).to.be.true;
+  });
+
+  it('renders invoker info based on selectedElement child nodes', async () => {
+    const el = await fixture(html`
+      <lion-listbox-invoker></lion-listbox-invoker>
+    `);
+    el.selectedElement = await fixture(`<div class="option"><h2>I am</h2><p>2 lines</p></div>`);
+    await el.updateComplete;
+
+    expect(el.contentWrapper).lightDom.to.equal(`
+      <h2>I am</h2>
+      <p>2 lines</p>
+    `);
+  });
+
+  describe('Subclassers', () => {
+    it('can create complex custom invoker renderers', async () => {
+      const nodes = [];
+
+      for (let i = 0; i < 2; i += 1) {
+        const myNode = document.createElement('div');
+        myNode.propX = `x${i}`;
+        myNode.propY = `y${i}`;
+        nodes.push(myNode);
+      }
+
+      // TODO: pseudo code: api for multiple selected might change
+      const myTag = defineCE(
+        class extends LionListboxInvoker {
+          constructor() {
+            super();
+            this.selectedElements = nodes;
+          }
+
+          _contentTemplate() {
+            // Display multi-select as chips
+            return html`
+              <div>
+                ${this.selectedElements.forEach(
+                  sEl => html`
+                    <div class="c-chip">
+                      ${sEl.propX}
+                      <span class="c-chip__part">
+                        ${sEl.propY}
+                      </span>
+                    </div>
+                  `,
+                )}
+              </div>
+            `;
+          }
+        },
+      );
+
+      const myEl = await fixture(`<${myTag}></${myTag}>`);
+      // pseudo...
+      expect(myEl).lightDom.to.contain('x1');
+      expect(myEl).lightDom.to.contain('x2');
+      expect(myEl).lightDom.to.contain('y1');
+      expect(myEl).lightDom.to.contain('y2');
+    });
+  });
+});

--- a/packages/select-rich/test/lion-select-rich.test.js
+++ b/packages/select-rich/test/lion-select-rich.test.js
@@ -1,0 +1,339 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+import '@lion/listbox/lion-option.js';
+import '@lion/listbox/lion-listbox.js';
+import '../lion-select-rich.js';
+
+describe('lion-select-rich', () => {
+  describe('values', () => {
+    it('sync modelValue, checkedValue from/to the listbox', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10}>Item 1</lion-option>
+            <lion-option .choiceValue=${20}>Item 2</lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(el.modelValue).to.equal([{ value: 10, checked: true }, { value: 20, checked: false }]);
+      expect(el.choiceValue).to.equal(10);
+    });
+
+    it('shows html content of the checked option inside the invoker', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10}>
+              <span>Item 1</span>
+            </lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(el._invokerNode.contentWrapper).lightDom.to.equal('<span>Item 1</span>');
+    });
+  });
+
+  describe('overlay', () => {
+    it('should be closed by default', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      expect(el.opened).to.be.false;
+    });
+
+    it('shows/hides the listbox via opened attribute', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      el.opened = true;
+      await el.updateComplete;
+      expect(el._listboxNode.style.display).to.be.equal('inline-block');
+
+      el.opened = false;
+      await el.updateComplete;
+      expect(el._listboxNode.style.display).to.be.equal('none');
+    });
+  });
+
+  describe('Disabled', () => {
+    it('can not be focused if disabled', async () => {
+      const el = await fixture(html`
+        <lion-select-rich disabled></lion-select-rich>
+      `);
+      expect(el.tabIndex).to.equal('-1');
+    });
+
+    it('should not open if disabled', async () => {
+      const el = await fixture(html`
+        <lion-select-rich disabled opened></lion-select-rich>
+      `);
+      expect(el.opened).to.be.false;
+      el.opend = true;
+      expect(el.opened).to.be.false;
+    });
+
+    it('can not be navigated with keyboard if disabled', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10} label="Item 1"></lion-option>
+            <lion-option .choiceValue=${20} label="Item 2"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+    });
+  });
+
+  describe('Keyboard navigation', () => {
+    it('opens the listbox with [enter] key', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await el.updateComplete;
+      expect(el.opened).to.be.true;
+    });
+
+    it('opens the listbox with [space] key', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Space' }));
+      await el.updateComplete;
+      expect(el.opened).to.be.true;
+    });
+
+    it('closes the listbox with [enter] key once opened', async () => {
+      const el = await fixture(html`
+        <lion-select-rich opened></lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await el.updateComplete;
+      expect(el.opened).to.be.false;
+    });
+
+    it('closes the listbox with [esc] key once opened', async () => {
+      const el = await fixture(html`
+        <lion-select-rich opened></lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Esc' }));
+      await el.updateComplete;
+      expect(el.opened).to.be.false;
+    });
+
+    it('closes the listbox with [tab] key once opened', async () => {
+      const el = await fixture(html`
+        <lion-select-rich opened></lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      await el.updateComplete;
+      expect(el.opened).to.be.false;
+    });
+
+    it('navigates through list with [arrow up] [arrow down] keys', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10} label="Item 1"></lion-option>
+            <lion-option .choiceValue=${20} label="Item 2"></lion-option>
+            <lion-option .choiceValue=${30} label="Item 3"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(el.choiceValue).to.equal(10);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(20);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+    });
+
+    it('navigates to first and last option with [home] [end] keys', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10} label="Item 1"></lion-option>
+            <lion-option .choiceValue=${20} label="Item 2"></lion-option>
+            <lion-option .choiceValue=${30} label="Item 3" checked></lion-option>
+            <lion-option .choiceValue=${40} label="Item 4"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(40);
+    });
+
+    // TODO: nice to have
+    it.skip('selects a value with single [character] key', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${'a'} label="A"></lion-option>
+            <lion-option .choiceValue=${'b'} label="B"></lion-option>
+            <lion-option .choiceValue=${'c'} label="C"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(el.choiceValue).to.equal('a');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'C' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal('c');
+    });
+
+    it.skip('selects a value with multiple [character] keys', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${'bar'} label="Bar"></lion-option>
+            <lion-option .choiceValue=${'far'} label="Far"></lion-option>
+            <lion-option .choiceValue=${'foo'} label="Foo"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'F' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal('far');
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'O' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal('foo');
+    });
+  });
+
+  // TODO: nice to have
+  describe.skip('Read only', () => {
+    it('can be focused if readonly', async () => {
+      const el = await fixture(html`
+        <lion-select-rich readonly></lion-select-rich>
+      `);
+      expect(el.tabIndex).to.equal('-1');
+    });
+
+    it('can not open if readonly', async () => {
+      const el = await fixture(html`
+        <lion-select-rich readonly></lion-select-rich>
+      `);
+      el.opened = true;
+      expect(el.opened).to.be.true;
+    });
+
+    it('can not be navigated with keyboard if readonly', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10} label="Item 1"></lion-option>
+            <lion-option .choiceValue=${20} label="Item 2"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+      await el.updateComplete;
+      expect(el.choiceValue).to.equal(10);
+    });
+  });
+
+  describe('Interaction states', () => {
+    it('syncs dirty, touched, prefilled from listbox', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10} label="Item 1"></lion-option>
+            <lion-option .choiceValue=${20} label="Item 2"></lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(el.dirty).to.be.false;
+      el.checkedValue = 20;
+      expect(el.dirty).to.be.true;
+
+      expect(el.touched).to.be.false;
+      el._invokerNode.focus();
+      expect(el.touched).to.be.true;
+    });
+
+    it('is prefilled if there is a value on init', async () => {
+      const el = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${10} label="">Item 1</lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(el.prefilled).to.be.true;
+
+      const elEmpty = await fixture(html`
+        <lion-select-rich>
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${null}>Please select a value</lion-option>
+            <lion-option .choiceValue=${10}>Item 1</lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(elEmpty.prefilled).to.be.false;
+    });
+  });
+
+  describe('Validation', () => {
+    it('can be required', async () => {
+      const lionSelect = await fixture(html`
+        <lion-select-rich name="foo" .errorValidators="${[`required`]}">
+          <lion-listbox slot="input">
+            <lion-option .choiceValue=${null}>Please select a value</lion-option>
+            <lion-option .choiceValue=${20}>Item 2</lion-option>
+          </lion-listbox>
+        </lion-select-rich>
+      `);
+      expect(lionSelect.error.required).to.be.true;
+      lionSelect.choiceValue = 20;
+      expect(lionSelect.error.required).to.be.undefined;
+    });
+  });
+
+  describe('Invoker', () => {
+    it('can toggle the listbox', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      expect(el.opened).to.be.false;
+      el._invokerNode.click();
+      expect(el.opened).to.be.true;
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has the right references to its inner elements', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      expect(el._invokerNode.getAttribute('aria-labelledby')).to.equal(
+        'ID_REF-label ID_RED-invoker',
+      );
+      expect(el._invokerNode.getAttribute('aria-haspopup')).to.equal('listbox');
+    });
+
+    it('notifies when the listbox is expanded or not', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      expect(el._invokerNode.getAttribute('aria-expanded')).to.be.false;
+      el.opened = true;
+      expect(el._invokerNode.getAttribute('aria-expanded')).to.be.true;
+    });
+
+    it('has tabindex="0" to on the invoker element', async () => {
+      const el = await fixture(html`
+        <lion-select-rich></lion-select-rich>
+      `);
+      expect(el._invokerNode.getAttribute('tabindex')).to.equal('0');
+    });
+  });
+});

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -24,3 +24,6 @@ import '../packages/overlays/stories/index.stories.js';
 import '../packages/popup/stories/index.stories.js';
 import '../packages/tooltip/stories/index.stories.js';
 import '../packages/calendar/stories/index.stories.js';
+
+// import '../packages/listbox/stories/index.stories.js';
+import '../packages/select-rich/stories/index.stories.js';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,14 @@
     lru-cache "^5.1.1"
     minimatch "^3.0.4"
 
+"@open-wc/chai-dom-equals@^0.11.7":
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/@open-wc/chai-dom-equals/-/chai-dom-equals-0.11.7.tgz#80c868f7137535093753ff956f61209f873ba9a5"
+  integrity sha512-p9l/Gv1cl8kDd+gav3wWOUqNyQjsESuWmkPnHmyuQeVh2EeCmtXE5ChFA9PogxIyk+JamQoPo9mggz0lNif4Hw==
+  dependencies:
+    "@open-wc/semantic-dom-diff" "^0.10.7"
+    "@types/chai" "^4.1.7"
+
 "@open-wc/chai-dom-equals@^0.12.5":
   version "0.12.5"
   resolved "https://registry.yarnpkg.com/@open-wc/chai-dom-equals/-/chai-dom-equals-0.12.5.tgz#bf883c2403b8cf282c63a2f44a7c1eb38331be76"
@@ -1899,10 +1907,20 @@
     eslint-config-prettier "^3.3.0"
     prettier "^1.15.0"
 
+"@open-wc/semantic-dom-diff@^0.10.7":
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.10.7.tgz#d4a6c59557adfa8204725242917215ceca82a1e5"
+  integrity sha512-HuoB6udX2pR5wvQu1zZAprQRJE/MLUsNxw6j003vMkn31UEUi4L6HJHif3I5HDNFkxQOcmRpU4ug68yS/PGa8Q==
+
 "@open-wc/semantic-dom-diff@^0.11.5":
   version "0.11.5"
   resolved "https://registry.yarnpkg.com/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.11.5.tgz#7e028a15ea74d758b8e5593d11d0abb945d51bf8"
   integrity sha512-+IQ8o64Z+voxn5807+YTN9GjIEfPsdZ6Zb1O04fGL2w1/qjWAKMFZa+G0r1UuFyEUP3LU+5XGGmCXPefWmSbhA==
+
+"@open-wc/testing-helpers@^0.8.10":
+  version "0.8.10"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing-helpers/-/testing-helpers-0.8.10.tgz#d0552e4be8a8905a86ce837b50f34f843d101fda"
+  integrity sha512-E3/BvJR9zonNNNKAOd7jUrqb2quTlngbtDxKfOIiW2yu9T/96UNHX1byTtA4W0MmKI9W3qnlHJEJ5hrjnGCJcg==
 
 "@open-wc/testing-helpers@^0.9.5":
   version "0.9.5"
@@ -1956,6 +1974,19 @@
   dependencies:
     wallaby-webpack "^3.0.0"
     webpack "^4.28.0"
+
+"@open-wc/testing@^0.11.1":
+  version "0.11.7"
+  resolved "https://registry.yarnpkg.com/@open-wc/testing/-/testing-0.11.7.tgz#a6bbf1c72f821952ad5b20d2879bd87ab8ff6075"
+  integrity sha512-qN30skJqV45C3odtxNc3cQLIUeiGgbAP1LPDj7SlR8rI709GACEdHwzhaXH8KNAGM54hDLbzgHzq4yk7HA9ghA==
+  dependencies:
+    "@bundled-es-modules/chai" "^4.2.0"
+    "@open-wc/chai-dom-equals" "^0.11.7"
+    "@open-wc/semantic-dom-diff" "^0.10.7"
+    "@open-wc/testing-helpers" "^0.8.10"
+    "@types/chai" "^4.1.7"
+    "@types/mocha" "^5.0.0"
+    mocha "^5.0.0"
 
 "@open-wc/testing@^0.12.5":
   version "0.12.5"


### PR DESCRIPTION
this should add all the requirements to start the implementation of a "rich" select.
- lion-select-rich 
  - is a "visual" wrapper that "connects" the a listbox overlay and an invoker "button"
  - all data (modelValue, dirty, name, ...) is synced/forwarded to the listbox
  - opens closes the overlay listbox

- lion-listbox
  - is sort of a radio group
  - is the actual element that get's added to the form
  - manages the actual modelValue and registration of elements
  - does a11y e.g. active-decedent, ...

- lion-option
  - is sort of a radio
  - has modelValue with value and checked state
  - has a11y stuff

- lion-listbox-invoker
  - actually displays the "info" from the "selected/checked" element
  - behaves like a button


ToDo:
- [ ] move lion-listbox-invoker into the listbox? or rename to `lion-select-invoker`?
- [ ] consider renaming `lion-select-rich` to `lion-select` and current `lion-select` => `lion-select-native` 
- [ ] move changes to the overlay into a separate PR