### PR TITLE
Fix prepublish pattern format

### DIFF
--- a/packages/ajax/README.md
+++ b/packages/ajax/README.md
@@ -1,6 +1,6 @@
 # Ajax
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `ajax` is the global manager for handling all ajax requests.
 It is a promise based system for fetching data, based on [axios](https://github.com/axios/axios)

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -1,6 +1,6 @@
 # Button
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-button` provides a component that is easily stylable and is accessible in all contexts.
 

--- a/packages/calendar/README.md
+++ b/packages/calendar/README.md
@@ -1,6 +1,6 @@
 # Calendar
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-calendar` is a reusable and accessible calendar view.
 

--- a/packages/checkbox-group/README.md
+++ b/packages/checkbox-group/README.md
@@ -1,6 +1,6 @@
 # Checkbox Group
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-checkbox-group` component is webcomponent that enhances the functionality of the native `<input type="checkbox">` element. Its purpose is to provide a way for users to check **multiple** options amongst a set of choices, or to function as a single toggle.
 

--- a/packages/checkbox/README.md
+++ b/packages/checkbox/README.md
@@ -1,6 +1,6 @@
 # Checkbox
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-checkbox` component is a sub-element to be used in [lion-checkbox-group](../checkbox-group/) elements. Its purpose is to provide a way for users to check **multiple** options amongst a set of choices, or to function as a single toggle.
 

--- a/packages/choice-input/README.md
+++ b/packages/choice-input/README.md
@@ -1,5 +1,5 @@
 # Choice Input
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 We still need help writing better documentation - care to help?

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # Core
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Deprecations
 

--- a/packages/field/README.md
+++ b/packages/field/README.md
@@ -1,7 +1,7 @@
 
 # Form Fundaments
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `Form control`s are the most fundamental building block of the Forms. They are the basis of
 both `field`s and `fieldset`s, and the `form` itself.

--- a/packages/fieldset/README.md
+++ b/packages/fieldset/README.md
@@ -1,6 +1,6 @@
 # Fieldset
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-fieldset` groups multiple input fields or other fieldsets together.
 

--- a/packages/form-system/README.md
+++ b/packages/form-system/README.md
@@ -1,6 +1,6 @@
 # Form System
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 The Form System allows you to create complex forms with various validation in an easy way.
 

--- a/packages/form/README.md
+++ b/packages/form/README.md
@@ -1,6 +1,6 @@
 # Form
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-form` is a webcomponent that enhances the functionality of the native `form` component. It is designed to interact with (instances of) the [form controls](../field/docs/FormFundaments.md).
 

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -1,6 +1,6 @@
 # Icon
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 A web component for displaying icons.
 

--- a/packages/input-amount/README.md
+++ b/packages/input-amount/README.md
@@ -1,6 +1,6 @@
 # Input Amount
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-input-amount` component is based on the generic text input field. Its purpose is to provide a way for users to fill in an amount.
 

--- a/packages/input-date/README.md
+++ b/packages/input-date/README.md
@@ -1,6 +1,6 @@
 # Input Date
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-input-date` component is based on the generic text input field. Its purpose is to provide a way for users to fill in a date.
 

--- a/packages/input-email/README.md
+++ b/packages/input-email/README.md
@@ -1,6 +1,6 @@
 # Input Email
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-input-email` component is based on the generic text input field. Its purpose is to provide a way for users to fill in an email.
 

--- a/packages/input-iban/README.md
+++ b/packages/input-iban/README.md
@@ -1,6 +1,6 @@
 # Input IBAN
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-input-iban` component is based on the generic text input field. Its purpose is to provide a way for users to fill in an iban.
 

--- a/packages/input/README.md
+++ b/packages/input/README.md
@@ -1,6 +1,6 @@
 # Input
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-input` component is a webcomponent that enhances the functionality of the native `<input>` element.
 

--- a/packages/localize/README.md
+++ b/packages/localize/README.md
@@ -1,6 +1,6 @@
 # Localize
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 The localization system helps to manage localization data split into locales and automate its loading.
 The loading of data tries to be as unobtrusive as possible for a typical workflow while providing a flexible and controllable mechanism for non-trivial use cases.

--- a/packages/overlays/README.md
+++ b/packages/overlays/README.md
@@ -1,6 +1,6 @@
 # Overlays System
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 Supports different types of overlays like dialogs, toasts, tooltips, dropdown, etc...
 Manages their position on the screen relative to other elements, including other overlays.

--- a/packages/popup/README.md
+++ b/packages/popup/README.md
@@ -1,6 +1,6 @@
 # Popup
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-popup` is a component used for basic popups on click.
 Its purpose is to show content appearing when the user clicks an invoker element with the cursor or with the keyboard.

--- a/packages/radio-group/README.md
+++ b/packages/radio-group/README.md
@@ -1,6 +1,6 @@
 # Radio-group
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-radio-group` component is webcomponent that enhances the functionality of the native `<input type="radio">` element. Its purpose is to provide a way for users to check a **single** option amongst a set of choices.
 

--- a/packages/radio/README.md
+++ b/packages/radio/README.md
@@ -1,6 +1,6 @@
 # Radio
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-radio` component is a sub-element to be used in [lion-radio-group](../radio-group/) elements. Its purpose is to provide a way for users to check a **single** option amongst a set of choices.
 

--- a/packages/select/README.md
+++ b/packages/select/README.md
@@ -1,6 +1,6 @@
 # Select
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-select` component is a wrapper around the native `select`.
 

--- a/packages/steps/README.md
+++ b/packages/steps/README.md
@@ -1,6 +1,6 @@
 # Steps
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-steps` breaks a single goal down into dependable sub-tasks.
 

--- a/packages/textarea/README.md
+++ b/packages/textarea/README.md
@@ -1,6 +1,6 @@
 # Textarea
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-textarea` component is a webcomponent that enhances the functionality of the native `<input type="textarea">` element.
 Its purpose is to provide a way for users to write text that is multiple lines long.

--- a/packages/tooltip/README.md
+++ b/packages/tooltip/README.md
@@ -1,6 +1,6 @@
 # Tooltip
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 `lion-tooltip` is a component used for basic popups on hover.
 Its purpose is to show content appearing when the user hovers over an invoker element with the cursor or with the keyboard, or if th

--- a/packages/validate/README.md
+++ b/packages/validate/README.md
@@ -1,6 +1,6 @@
 # Validate
 
-[//]: # (AUTO INSERT HEADER PREPUBLISH)
+[//]: # 'AUTO INSERT HEADER PREPUBLISH'
 
 ## Features
 

--- a/scripts/insert-header.js
+++ b/scripts/insert-header.js
@@ -6,7 +6,7 @@ function escapeRegExp(text) {
 }
 
 const filePath = `${process.cwd()}/README.md`;
-const findPattern = escapeRegExp('[//]: # (AUTO INSERT HEADER PREPUBLISH)');
+const findPattern = escapeRegExp("[//]: # 'AUTO INSERT HEADER PREPUBLISH'");
 const text = `
 > ## 🛠 Status: Pilot Phase
 > Lion Web Components are still in an early alpha stage; they should not be considered production ready yet.


### PR DESCRIPTION
Every time you work on a Markdown file, prettier changes this

```
- [//]: # (AUTO INSERT HEADER PREPUBLISH)
+ [//]: # 'AUTO INSERT HEADER PREPUBLISH'
```

One day someone will accidentally commit this and our `scripts/insert-header.js` will stop working for it. I decided to fix it everywhere to prevent potential issues and confusing side effects of prettier formatting.