### PR TITLE
fix(field): format conditionally on user input only

### DIFF
--- a/packages/field/test/FormatMixin.test.js
+++ b/packages/field/test/FormatMixin.test.js
@@ -157,6 +157,25 @@ describe('FormatMixin', () => {
     expect(formatEl.inputElement.value).to.equal('foo: test');
   });
 
+  it('reflects back .formattedValue immediately when .modelValue changed imperatively', async () => {
+    const el = await fixture(html`
+      <${elem} .formatter="${value => `foo: ${value}`}">
+        <input slot="input" />
+      </${elem}>
+    `);
+    // The FormatMixin can be used in conjunction with the ValidateMixin, in which case
+    // it can hold errorState (affecting the formatting)
+    el.errorState = true;
+
+    // users types value 'test'
+    mimicUserInput(el, 'test');
+    expect(el.inputElement.value).to.not.equal('foo: test');
+
+    // Now see the difference for an imperative change
+    el.modelValue = 'test2';
+    expect(el.inputElement.value).to.equal('foo: test2');
+  });
+
   describe('parsers/formatters/serializers', () => {
     it('should call the parser|formatter|serializer provided by user', async () => {
       const formatterSpy = sinon.spy(value => `foo: ${value}`);
@@ -206,7 +225,7 @@ describe('FormatMixin', () => {
       expect(parserSpy.callCount).to.equal(1);
     });
 
-    it('will only call the formatter for valid values', async () => {
+    it('will only call the formatter for valid values on `user-input-changed` ', async () => {
       const formatterSpy = sinon.spy(value => `foo: ${value}`);
       const el = await fixture(html`
         <${elem} .formatter=${formatterSpy}>
@@ -216,12 +235,12 @@ describe('FormatMixin', () => {
       expect(formatterSpy.callCount).to.equal(1);
 
       el.errorState = true;
-      el.modelValue = 'bar';
+      mimicUserInput(el, 'bar');
       expect(formatterSpy.callCount).to.equal(1);
-      expect(el.formattedValue).to.equal('foo: init-string');
+      expect(el.formattedValue).to.equal('bar');
 
       el.errorState = false;
-      el.modelValue = 'bar2';
+      mimicUserInput(el, 'bar2');
       expect(formatterSpy.callCount).to.equal(2);
 
       expect(el.formattedValue).to.equal('foo: bar2');

--- a/packages/field/test/lion-field.test.js
+++ b/packages/field/test/lion-field.test.js
@@ -19,6 +19,11 @@ const tag = unsafeStatic(tagString);
 const inputSlotString = '<input slot="input" />';
 const inputSlot = unsafeHTML(inputSlotString);
 
+function mimicUserInput(formControl, newViewValue) {
+  formControl.value = newViewValue; // eslint-disable-line no-param-reassign
+  formControl.inputElement.dispatchEvent(new CustomEvent('input', { bubbles: true }));
+}
+
 beforeEach(() => {
   localizeTearDown();
 });
@@ -328,7 +333,7 @@ describe('<lion-field>', () => {
       expect(lionField.error.required).to.be.undefined;
     });
 
-    it('will only update formattedValue the value when valid', async () => {
+    it('will only update formattedValue when valid on `user-input-changed`', async () => {
       const formatterSpy = sinon.spy(value => `foo: ${value}`);
       function isBarValidator(value) {
         return { isBar: value === 'bar' };
@@ -348,9 +353,9 @@ describe('<lion-field>', () => {
       expect(formatterSpy.callCount).to.equal(1);
       expect(lionField.formattedValue).to.equal('foo: bar');
 
-      lionField.modelValue = 'foo';
+      mimicUserInput(lionField, 'foo');
       expect(formatterSpy.callCount).to.equal(1);
-      expect(lionField.formattedValue).to.equal('foo: bar');
+      expect(lionField.formattedValue).to.equal('foo');
     });
   });
 


### PR DESCRIPTION
fixes https://github.com/ing-bank/lion/issues/94

- See for explanation: https://github.com/ing-bank/lion/pull/132/files#diff-8a0f76e26a132ed6bb832fc7ff0518c8R202

- Note that we discriminate two flows: https://github.com/ing-bank/lion/pull/132/files#diff-8a0f76e26a132ed6bb832fc7ff0518c8R11

- `__preventDownwardsSync ` has been renamed to `__isHandlingUserInput `

- other doc changes are cosmetic (indenting)