### PR TITLE
Support fallback locale

### DIFF
--- a/packages/localize/src/localize.js
+++ b/packages/localize/src/localize.js
@@ -3,6 +3,7 @@ import { LocalizeManager } from './LocalizeManager.js';
 // eslint-disable-next-line import/no-mutable-exports
 export let localize = LocalizeManager.getInstance({
   autoLoadOnLocaleChange: true,
+  fallbackLocale: 'en-GB',
 });
 
 export function setLocalize(newLocalize) {

--- a/packages/localize/test/localize.test.js
+++ b/packages/localize/test/localize.test.js
@@ -38,4 +38,8 @@ describe('localize', () => {
   it('is configured to automatically load namespaces if locale is changed', () => {
     expect(localize._autoLoadOnLocaleChange).to.equal(true);
   });
+
+  it('is configured to fallback to the locale "en-GB"', () => {
+    expect(localize._fallbackLocale).to.equal('en-GB');
+  });
 });


### PR DESCRIPTION
We need this to support multiple scenarios:

1. The apps where some components were translated to English, but NOT YET to other languages the app needs to support, so that the app continues to work with some parts still in English (now it throws and breaks which is not what most people would like to see)
2. Fix [this bug](https://github.com/ing-bank/lion/issues/152) which breaks Google Chrome translate

So this is both a new feature and a bug fix :P

For people who don't like such a default I implemented it as a configurable option. They will be able to opt-out from this behavior if needed, or change the default (currently 'en-GB') by changing the singleton using `setLocalize`.