### PR TITLE
fix(field): make sure RegistrationSystem works well with ShadyDom

### DIFF
--- a/packages/field/index.js
+++ b/packages/field/index.js
@@ -4,3 +4,5 @@ export { FormatMixin } from './src/FormatMixin.js';
 export { FormControlMixin } from './src/FormControlMixin.js';
 export { InteractionStateMixin } from './src/InteractionStateMixin.js'; // applies FocusMixin
 export { LionField } from './src/LionField.js';
+export { FormRegisteringMixin } from './src/FormRegisteringMixin.js';
+export { FormRegistrarMixin } from './src/FormRegistrarMixin.js';

--- a/packages/field/src/FormControlMixin.js
+++ b/packages/field/src/FormControlMixin.js
@@ -1,5 +1,6 @@
 import { html, css, nothing, dedupeMixin, SlotMixin } from '@lion/core';
 import { ObserverMixin } from '@lion/core/src/ObserverMixin.js';
+import { FormRegisteringMixin } from './FormRegisteringMixin.js';
 
 /**
  * #FormControlMixin :
@@ -14,7 +15,7 @@ import { ObserverMixin } from '@lion/core/src/ObserverMixin.js';
 export const FormControlMixin = dedupeMixin(
   superclass =>
     // eslint-disable-next-line no-shadow, no-unused-vars
-    class FormControlMixin extends ObserverMixin(SlotMixin(superclass)) {
+    class FormControlMixin extends FormRegisteringMixin(ObserverMixin(SlotMixin(superclass))) {
       static get properties() {
         return {
           ...super.properties,
@@ -105,8 +106,6 @@ export const FormControlMixin = dedupeMixin(
         super.connectedCallback();
         this._enhanceLightDomClasses();
         this._enhanceLightDomA11y();
-        this._registerFormElement();
-        this._requestParentFormGroupUpdateOfResetModelValue();
       }
 
       /**
@@ -148,42 +147,6 @@ export const FormControlMixin = dedupeMixin(
           }
         }
         this._enhanceLightDomA11yForAdditionalSlots();
-      }
-
-      /**
-       * Fires a registration event in the next frame.
-       *
-       * Why next frame?
-       * if ShadyDOM is used and you add a listener and fire the event in the same frame
-       * it will not bubble and there can not be cought by a parent element
-       * for more details see: https://github.com/Polymer/lit-element/issues/658
-       * will requires a `await nextFrame()` in tests
-       */
-      _registerFormElement() {
-        this.updateComplete.then(() => {
-          this.dispatchEvent(
-            new CustomEvent('form-element-register', {
-              detail: { element: this },
-              bubbles: true,
-            }),
-          );
-        });
-      }
-
-      /**
-       * Makes sure our parentFormGroup has the most up to date resetModelValue
-       * FormGroups will call the same on their parentFormGroup so the full tree gets the correct
-       * values.
-       *
-       * Why next frame?
-       * @see {@link this._registerFormElement}
-       */
-      _requestParentFormGroupUpdateOfResetModelValue() {
-        this.updateComplete.then(() => {
-          if (this.__parentFormGroup) {
-            this.__parentFormGroup._updateResetModelValue();
-          }
-        });
       }
 
       /**

--- a/packages/field/src/FormRegisteringMixin.js
+++ b/packages/field/src/FormRegisteringMixin.js
@@ -1,0 +1,71 @@
+import { dedupeMixin } from '@lion/core';
+import { formRegistrarManager } from './formRegistrarManager.js';
+
+/**
+ * #FormRegisteringMixin:
+ *
+ * This Mixin registers a form element to a Registrar
+ *
+ * @polymerMixin
+ * @mixinFunction
+ */
+export const FormRegisteringMixin = dedupeMixin(
+  superclass =>
+    // eslint-disable-next-line no-shadow, no-unused-vars
+    class FormRegisteringMixin extends superclass {
+      connectedCallback() {
+        if (super.connectedCallback) {
+          super.connectedCallback();
+        }
+        this.__setupRegistrationHook();
+      }
+
+      disconnectedCallback() {
+        if (super.disconnectedCallback) {
+          super.disconnectedCallback();
+        }
+        this._unregisterFormElement();
+      }
+
+      __setupRegistrationHook() {
+        if (formRegistrarManager.ready) {
+          this._registerFormElement();
+        } else {
+          formRegistrarManager.addEventListener('all-forms-open-for-registration', () => {
+            this._registerFormElement();
+          });
+        }
+      }
+
+      _registerFormElement() {
+        this._dispatchRegistration();
+        this._requestParentFormGroupUpdateOfResetModelValue();
+      }
+
+      _dispatchRegistration() {
+        this.dispatchEvent(
+          new CustomEvent('form-element-register', {
+            detail: { element: this },
+            bubbles: true,
+          }),
+        );
+      }
+
+      _unregisterFormElement() {
+        if (this.__parentFormGroup) {
+          this.__parentFormGroup.removeFormElement(this);
+        }
+      }
+
+      /**
+       * Makes sure our parentFormGroup has the most up to date resetModelValue
+       * FormGroups will call the same on their parentFormGroup so the full tree gets the correct
+       * values.
+       */
+      _requestParentFormGroupUpdateOfResetModelValue() {
+        if (this.__parentFormGroup && this.__parentFormGroup._updateResetModelValue) {
+          this.__parentFormGroup._updateResetModelValue();
+        }
+      }
+    },
+);

