### PR TITLE
fix(field): remove CssClassMixin from InteractionStateMixin

### DIFF
--- a/packages/field/src/InteractionStateMixin.js
+++ b/packages/field/src/InteractionStateMixin.js
@@ -73,7 +73,7 @@ export const InteractionStateMixin = dedupeMixin(
         this.touched = false;
         this.dirty = false;
         this.prefilled = false;
-        this.leaveEvent = 'blur';
+        this._leaveEvent = 'blur';
         this._valueChangedEvent = 'model-value-changed';
 
         this._iStateOnLeave = this._iStateOnLeave.bind(this);
@@ -87,7 +87,7 @@ export const InteractionStateMixin = dedupeMixin(
         if (super.connectedCallback) {
           super.connectedCallback();
         }
-        this.addEventListener(this.leaveEvent, this._iStateOnLeave);
+        this.addEventListener(this._leaveEvent, this._iStateOnLeave);
         this.addEventListener(this._valueChangedEvent, this._iStateOnValueChange);
         this.initInteractionState();
       }
@@ -96,7 +96,7 @@ export const InteractionStateMixin = dedupeMixin(
         if (super.disconnectedCallback) {
           super.disconnectedCallback();
         }
-        this.removeEventListener(this.leaveEvent, this._iStateOnLeave);
+        this.removeEventListener(this._leaveEvent, this._iStateOnLeave);
         this.removeEventListener(this._valueChangedEvent, this._iStateOnValueChange);
       }
 
@@ -158,6 +158,20 @@ export const InteractionStateMixin = dedupeMixin(
 
       _onDirtyChanged() {
         this.dispatchEvent(new CustomEvent('dirty-changed', { bubbles: true, composed: true }));
+      }
+
+      /**
+       * @deprecated
+       */
+      get leaveEvent() {
+        return this._leaveEvent;
+      }
+
+      /**
+       * @deprecated
+       */
+      set leaveEvent(eventName) {
+        this._leaveEvent = eventName;
       }
     },
 );

--- a/packages/field/src/InteractionStateMixin.js
+++ b/packages/field/src/InteractionStateMixin.js
@@ -2,7 +2,6 @@ import { dedupeMixin } from '@lion/core';
 import { CssClassMixin } from '@lion/core/src/CssClassMixin.js';
 import { ObserverMixin } from '@lion/core/src/ObserverMixin.js';
 import { Unparseable } from '@lion/validate';
