### PR TITLE
[textarea] Disable user resize behavior

### DIFF
--- a/packages/textarea/src/LionTextarea.js
+++ b/packages/textarea/src/LionTextarea.js
@@ -40,7 +40,16 @@ export class LionTextarea extends ObserverMixin(LionInput) {
   get slots() {
     return {
       ...super.slots,
-      input: () => document.createElement('textarea'),
+      input: () => {
+        const input = document.createElement('textarea');
+
+        // disable user resize behavior if browser supports it
+        if (input.style.resize !== undefined) {
+          input.style.resize = 'none';
+        }
+
+        return input;
+      },
     };
   }
 

--- a/packages/textarea/test/lion-textarea.test.js
+++ b/packages/textarea/test/lion-textarea.test.js
@@ -2,6 +2,11 @@ import { expect, fixture, html } from '@open-wc/testing';
 
 import '../lion-textarea.js';
 
+function hasBrowserResizeSupport() {
+  const textarea = document.createElement('textarea');
+  return textarea.style.resize !== undefined;
+}
+
 describe('<lion-textarea>', () => {
   it(`can be used with the following declaration
   ~~~
@@ -15,6 +20,16 @@ describe('<lion-textarea>', () => {
     const el = await fixture(`<lion-textarea></lion-textarea>`);
     expect(el.rows).to.equal(2);
     expect(el.maxRows).to.equal(6);
+  });
+
+  it('disables user resize behavior', async () => {
+    if (!hasBrowserResizeSupport()) {
+      return;
+    }
+
+    const el = await fixture(`<lion-textarea></lion-textarea>`);
+    const computedStyle = window.getComputedStyle(el.inputElement);
+    expect(computedStyle.resize).to.equal('none');
   });
 
   it('supports initial modelValue', async () => {


### PR DESCRIPTION
Hey guys, I'm hoping not being a bother :)
I was taking a look at #165 and I've seen that the autosize library applies a resize horizontal style inline if the textarea element doesn't disable it first:

```
const style = window.getComputedStyle(ta, null);

if (style.resize === 'vertical') {
	ta.style.resize = 'none';
} else if (style.resize === 'both') {
	ta.style.resize = 'horizontal';
}
```

I thought that applying the resize CSS property as none inline was a bad thing, so I've added it on the slotted ` .form-control` and I've needed to move the autosize call to the firstUpdate lifecycle hook to make sure the styles were applied before calling the library.
I've could have kept it on the connectedCallback and awaited the updateComplete but it looked too noisy for me.

