### PR TITLE
Observe <html lang> attribute

### DIFF
--- a/packages/localize/src/LocalizeManager.js
+++ b/packages/localize/src/LocalizeManager.js
@@ -181,6 +181,9 @@ export class LocalizeManager extends LionSingleton {
   }
 
   _onLocaleChanged(newLocale, oldLocale) {
+    if (newLocale === oldLocale) {
+      return;
+    }
     this.dispatchEvent(new CustomEvent('localeChanged', { detail: { newLocale, oldLocale } }));
     if (this._autoLoadOnLocaleChange) {
       this._loadAllMissing(newLocale, oldLocale);

--- a/packages/localize/src/localize.js
+++ b/packages/localize/src/localize.js
@@ -6,5 +6,6 @@ export let localize = LocalizeManager.getInstance({
 });
 
 export function setLocalize(newLocalize) {
+  localize.teardown();
   localize = newLocalize;
 }

--- a/packages/localize/test/LocalizeManager.test.js
+++ b/packages/localize/test/LocalizeManager.test.js
@@ -1,4 +1,5 @@
 import { expect, oneEvent } from '@open-wc/testing';
+import sinon from 'sinon';
 import { fetchMock } from '@bundled-es-modules/fetch-mock';
 import { setupFakeImport, resetFakeImport, fakeImport } from './test-utils.js';
 
@@ -46,6 +47,15 @@ describe('LocalizeManager', () => {
     const event = await oneEvent(manager, 'localeChanged');
     expect(event.detail.newLocale).to.equal('en-US');
     expect(event.detail.oldLocale).to.equal('en-GB');
+  });
+
+  it('does not fire "localeChanged" event if it was set to the same locale', () => {
+    const manager = new LocalizeManager();
+    const eventSpy = sinon.spy();
+    manager.addEventListener('localeChanged', eventSpy);
+    manager.locale = 'en-US';
+    manager.locale = 'en-US';
+    expect(eventSpy.callCount).to.equal(1);
   });
 
   describe('addData()', () => {

--- a/packages/localize/test/localize.test.js
+++ b/packages/localize/test/localize.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
 
 import { LionSingleton } from '@lion/core';
 import { LocalizeManager } from '../src/LocalizeManager.js';
@@ -22,10 +23,16 @@ describe('localize', () => {
 
   it('is overridable globally', () => {
     const oldLocalize = localize;
-    const newLocalize = {};
+    const oldLocalizeTeardown = localize.teardown;
+    localize.teardown = sinon.spy();
+
+    const newLocalize = { teardown: () => {} };
     setLocalize(newLocalize);
     expect(localize).to.equal(newLocalize);
+    expect(oldLocalize.teardown.callCount).to.equal(1);
+
     setLocalize(oldLocalize);
+    localize.teardown = oldLocalizeTeardown;
   });
 
   it('is configured to automatically load namespaces if locale is changed', () => {


### PR DESCRIPTION
I had to also fix another not related bug when `localeChanged` event fires multiple times with no real changes. That was necessary because the mutation observer is called multiple times for the same attribute change for some reason, like if you change the attribute it is called 5 times for it 🤷‍♂ 