### PR TITLE
[button] Fix redispatching of click event

### DIFF
--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -140,7 +140,6 @@ export class LionButton extends DelegateMixin(SlotMixin(LionLitElement)) {
     this.disabled = false;
     this.role = 'button';
     this.tabindex = 0;
-    this.__keydownDelegationHandler = this.__keydownDelegationHandler.bind(this);
   }
 
   connectedCallback() {

--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -159,7 +159,18 @@ export class LionButton extends DelegateMixin(SlotMixin(LionLitElement)) {
     oldEvent.stopPropagation();
     // replacing `MouseEvent` with `oldEvent.constructor` breaks IE
     const newEvent = new MouseEvent(oldEvent.type, oldEvent);
+    this.__enforceHostEventTarget(newEvent);
     this.$$slot('_button').dispatchEvent(newEvent);
+  }
+
+  __enforceHostEventTarget(event) {
+    try {
+      // this is for IE11 (and works in others), because `Object.defineProperty` does not give any effect there
+      event.__defineGetter__('target', () => this); // eslint-disable-line no-restricted-properties
+    } catch (error) {
+      // in case `__defineGetter__` is removed from the platform
+      Object.defineProperty(event, 'target', { writable: false, value: this });
+    }
   }
 
   __setupDelegation() {

--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -152,9 +152,14 @@ export class LionButton extends DelegateMixin(SlotMixin(LionLitElement)) {
     this.__teardownDelegation();
   }
 
-  __clickDelegationHandler(e) {
-    e.stopPropagation(); // prevent click on the fake element and cause click on the native button
-    this.$$slot('_button').click();
+  /**
+   * Prevent click on the fake element and cause click on the native button.
+   */
+  __clickDelegationHandler(oldEvent) {
+    oldEvent.stopPropagation();
+    // replacing `MouseEvent` with `oldEvent.constructor` breaks IE
+    const newEvent = new MouseEvent(oldEvent.type, oldEvent);
+    this.$$slot('_button').dispatchEvent(newEvent);
   }
 
   __setupDelegation() {
@@ -180,7 +185,7 @@ export class LionButton extends DelegateMixin(SlotMixin(LionLitElement)) {
     if (e.keyCode === 32 /* space */ || e.keyCode === 13 /* enter */) {
       e.preventDefault();
       this.shadowRoot.querySelector('.btn').removeAttribute('active');
-      this.$$slot('_button').click();
+      this.shadowRoot.querySelector('.click-area').click();
     }
   }
 

--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -152,15 +152,19 @@ export class LionButton extends DelegateMixin(SlotMixin(LionLitElement)) {
     this.__teardownDelegation();
   }
 
-  /**
-   * Prevent click on the fake element and cause click on the native button.
-   */
-  __clickDelegationHandler(oldEvent) {
-    oldEvent.stopPropagation();
+  _redispatchClickEvent(oldEvent) {
     // replacing `MouseEvent` with `oldEvent.constructor` breaks IE
     const newEvent = new MouseEvent(oldEvent.type, oldEvent);
     this.__enforceHostEventTarget(newEvent);
     this.$$slot('_button').dispatchEvent(newEvent);
+  }
+
+  /**
+   * Prevent click on the fake element and cause click on the native button.
+   */
+  __clickDelegationHandler(e) {
+    e.stopPropagation();
+    this._redispatchClickEvent(e);
   }
 
   __enforceHostEventTarget(event) {

--- a/packages/button/test/lion-button.test.js
+++ b/packages/button/test/lion-button.test.js
@@ -1,8 +1,19 @@
-import { expect, fixture, html, aTimeout } from '@open-wc/testing';
+import { expect, fixture, html, aTimeout, oneEvent } from '@open-wc/testing';
 import sinon from 'sinon';
-import { pressEnter, pressSpace } from '@polymer/iron-test-helpers/mock-interactions.js';
+import {
+  makeMouseEvent,
+  pressEnter,
+  pressSpace,
+} from '@polymer/iron-test-helpers/mock-interactions.js';
 
 import '../lion-button.js';
+
+function getTopElement(el) {
+  const { left, top } = el.getBoundingClientRect();
+  // to support elementFromPoint() in polyfilled browsers we have to use document
+  const crossBrowserRoot = el.shadowRoot.elementFromPoint ? el.shadowRoot : document;
+  return crossBrowserRoot.elementFromPoint(left, top);
+}
 
 describe('lion-button', () => {
   it('behaves like native `button` in terms of a11y', async () => {
@@ -99,11 +110,7 @@ describe('lion-button', () => {
       `);
 
       const button = form.querySelector('lion-button');
-      const { left, top } = button.getBoundingClientRect();
-      // to support elementFromPoint() in polyfilled browsers we have to use document
-      const crossBrowserRoot = button.shadowRoot.elementFromPoint ? button.shadowRoot : document;
-      const shadowClickAreaElement = crossBrowserRoot.elementFromPoint(left, top);
-      shadowClickAreaElement.click();
+      getTopElement(button).click();
 
       expect(formSubmitSpy.called).to.be.true;
     });
@@ -136,6 +143,64 @@ describe('lion-button', () => {
       await aTimeout();
 
       expect(formSubmitSpy.called).to.be.true;
+    });
+  });
+
+  describe('click event', () => {
+    it('is fired once', async () => {
+      const clickSpy = sinon.spy();
+      const el = await fixture(
+        html`
+          <lion-button @click="${clickSpy}"></lion-button>
+        `,
+      );
+
+      getTopElement(el).click();
+
+      // trying to wait for other possible redispatched events
+      await aTimeout();
+      await aTimeout();
+
+      expect(clickSpy.callCount).to.equal(1);
+    });
+
+    describe('event after redispatching', async () => {
+      async function prepareClickEvent(el, host) {
+        setTimeout(() => {
+          if (host) {
+            // click on host like in native button
+            makeMouseEvent('click', { x: 11, y: 11 }, el);
+          } else {
+            // click on click-area which is then redispatched
+            makeMouseEvent('click', { x: 11, y: 11 }, getTopElement(el));
+          }
+        });
+        return oneEvent(el, 'click');
+      }
+
+      let hostEvent;
+      let redispatchedEvent;
+
+      before(async () => {
+        const el = await fixture('<lion-button></lion-button>');
+        hostEvent = await prepareClickEvent(el, true);
+        redispatchedEvent = await prepareClickEvent(el, false);
+      });
+
+      const sameProperties = [
+        'constructor',
+        'composed',
+        'bubbles',
+        'cancelable',
+        'clientX',
+        'clientY',
+      ];
+
+      sameProperties.forEach(property => {
+        it(`has same value of the property "${property}"`, async () => {
+          expect(redispatchedEvent[property]).to.equal(hostEvent[property]);
+        });
+      });
     });
   });
 });

--- a/packages/button/test/lion-button.test.js
+++ b/packages/button/test/lion-button.test.js
@@ -194,6 +194,7 @@ describe('lion-button', () => {
         'cancelable',
         'clientX',
         'clientY',
+        'target',
       ];
 
       sameProperties.forEach(property => {


### PR DESCRIPTION
Quite some fixes for the mechanism of redispatching the click event of the button.

Most important fixes are related to the creation of the new click event:
1. It is created with properties from the original event.
2. We patch the `.target` property of it to fix #89 (and it suddenly does not break integration with forms).