### PR TITLE
fix(calendar): disabled dates don't trigger @user-selected-date-changed

### DIFF
--- a/packages/calendar/src/LionCalendar.js
+++ b/packages/calendar/src/LionCalendar.js
@@ -454,11 +454,10 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
   }
 
   __addEventDelegationForClickDate() {
-    const isDayCellOrButton = el =>
-      el.classList.contains('calendar__day-cell') || el.classList.contains('calendar__day-button');
+    const isDayButton = el => el.classList.contains('calendar__day-button');
     this.__clickDateDelegation = this.__contentWrapperElement.addEventListener('click', ev => {
-      const el = ev.composedPath()[0];
-      if (isDayCellOrButton(el)) {
+      const el = ev.target;
+      if (isDayButton(el)) {
         this.__dateSelectedByUser(el.date);
       }
     });

--- a/packages/calendar/test/lion-calendar.test.js
+++ b/packages/calendar/test/lion-calendar.test.js
@@ -204,6 +204,22 @@ describe('<lion-calendar>', () => {
       ).to.equal(true);
     });
 
+    it('doesn\'t send event "user-selected-date-changed" when user selects a disabled date', async () => {
+      const dateChangedSpy = sinon.spy();
+      const disable15th = d => d.getDate() === 15;
+      const el = await fixture(html`
+        <lion-calendar
+          .selectedDate="${new Date('2000/12/12')}"
+          @user-selected-date-changed="${dateChangedSpy}"
+          .disableDates=${disable15th}
+        ></lion-calendar>
+      `);
+      const elObj = new CalendarObject(el);
+      elObj.getDayEl(15).click();
+      await el.updateComplete;
+      expect(dateChangedSpy.called).to.equal(false);
+    });
+
     it('exposes focusedDate getter', async () => {
       const el = await fixture(html`
         <lion-calendar .centralDate="${new Date('2019/06/01')}"></lion-calendar>


### PR DESCRIPTION
fixes https://github.com/ing-bank/lion/issues/221