### PR TITLE
fix(form): improve managing elements in Form Registrar Manager

### DIFF
--- a/packages/field/src/FormRegistrarMixin.js
+++ b/packages/field/src/FormRegistrarMixin.js
@@ -34,6 +34,13 @@ export const FormRegistrarMixin = dedupeMixin(
         this.addEventListener('form-element-register', this._onRequestToAddFormElement);
       }
 
+      disconnectedCallback() {
+        if (super.disconnectedCallback) {
+          super.disconnectedCallback();
+        }
+        formRegistrarManager.remove(this);
+      }
+
       isRegisteredFormElement(el) {
         return this.formElementsArray.some(exitingEl => exitingEl === el);
       }

--- a/packages/field/src/FormRegistrarMixin.js
+++ b/packages/field/src/FormRegistrarMixin.js
@@ -28,10 +28,16 @@ export const FormRegistrarMixin = dedupeMixin(
         this.registrationReady = new Promise(resolve => {
           this.__resolveRegistrationReady = resolve;
         });
-        formRegistrarManager.add(this);
 
         this._onRequestToAddFormElement = this._onRequestToAddFormElement.bind(this);
         this.addEventListener('form-element-register', this._onRequestToAddFormElement);
+      }
+
+      connectedCallback() {
+        if (super.connectedCallback) {
+          super.connectedCallback();
+        }
+        formRegistrarManager.add(this);
       }
 
       disconnectedCallback() {

--- a/packages/field/src/formRegistrarManager.js
+++ b/packages/field/src/formRegistrarManager.js
@@ -16,6 +16,10 @@ class FormRegistrarManager {
     this.ready = false;
   }
 
+  remove(registrar) {
+    this.__elements.splice(this.__elements.indexOf(registrar));
+  }
+
   becomesReady() {
     if (this.__elements.every(el => el.__readyForRegistration === true)) {
       this.dispatchEvent(new Event('all-forms-open-for-registration'));

--- a/packages/field/src/formRegistrarManager.js
+++ b/packages/field/src/formRegistrarManager.js
@@ -17,7 +17,7 @@ class FormRegistrarManager {
   }
 
   remove(registrar) {
-    this.__elements.splice(this.__elements.indexOf(registrar));
+    this.__elements.splice(this.__elements.indexOf(registrar), 1);
   }
 
   becomesReady() {

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -43,15 +43,19 @@ describe('FormRegistrationMixins', () => {
         <form-registrar>
           <form-registering></form-registering>
         </form-registrar>
-        <form-registrar id="remove">
-          <form-registering></form-registering>
-        </form-registrar>
       </form-registrar>
     `);
-    await el.registrationReady;
+
+    const secondRegistrar = await fixture(html`
+      <form-registrar>
+        <form-registering></form-registering>
+      </form-registrar>
+    `);
+
+    el.appendChild(secondRegistrar);
     expect(formRegistrarManager.__elements.length).to.equal(3);
 
-    el.querySelector('#remove').remove();
+    el.removeChild(secondRegistrar);
     expect(formRegistrarManager.__elements.length).to.equal(2);
   });
 

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -2,6 +2,7 @@ import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing'
 import sinon from 'sinon';
 import { LitElement, UpdatingElement } from '@lion/core';
 
+import { formRegistrarManager } from '../src/formRegistrarManager.js';
 import { FormRegisteringMixin } from '../src/FormRegisteringMixin.js';
 import { FormRegistrarMixin } from '../src/FormRegistrarMixin.js';
 
@@ -34,6 +35,24 @@ describe('FormRegistrationMixins', () => {
     await el.registrationReady;
     expect(el.formElements.length).to.equal(1);
     expect(el.querySelector('form-registrar').formElements.length).to.equal(1);
+  });
+
+  it('forgets disconnected registrars', async () => {
+    const el = await fixture(html`
+      <form-registrar>
+        <form-registrar>
+          <form-registering></form-registering>
+        </form-registrar>
+        <form-registrar id="remove">
+          <form-registering></form-registering>
+        </form-registrar>
+      </form-registrar>
+    `);
+    await el.registrationReady;
+    expect(formRegistrarManager.__elements.length).to.equal(3);
+
+    el.querySelector('#remove').remove();
+    expect(formRegistrarManager.__elements.length).to.equal(2);
   });
 
   it('works for component that have a delayed render', async () => {


### PR DESCRIPTION
Fixes https://github.com/ing-bank/lion/issues/215

Credit to @LarsDenBakker, this was pretty much his quick fix after his analysis. I applied it locally and tested my use case, and this resolves the issue for me. The form system is pretty complex so I hope this is on the right track.

I covered the memory leak in a test. In case you would like to see a test for registering elements in the connected callback also, I'd love some feedback on how/where you'd like to see this (I don't see related tests).