-import { FocusMixin } from './FocusMixin.js';
 
 /**
  * `InteractionStateMixin` adds meta information about touched and dirty states, that can
@@ -16,7 +15,7 @@ import { FocusMixin } from './FocusMixin.js';
 export const InteractionStateMixin = dedupeMixin(
   superclass =>
     // eslint-disable-next-line no-unused-vars, no-shadow
-    class InteractionStateMixin extends CssClassMixin(FocusMixin(ObserverMixin(superclass))) {
+    class InteractionStateMixin extends CssClassMixin(ObserverMixin(superclass)) {
       static get properties() {
         return {
           ...super.properties,

--- a/packages/field/src/InteractionStateMixin.js
+++ b/packages/field/src/InteractionStateMixin.js
@@ -1,5 +1,4 @@
 import { dedupeMixin } from '@lion/core';
-import { CssClassMixin } from '@lion/core/src/CssClassMixin.js';
 import { ObserverMixin } from '@lion/core/src/ObserverMixin.js';
 import { Unparseable } from '@lion/validate';
 
@@ -15,7 +14,7 @@ import { Unparseable } from '@lion/validate';
 export const InteractionStateMixin = dedupeMixin(
   superclass =>
     // eslint-disable-next-line no-unused-vars, no-shadow
-    class InteractionStateMixin extends CssClassMixin(ObserverMixin(superclass)) {
+    class InteractionStateMixin extends ObserverMixin(superclass) {
       static get properties() {
         return {
           ...super.properties,
@@ -24,7 +23,7 @@ export const InteractionStateMixin = dedupeMixin(
            */
           touched: {
             type: Boolean,
-            nonEmptyToClass: 'state-touched',
+            reflect: true,
           },
 
           /**
@@ -32,7 +31,7 @@ export const InteractionStateMixin = dedupeMixin(
            */
           dirty: {
             type: Boolean,
-            nonEmptyToClass: 'state-dirty',
+            reflect: true,
           },
 
           /**
@@ -99,6 +98,17 @@ export const InteractionStateMixin = dedupeMixin(
         }
         this.removeEventListener(this.leaveEvent, this._iStateOnLeave);
         this.removeEventListener(this._valueChangedEvent, this._iStateOnValueChange);
+      }
+
+      updated(changedProperties) {
+        super.updated(changedProperties);
+        // classes are added only for backward compatibility - they are deprecated
+        if (changedProperties.has('touched')) {
+          this.classList[this.touched ? 'add' : 'remove']('state-touched');
+        }
+        if (changedProperties.has('dirty')) {
+          this.classList[this.dirty ? 'add' : 'remove']('state-dirty');
+        }
       }
 
       /**

--- a/packages/field/src/LionField.js
+++ b/packages/field/src/LionField.js
@@ -8,6 +8,7 @@ import { ValidateMixin } from '@lion/validate';
 import { FormControlMixin } from './FormControlMixin.js';
 import { InteractionStateMixin } from './InteractionStateMixin.js'; // applies FocusMixin
 import { FormatMixin } from './FormatMixin.js';
+import { FocusMixin } from './FocusMixin.js';
 
 /**
  * LionField: wraps components input, textarea and select and potentially others
@@ -29,9 +30,11 @@ import { FormatMixin } from './FormatMixin.js';
 // eslint-disable-next-line max-len, no-unused-vars
 export class LionField extends FormControlMixin(
   InteractionStateMixin(
-    FormatMixin(
-      ValidateMixin(
-        CssClassMixin(ElementMixin(DelegateMixin(SlotMixin(ObserverMixin(LionLitElement))))),
+    FocusMixin(
+      FormatMixin(
+        ValidateMixin(
+          CssClassMixin(ElementMixin(DelegateMixin(SlotMixin(ObserverMixin(LionLitElement))))),
+        ),
       ),
     ),
   ),

--- a/packages/field/test/InteractionStateMixin.test.js
+++ b/packages/field/test/InteractionStateMixin.test.js
@@ -164,4 +164,26 @@ describe('InteractionStateMixin', async () => {
     expect(el.touched).to.be.false;
     expect(el.prefilled).to.be.true;
   });
+
+  describe('SubClassers', () => {
+    it('can override the `_leaveEvent`', async () => {
+      const tagLeaveString = defineCE(
+        class IState extends InteractionStateMixin(LitElement) {
+          constructor() {
+            super();
+            this._leaveEvent = 'custom-blur';
+          }
+        },
+      );
+      const tagLeave = unsafeStatic(tagLeaveString);
+      const el = await fixture(html`<${tagLeave}></${tagLeave}>`);
+      el.dispatchEvent(new Event('custom-blur'));
+      expect(el.touched).to.be.true;
+    });
+
+    it('can override the deprecated `leaveEvent`', async () => {
+      const el = await fixture(html`<${tag} .leaveEvent=${'custom-blur'}></${tag}>`);
+      expect(el._leaveEvent).to.equal('custom-blur');
+    });
+  });
 });

--- a/packages/field/test/InteractionStateMixin.test.js
+++ b/packages/field/test/InteractionStateMixin.test.js
@@ -59,6 +59,7 @@ describe('InteractionStateMixin', async () => {
     expect(el.touched).to.be.true;
   });
 
+  // classes are added only for backward compatibility - they are deprecated
   it('sets a class "state-(touched|dirty)"', async () => {
     const el = await fixture(html`<${tag}></${tag}>`);
     el.touched = true;
@@ -68,6 +69,20 @@ describe('InteractionStateMixin', async () => {
     el.dirty = true;
     await el.updateComplete;
     expect(el.classList.contains('state-dirty')).to.equal(true, 'has class "state-dirty"');
+  });
+
+  it('sets an attribute "touched', async () => {
+    const el = await fixture(html`<${tag}></${tag}>`);
+    el.touched = true;
+    await el.updateComplete;
+    expect(el.hasAttribute('touched')).to.be.true;
+  });
+
+  it('sets an attribute "dirty', async () => {
+    const el = await fixture(html`<${tag}></${tag}>`);
+    el.dirty = true;
+    await el.updateComplete;
+    expect(el.hasAttribute('dirty')).to.be.true;
   });
 
   it('fires "(touched|dirty)-state-changed" event when state changes', async () => {


### PR DESCRIPTION
- requirement 2 for Rich Select
- let's merge it all to develop and then release

=> has 4 commits
- chore(field): improve InteractionStateMixin tests
- fix(field): move FocusMixin out of InteractionStateMixin
- fix(field): remove CssClassMixin from InteractionStateMixin
- fix(field): make InteractionState leaveEvent protected

probably easier to review them individually