### PR TITLE
fix(overlays): fix popper for IE11 by using esm dist target

### DIFF
--- a/packages/overlays/src/LocalOverlayController.js
+++ b/packages/overlays/src/LocalOverlayController.js
@@ -3,7 +3,7 @@ import { containFocus } from './utils/contain-focus.js';
 import { keyCodes } from './utils/key-codes.js';
 
 async function __preloadPopper() {
-  return import('popper.js/dist/popper.min.js');
+  return import('popper.js/dist/esm/popper.min.js');
 }
 export class LocalOverlayController {
   constructor(params = {}) {

--- a/packages/overlays/test/LocalOverlayController.test.js
+++ b/packages/overlays/test/LocalOverlayController.test.js
@@ -1,6 +1,6 @@
 import { expect, fixture, html, aTimeout, defineCE, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
-import Popper from 'popper.js/dist/popper.min.js';
+import Popper from 'popper.js/dist/esm/popper.min.js';
 
 import { keyUpOn } from '@polymer/iron-test-helpers/mock-interactions.js';
 import { LionLitElement } from '@lion/core/src/LionLitElement.js';


### PR DESCRIPTION
https://github.com/FezVrasta/popper.js#dist-targets

I'm under the impression we should use ESM, when reviewing please double check my assumption ;). Works in IE11 as far as I can tell