### PR TITLE
[input] Delegate "step" attribute

### DIFF
--- a/packages/input/src/LionInput.js
+++ b/packages/input/src/LionInput.js
@@ -25,6 +25,14 @@ export class LionInput extends LionField {
     };
   }
 
+  get delegations() {
+    return {
+      ...super.delegations,
+      properties: [...super.delegations.properties, 'step'],
+      attributes: [...super.delegations.attributes, 'step'],
+    };
+  }
+
   get slots() {
     return {
       ...super.slots,

--- a/packages/input/test/lion-input.test.js
+++ b/packages/input/test/lion-input.test.js
@@ -14,6 +14,14 @@ describe('<lion-input>', () => {
     expect(el.inputElement.readOnly).to.equal(false);
   });
 
+  it('delegates "step" attribute and property', async () => {
+    const el = await fixture(`<lion-input step="0.01"></lion-input>`);
+    expect(el.inputElement.step).to.equal('0.01');
+    // TODO: activate when DelegateMixin is refactored
+    // const el2 = await fixture(`<lion-input .step="${'0.02'}"></lion-input>`);
+    // expect(el2.inputElement.step).to.equal('0.02');
+  });
+
   it('automatically creates an <input> element if not provided by user', async () => {
     const el = await fixture(`<lion-input></lion-input>`);
     expect(el.querySelector('input')).to.equal(el.inputElement);


### PR DESCRIPTION
Make step attribute work:

```
<ing-input
          step="0.01"
          type="number">
          <div slot="suffix">%</div>
</ing-input>
```