### PR TITLE
chore(icon): remove misleading story

### DIFF
--- a/packages/icon/stories/index.stories.js
+++ b/packages/icon/stories/index.stories.js
@@ -1,5 +1,4 @@
 import { storiesOf, html } from '@open-wc/demoing-storybook';
-import { until } from '@lion/core';
 
 import '../lion-icon.js';
 
@@ -141,22 +140,6 @@ storiesOf('Icon System|Icon', module)
         class="icon"
         .svg=${import('./icons/bugs/bug05.svg.js')}
         aria-label="Skinny dung beatle"
-      ></lion-icon>
-    `,
-  )
-  .add(
-    'dynamic icons using until',
-    () => html`
-      <style>
-        .icon {
-          width: 32px;
-          height: 32px;
-        }
-      </style>
-      <lion-icon
-        class="icon"
-        .svg=${until(import('./icons/bugs/bug12.svg.js').then(e => e.default), 'Loading...')}
-        aria-label="Striped beatle"
       ></lion-icon>
     `,
   );


### PR DESCRIPTION
My expectation would be:

```html
// mind the loaderSvg
<lion-icon
  class="icon"
  .svg=${until(import('./icons/bugs/bug12.svg.js').then(e => e.default), loaderSvg)}
  aria-label="Striped beatle"
></lion-icon>
```

But we have smth that does not make much sense - renreding string instead if SVG within an icon:

```html
// mind the string 'Loading...'
<lion-icon
  class="icon"
  .svg=${until(import('./icons/bugs/bug12.svg.js').then(e => e.default), 'Loading...')}
  aria-label="Striped beatle"
></lion-icon>
```

Also this story is currently broken due to recent changes in the icon.

I think this is better to remove the story for now from our storybook and contribute a proper and working one later.

PS: if you need a string "Loading..." during loading, the `until` should wrap the entire `lion-icon` element, but that's just a lit-html feature in the end and there is not much reason to have a story with that exmple