--- a/packages/field/src/FormRegistrarMixin.js
+++ b/packages/field/src/FormRegistrarMixin.js
@@ -1,0 +1,92 @@
+import { dedupeMixin } from '@lion/core';
+import { formRegistrarManager } from './formRegistrarManager.js';
+import { FormRegisteringMixin } from './FormRegisteringMixin.js';
+
+/**
+ * This allows an element to become the manager of a register
+ */
+export const FormRegistrarMixin = dedupeMixin(
+  superclass =>
+    // eslint-disable-next-line no-shadow, no-unused-vars
+    class FormRegistrarMixin extends FormRegisteringMixin(superclass) {
+      get formElements() {
+        return this.__formElements;
+      }
+
+      set formElements(value) {
+        this.__formElements = value;
+      }
+
+      get formElementsArray() {
+        return this.__formElements;
+      }
+
+      constructor() {
+        super();
+        this.formElements = [];
+        this.__readyForRegistration = false;
+        this.registrationReady = new Promise(resolve => {
+          this.__resolveRegistrationReady = resolve;
+        });
+        formRegistrarManager.add(this);
+
+        this._onRequestToAddFormElement = this._onRequestToAddFormElement.bind(this);
+        this.addEventListener('form-element-register', this._onRequestToAddFormElement);
+      }
+
+      isRegisteredFormElement(el) {
+        return this.formElementsArray.some(exitingEl => exitingEl === el);
+      }
+
+      firstUpdated(changedProperties) {
+        super.firstUpdated(changedProperties);
+        this.__resolveRegistrationReady();
+        this.__readyForRegistration = true;
+        formRegistrarManager.becomesReady(this);
+      }
+
+      addFormElement(child) {
+        // This is a way to let the child element (a lion-fieldset or lion-field) know, about its parent
+        // eslint-disable-next-line no-param-reassign
+        child.__parentFormGroup = this;
+
+        this.formElements.push(child);
+      }
+
+      removeFormElement(child) {
+        const index = this.formElements.indexOf(child);
+        if (index > -1) {
+          this.formElements.splice(index, 1);
+        }
+      }
+
+      _onRequestToAddFormElement(ev) {
+        const child = ev.detail.element;
+        if (child === this) {
+          // as we fire and listen - don't add ourselves
+          return;
+        }
+        if (this.isRegisteredFormElement(child)) {
+          // do not readd already existing elements
+          return;
+        }
+        ev.stopPropagation();
+        this.addFormElement(child);
+      }
+
+      _onRequestToRemoveFormElement(ev) {
+        const child = ev.detail.element;
+        if (child === this) {
+          // as we fire and listen - don't add ourselves
+          return;
+        }
+        if (!this.isRegisteredFormElement(child)) {
+          // do not readd already existing elements
+          return;
+        }
+        ev.stopPropagation();
+
+        this.removeFormElement(child);
+      }
+    },
+);

--- a/packages/field/src/formRegistrarManager.js
+++ b/packages/field/src/formRegistrarManager.js
@@ -1,0 +1,36 @@
+/**
+ * Allows to align the timing for all Registrars (like form, fieldset).
+ * e.g. it will only be ready once all Registrars have been fully rendered
+ *
+ * This is a requirement for ShadyDOM as otherwise forms can not catch registration events
+ */
+class FormRegistrarManager {
+  constructor() {
+    this.__elements = [];
+    this._fakeExtendsEventTarget();
+    this.ready = false;
+  }
+
+  add(registrar) {
+    this.__elements.push(registrar);
+    this.ready = false;
+  }
+
+  becomesReady() {
+    if (this.__elements.every(el => el.__readyForRegistration === true)) {
+      this.dispatchEvent(new Event('all-forms-open-for-registration'));
+      this.ready = true;
+    }
+  }
+
+  // TODO: this method has to be removed when EventTarget polyfill is available on IE11
+  // issue: https://gitlab.ing.net/TheGuideComponents/lion-element/issues/12
+  _fakeExtendsEventTarget() {
+    const delegate = document.createDocumentFragment();
+    ['addEventListener', 'dispatchEvent', 'removeEventListener'].forEach(funcName => {
+      this[funcName] = (...args) => delegate[funcName](...args);
+    });
+  }
+}
+
+export const formRegistrarManager = new FormRegistrarManager();

--- a/packages/field/test/FormControlMixin.test.js
+++ b/packages/field/test/FormControlMixin.test.js
@@ -1,5 +1,4 @@
-import { expect, fixture, html, defineCE, unsafeStatic, nextFrame } from '@open-wc/testing';
-import sinon from 'sinon';
+import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
 import { SlotMixin } from '@lion/core';
 import { LionLitElement } from '@lion/core/src/LionLitElement.js';
 
