### PR TITLE
[textarea] Wait for textarea slot before init autoresize

### DIFF
--- a/packages/textarea/src/LionTextarea.js
+++ b/packages/textarea/src/LionTextarea.js
@@ -62,8 +62,7 @@ export class LionTextarea extends ObserverMixin(LionInput) {
   connectedCallback() {
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
-    this.setTextareaMaxHeight();
-    autosize(this.inputElement);
+    this.__initializeAutoresize();
   }
 
   disconnectedCallback() {
@@ -101,7 +100,39 @@ export class LionTextarea extends ObserverMixin(LionInput) {
     ];
   }
 
+  get updateComplete() {
+    if (this.__textareaUpdateComplete) {
+      return Promise.all([this.__textareaUpdateComplete, super.updateComplete]);
+    }
+    return super.updateComplete;
+  }
+
   resizeTextarea() {
     autosize.update(this.inputElement);
+  }
+
+  __initializeAutoresize() {
+    if (this.__shady_native_contains) {
+      this.__textareaUpdateComplete = this.__waitForTextareaRenderedInRealDOM().then(() => {
+        this.__startAutoresize();
+        this.__textareaUpdateComplete = null;
+      });
+    } else {
+      this.__startAutoresize();
+    }
+  }
+
+  async __waitForTextareaRenderedInRealDOM() {
+    let count = 3; // max tasks to wait for
+    while (count !== 0 && !this.__shady_native_contains(this.inputElement)) {
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise(resolve => setTimeout(resolve));
+      count -= 1;
+    }
+  }
+
+  __startAutoresize() {
+    autosize(this.inputElement);
+    this.setTextareaMaxHeight();
   }
 }


### PR DESCRIPTION
Fixes #203 

I've seen this behavior before, unfortunately, I've misled myself to the thought that it was working.

On Edge, on the `connnectedCalback`, when the lion-textarea tries to apply the `autosize` and `setTextareaMaxHeight`, the `inputElement` isn't rendered yet, and it creates this bug since both functions need the properties related to the rendered state of the element.
I've tried to wait for the `slotchange` event on the `firstUpdated` but the element is only going to be rendered on the next update so it needs to await the `updateComplete` before calling those functions.

Right now It's working and passing the tests on all the browsers that I've tested (Chrome, Opera, Firefox, Edge, and IE), but I've marked it as `WIP` so I can take a look if there is a less "cumbersome" way to accomplish it.