### PR TITLE
Prevent users from committing lockfiles with invalid resolved source

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
       "eslint --fix",
       "prettier --write",
       "git add"
+    ],
+    "yarn.lock": [
+      "node ./scripts/yarn-lock-scan.js"
     ]
   }
 }

--- a/scripts/yarn-lock-scan.js
+++ b/scripts/yarn-lock-scan.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+const yarnLockPath = './yarn.lock';
+const data = fs.readFileSync(path.resolve(yarnLockPath), 'utf8');
+if (data.match(/artifactory/g)) {
+  throw new Error(
+    'Artifactory references in your yarn.lock! Please make sure you are using the official yarn or npm registry when downloading your dependencies!',
+  );
+}


### PR DESCRIPTION
This checks for lockfiles generated using a commonly used product in companies that do dependency resolution through a proxy rather than directly from yarn or npm official registry. Such a lockfile would be unusable for users without access to this domain.