@@ -24,42 +23,6 @@ describe('FormControlMixin', () => {
 
     elem = defineCE(FormControlMixinClass);
     tag = unsafeStatic(elem);
-  });
-
-  it('dispatches event to register in Light DOM', async () => {
-    const registerSpy = sinon.spy();
-    await fixture(html`
-      <div @form-element-register=${registerSpy}>
-        <${tag}></${tag}>
-      </div>
-    `);
-    await nextFrame();
-    expect(registerSpy.callCount).to.equal(1);
-  });
-
-  it('can by caught by listening in the appropriate dom', async () => {
-    const registerSpy = sinon.spy();
-    const testTag = unsafeStatic(
-      defineCE(
-        class extends LionLitElement {
-          connectedCallback() {
-            super.connectedCallback();
-            this.shadowRoot.addEventListener('form-element-register', registerSpy);
-          }
-
-          render() {
-            return html`
-              <${tag}></${tag}>
-            `;
-          }
-        },
-      ),
-    );
-    await fixture(html`
-      <${testTag}></${testTag}>
-    `);
-    await nextFrame();
-    expect(registerSpy.callCount).to.equal(1);
   });
 
   it('has the capability to override the help text', async () => {

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -1,0 +1,106 @@
+import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
+import sinon from 'sinon';
+import { LitElement, UpdatingElement } from '@lion/core';
+
+import { FormRegisteringMixin } from '../src/FormRegisteringMixin.js';
+import { FormRegistrarMixin } from '../src/FormRegistrarMixin.js';
+
+describe('FormRegistrationMixins', () => {
+  before(async () => {
+    const FormRegistrarEl = class extends FormRegistrarMixin(UpdatingElement) {};
+    customElements.define('form-registrar', FormRegistrarEl);
+    const FormRegisteringEl = class extends FormRegisteringMixin(UpdatingElement) {};
+    customElements.define('form-registering', FormRegisteringEl);
+  });
+
+  it('can register a formElement', async () => {
+    const el = await fixture(html`
+      <form-registrar>
+        <form-registering></form-registering>
+      </form-registrar>
+    `);
+    await el.registrationReady;
+    expect(el.formElements.length).to.equal(1);
+  });
+
+  it('supports nested registrar', async () => {
+    const el = await fixture(html`
+      <form-registrar>
+        <form-registrar>
+          <form-registering></form-registering>
+        </form-registrar>
+      </form-registrar>
+    `);
+    await el.registrationReady;
+    expect(el.formElements.length).to.equal(1);
+    expect(el.querySelector('form-registrar').formElements.length).to.equal(1);
+  });
+
+  it('works for component that have a delayed render', async () => {
+    const tagWrapperString = defineCE(
+      class extends FormRegistrarMixin(LitElement) {
+        async performUpdate() {
+          await new Promise(resolve => setTimeout(() => resolve(), 10));
+          await super.performUpdate();
+        }
+
+        render() {
+          return html`
+            <slot></slot>
+          `;
+        }
+      },
+    );
+    const tagWrapper = unsafeStatic(tagWrapperString);
+    const registerSpy = sinon.spy();
+    const el = await fixture(html`
+      <${tagWrapper} @form-element-register=${registerSpy}>
+        <form-registering></form-registering>
+      </${tagWrapper}>
+    `);
+    await el.registrationReady;
+    expect(el.formElements.length).to.equal(1);
+  });
+
+  it('requests update of the resetModelValue function of its parent formGroup', async () => {
+    const ParentFormGroupClass = class extends FormRegistrarMixin(LitElement) {
+      _updateResetModelValue() {
+        this.resetModelValue = 'foo';
+      }
+    };
+    const ChildFormGroupClass = class extends FormRegisteringMixin(LitElement) {
+      constructor() {
+        super();
+        this.__parentFormGroup = this.parentNode;
+      }
+    };
+
+    const parentClass = defineCE(ParentFormGroupClass);
+    const formGroup = unsafeStatic(parentClass);
+    const childClass = defineCE(ChildFormGroupClass);
+    const childFormGroup = unsafeStatic(childClass);
+    const parentFormEl = await fixture(html`
+      <${formGroup}><${childFormGroup} id="child" name="child[]"></${childFormGroup}></${formGroup}>
+    `);
+    expect(parentFormEl.resetModelValue).to.equal('foo');
+  });
+
+  it('can dynamically add/remove elements', async () => {
+    const el = await fixture(html`
+      <form-registrar>
+        <form-registering></form-registering>
+      </form-registrar>
+    `);
+    const newField = await fixture(html`
+      <form-registering></form-registering>
+    `);
+
+    expect(el.formElements.length).to.equal(1);
+
+    el.appendChild(newField);
+    expect(el.formElements.length).to.equal(2);
+
+    el.removeChild(newField);
+    expect(el.formElements.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
This introduces an "update" to the registration system
It is now 2 way... 
1. the form (Registrar) Element which fires an even on the body when it is ready to accepts registrations
2. the field (Registering) Element which waits for the body event and then fires it's registration

The change is needed as ShadyDom can only catch events once fully rendered... e.g. the child needs to wait until it's parent is ready... 

it is implemented via 2 mixins
1. FormRegistrarMixin
2. FormRegisteringMixin