### PR TITLE
[wip] fix: form registration

### DIFF
--- a/karma.bs.config.js
+++ b/karma.bs.config.js
@@ -12,12 +12,12 @@ module.exports = config => {
         project: 'lion',
       },
       browsers: [
-        'bs_win10_chrome_latest',
+        // 'bs_win10_chrome_latest',
         // Only chrome for now
         // 'bs_win10_firefox_latest',
         // 'bs_win10_edge_latest',
         // 'bs_osxmojave_safari_latest',
-        // 'bs_win10_ie_11',
+        'bs_win10_ie_11',
       ],
     }),
   );

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:legacy:watch": "karma start --legacy --auto-watch=true --single-run=false",
     "test:update-snapshots": "karma start --update-snapshots",
     "test:prune-snapshots": "karma start --prune-snapshots",
-    "test:bs": "karma start karma.bs.config.js --coverage",
+    "test:bs": "karma start --legacy karma.bs.config.js --coverage",
     "lint": "run-p lint:*",
     "lint:eclint": "git ls-files | xargs eclint check",
     "lint:eslint": "eslint --ext .js,.html .",

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -52,4 +52,5 @@ export { DomHelpersMixin } from './src/DomHelpersMixin.js';
 export { LionSingleton } from './src/LionSingleton.js';
 export { SlotMixin } from './src/SlotMixin.js';
 export { DisabledMixin } from './src/DisabledMixin.js';
+export { DisabledWithTabIndexMixin } from './src/DisabledWithTabIndexMixin.js';
 export { LitPatchShadyMixin } from './src/LitPatchShadyMixin.js';

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -52,4 +52,4 @@ export { DomHelpersMixin } from './src/DomHelpersMixin.js';
 export { LionSingleton } from './src/LionSingleton.js';
 export { SlotMixin } from './src/SlotMixin.js';
 export { DisabledMixin } from './src/DisabledMixin.js';
-export { DisabledWithTabIndexMixin } from './src/DisabledWithTabIndexMixin.js';
+export { LitPatchShadyMixin } from './src/LitPatchShadyMixin.js';

--- a/packages/core/src/LitPatchShadyMixin.js
+++ b/packages/core/src/LitPatchShadyMixin.js
@@ -1,4 +1,4 @@
-import { UpdatingElement } from 'lit-html';
+import { UpdatingElement } from 'lit-element';
 import { dedupeMixin } from './dedupeMixin.js';
 
 /**
@@ -29,7 +29,7 @@ export const LitPatchShadyMixin = dedupeMixin(superclass =>
     /** @override */
     update(changedProperties) {
       // Right before LitElement calls render, create a shadow root
-      if(!this.__hasCreatedRenderRoot) {
+      if(!this.__hasCreatedRenderRoot && /* compatibility UpdatingElement */ this.createRenderRoot) {
         // Original logic from LitElement.prototype.initialize is placed here
         this.renderRoot = this.createRenderRoot();
         if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {

--- a/packages/core/src/LitPatchShadyMixin.js
+++ b/packages/core/src/LitPatchShadyMixin.js
@@ -1,51 +1,41 @@
-import { UpdatingElement, dedupeMixin } from '@lion/core';
+import { UpdatingElement } from 'lit-html';
+import { dedupeMixin } from './dedupeMixin.js';
 
 /**
  * This temporary mixin is needed until https://github.com/webcomponents/polyfills/issues/95 is
  * fixed.
  * It solves an issue that currently occurs when LitElement is combined with ShadyDOM.
  *
- * The flow below illustrates the problem:
- * - 1. LitElement creates a shadowRoot first renders to it.
+ * The flow below illustrates the problem in LitElement:
+ * - 1. It creates a shadowRoot
  * - 2. It renders asynchronously (at an unpredictable time in case render gets postponed).
- * All events sent between 1 and 2 (usually connectedCallback) are lost when ShadyDOM is used.
+ * All events sent between 1 and 2 (usually connectedCallback) are 'lost' when ShadyDOM is used
+ * in combination with LitElement.
  *
- * This mixin solves the problem by creating the shadow root right before the first render,
+ * This mixin solves this problem by creating the shadow root right before the first render,
  * as suggested by Steve Orvell here: https://github.com/Polymer/lit-element/issues/658
  */
 export const LitPatchShadyMixin = dedupeMixin(superclass =>
   // eslint-disable-next-line no-shadow
   class LitPatchShadyMixin extends superclass {
-    /**
-     * @override
-     */
+    /** @override */
     initialize() {
       // We must make sure we bypass initialize of LitElement, but call the one of UpdatingElement
       const superInitialize = UpdatingElement.prototype.initialize.bind(this);
       superInitialize();
-
-      // Before patch, in original LitElement.prototype.initialize, a shadow root was created here.
-      // This logic is now delayed until first render and put in
-      // this.__createRenderRootAndAdoptStyles.
+      // Original from logic LitElement.prototype.initialize was here before
     }
 
-    __createRenderRootAndAdoptStyles() {
-      // Logic was extracted from LitElement.prototype.initialize
-      this.renderRoot = this.createRenderRoot();
-      if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {
-        this.adoptStyles();
-      }
-
-      this.__hasCreatedRenderRoot = true;
-    }
-
-    /**
-     * @override
-     */
+    /** @override */
     update(changedProperties) {
       // Right before LitElement calls render, create a shadow root
       if(!this.__hasCreatedRenderRoot) {
-        this.__createRenderRootAndAdoptStyles();
+        // Original logic from LitElement.prototype.initialize is placed here
+        this.renderRoot = this.createRenderRoot();
+        if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {
+          this.adoptStyles();
+        }
+        this.__hasCreatedRenderRoot = true;
       }
       // Now hand over to LitElement again
       super.update(changedProperties);

--- a/packages/field/src/FormControlMixin.js
+++ b/packages/field/src/FormControlMixin.js
@@ -102,8 +102,8 @@ export const FormControlMixin = dedupeMixin(
         this._ariaDescribedby = '';
       }
 
-      connectedCallback() {
-        super.connectedCallback();
+      firstUpdated(c) {
+        super.firstUpdated(c);
         this._enhanceLightDomClasses();
         this._enhanceLightDomA11y();
       }

--- a/packages/field/src/FormRegisteringMixin.js
+++ b/packages/field/src/FormRegisteringMixin.js
@@ -1,71 +1,75 @@
-import { dedupeMixin } from '@lion/core';
-import { formRegistrarManager } from './formRegistrarManager.js';
+export { RegistrationChildMixin as FormRegisteringMixin } from './registration/RegistrationChildMixin.js';
 
-/**
- * #FormRegisteringMixin:
- *
- * This Mixin registers a form element to a Registrar
- *
- * @polymerMixin
- * @mixinFunction
- */
-export const FormRegisteringMixin = dedupeMixin(
-  superclass =>
-    // eslint-disable-next-line no-shadow, no-unused-vars
-    class FormRegisteringMixin extends superclass {
-      connectedCallback() {
-        if (super.connectedCallback) {
-          super.connectedCallback();
-        }
-        this.__setupRegistrationHook();
-      }
+// import { dedupeMixin } from '@lion/core';
+// import { formRegistrarManager } from './formRegistrarManager.js';
 
-      disconnectedCallback() {
-        if (super.disconnectedCallback) {
-          super.disconnectedCallback();
-        }
-        this._unregisterFormElement();
-      }
 
-      __setupRegistrationHook() {
-        if (formRegistrarManager.ready) {
-          this._registerFormElement();
-        } else {
-          formRegistrarManager.addEventListener('all-forms-open-for-registration', () => {
-            this._registerFormElement();
-          });
-        }
-      }
 
-      _registerFormElement() {
-        this._dispatchRegistration();
-        this._requestParentFormGroupUpdateOfResetModelValue();
-      }
+// /**
+//  * #FormRegisteringMixin:
+//  *
+//  * This Mixin registers a form element to a Registrar
+//  *
+//  * @polymerMixin
+//  * @mixinFunction
+//  */
+// export const FormRegisteringMixin = dedupeMixin(
+//   superclass =>
+//     // eslint-disable-next-line no-shadow, no-unused-vars
+//     class FormRegisteringMixin extends superclass {
+//       connectedCallback() {
+//         if (super.connectedCallback) {
+//           super.connectedCallback();
+//         }
+//         this.__setupRegistrationHook();
+//       }
 
-      _dispatchRegistration() {
-        this.dispatchEvent(
-          new CustomEvent('form-element-register', {
-            detail: { element: this },
-            bubbles: true,
-          }),
-        );
-      }
+//       disconnectedCallback() {
+//         if (super.disconnectedCallback) {
+//           super.disconnectedCallback();
+//         }
+//         this._unregisterFormElement();
+//       }
 
-      _unregisterFormElement() {
-        if (this.__parentFormGroup) {
-          this.__parentFormGroup.removeFormElement(this);
-        }
-      }
+//       __setupRegistrationHook() {
+//         if (formRegistrarManager.ready) {
+//           this._registerFormElement();
+//         } else {
+//           formRegistrarManager.addEventListener('all-forms-open-for-registration', () => {
+//             this._registerFormElement();
+//           });
+//         }
+//       }
 
-      /**
-       * Makes sure our parentFormGroup has the most up to date resetModelValue
-       * FormGroups will call the same on their parentFormGroup so the full tree gets the correct
-       * values.
-       */
-      _requestParentFormGroupUpdateOfResetModelValue() {
-        if (this.__parentFormGroup && this.__parentFormGroup._updateResetModelValue) {
-          this.__parentFormGroup._updateResetModelValue();
-        }
-      }
-    },
-);
+//       _registerFormElement() {
+//         this._dispatchRegistration();
+//         this._requestParentFormGroupUpdateOfResetModelValue();
+//       }
+
+//       _dispatchRegistration() {
+//         this.dispatchEvent(
+//           new CustomEvent('form-element-register', {
+//             detail: { element: this },
+//             bubbles: true,
+//           }),
+//         );
+//       }
+
+//       _unregisterFormElement() {
+//         if (this.__parentFormGroup) {
+//           this.__parentFormGroup.removeFormElement(this);
+//         }
+//       }
+
+//       /**
+//        * Makes sure our parentFormGroup has the most up to date resetModelValue
+//        * FormGroups will call the same on their parentFormGroup so the full tree gets the correct
+//        * values.
+//        */
+//       _requestParentFormGroupUpdateOfResetModelValue() {
+//         if (this.__parentFormGroup && this.__parentFormGroup._updateResetModelValue) {
+//           this.__parentFormGroup._updateResetModelValue();
+//         }
+//       }
+//     },
+// );

--- a/packages/field/src/FormRegistrarMixin.js
+++ b/packages/field/src/FormRegistrarMixin.js
@@ -1,92 +1,94 @@
-import { dedupeMixin } from '@lion/core';
-import { formRegistrarManager } from './formRegistrarManager.js';
-import { FormRegisteringMixin } from './FormRegisteringMixin.js';
+export { RegistrationParentMixin as FormRegisteringMixin } from './registration/RegistrationParentMixin.js';
 
-/**
- * This allows an element to become the manager of a register
- */
-export const FormRegistrarMixin = dedupeMixin(
-  superclass =>
-    // eslint-disable-next-line no-shadow, no-unused-vars
-    class FormRegistrarMixin extends FormRegisteringMixin(superclass) {
-      get formElements() {
-        return this.__formElements;
-      }
+// import { dedupeMixin } from '@lion/core';
+// import { formRegistrarManager } from './formRegistrarManager.js';
+// import { FormRegisteringMixin } from './FormRegisteringMixin.js';
 
-      set formElements(value) {
-        this.__formElements = value;
-      }
+// /**
+//  * This allows an element to become the manager of a register
+//  */
+// export const FormRegistrarMixin = dedupeMixin(
+//   superclass =>
+//     // eslint-disable-next-line no-shadow, no-unused-vars
+//     class FormRegistrarMixin extends FormRegisteringMixin(superclass) {
+//       get formElements() {
+//         return this.__formElements;
+//       }
 
-      get formElementsArray() {
-        return this.__formElements;
-      }
+//       set formElements(value) {
+//         this.__formElements = value;
+//       }
 
-      constructor() {
-        super();
-        this.formElements = [];
-        this.__readyForRegistration = false;
-        this.registrationReady = new Promise(resolve => {
-          this.__resolveRegistrationReady = resolve;
-        });
-        formRegistrarManager.add(this);
+//       get formElementsArray() {
+//         return this.__formElements;
+//       }
 
-        this._onRequestToAddFormElement = this._onRequestToAddFormElement.bind(this);
-        this.addEventListener('form-element-register', this._onRequestToAddFormElement);
-      }
+//       constructor() {
+//         super();
+//         this.formElements = [];
+//         this.__readyForRegistration = false;
+//         this.registrationReady = new Promise(resolve => {
+//           this.__resolveRegistrationReady = resolve;
+//         });
+//         formRegistrarManager.add(this);
 
-      isRegisteredFormElement(el) {
-        return this.formElementsArray.some(exitingEl => exitingEl === el);
-      }
+//         this._onRequestToAddFormElement = this._onRequestToAddFormElement.bind(this);
+//         this.addEventListener('form-element-register', this._onRequestToAddFormElement);
+//       }
 
-      firstUpdated(changedProperties) {
-        super.firstUpdated(changedProperties);
-        this.__resolveRegistrationReady();
-        this.__readyForRegistration = true;
-        formRegistrarManager.becomesReady(this);
-      }
+//       isRegisteredFormElement(el) {
+//         return this.formElementsArray.some(exitingEl => exitingEl === el);
+//       }
 
-      addFormElement(child) {
-        // This is a way to let the child element (a lion-fieldset or lion-field) know, about its parent
-        // eslint-disable-next-line no-param-reassign
-        child.__parentFormGroup = this;
+//       firstUpdated(changedProperties) {
+//         super.firstUpdated(changedProperties);
+//         this.__resolveRegistrationReady();
+//         this.__readyForRegistration = true;
+//         formRegistrarManager.becomesReady(this);
+//       }
 
-        this.formElements.push(child);
-      }
+//       addFormElement(child) {
+//         // This is a way to let the child element (a lion-fieldset or lion-field) know, about its parent
+//         // eslint-disable-next-line no-param-reassign
+//         child.__parentFormGroup = this;
 
-      removeFormElement(child) {
-        const index = this.formElements.indexOf(child);
-        if (index > -1) {
-          this.formElements.splice(index, 1);
-        }
-      }
+//         this.formElements.push(child);
+//       }
 
-      _onRequestToAddFormElement(ev) {
-        const child = ev.detail.element;
-        if (child === this) {
-          // as we fire and listen - don't add ourselves
-          return;
-        }
-        if (this.isRegisteredFormElement(child)) {
-          // do not readd already existing elements
-          return;
-        }
-        ev.stopPropagation();
-        this.addFormElement(child);
-      }
+//       removeFormElement(child) {
+//         const index = this.formElements.indexOf(child);
+//         if (index > -1) {
+//           this.formElements.splice(index, 1);
+//         }
+//       }
 
-      _onRequestToRemoveFormElement(ev) {
-        const child = ev.detail.element;
-        if (child === this) {
-          // as we fire and listen - don't add ourselves
-          return;
-        }
-        if (!this.isRegisteredFormElement(child)) {
-          // do not readd already existing elements
-          return;
-        }
-        ev.stopPropagation();
+//       _onRequestToAddFormElement(ev) {
+//         const child = ev.detail.element;
+//         if (child === this) {
+//           // as we fire and listen - don't add ourselves
+//           return;
+//         }
+//         if (this.isRegisteredFormElement(child)) {
+//           // do not readd already existing elements
+//           return;
+//         }
+//         ev.stopPropagation();
+//         this.addFormElement(child);
+//       }
 
-        this.removeFormElement(child);
-      }
-    },
-);
+//       _onRequestToRemoveFormElement(ev) {
+//         const child = ev.detail.element;
+//         if (child === this) {
+//           // as we fire and listen - don't add ourselves
+//           return;
+//         }
+//         if (!this.isRegisteredFormElement(child)) {
+//           // do not readd already existing elements
+//           return;
+//         }
+//         ev.stopPropagation();
+
+//         this.removeFormElement(child);
+//       }
+//     },
+// );

--- a/packages/field/src/FormRegistrarMixin.js
+++ b/packages/field/src/FormRegistrarMixin.js
@@ -1,4 +1,4 @@
-export { RegistrationParentMixin as FormRegisteringMixin } from './registration/RegistrationParentMixin.js';
+export { RegistrationParentMixin as FormRegistrarMixin } from './registration/RegistrationParentMixin.js';
 
 // import { dedupeMixin } from '@lion/core';
 // import { formRegistrarManager } from './formRegistrarManager.js';

--- a/packages/field/src/LionField.js
+++ b/packages/field/src/LionField.js
@@ -66,6 +66,13 @@ export class LionField extends FormControlMixin(
         // make sure validation can be triggered based on observer
         type: Boolean,
       },
+      /**
+       * This is the modelValue that can be used to
+       * reset a form. It's read in the `firstUpdated` callback
+       */
+      _initialModelValue: {
+        type: Object,
+      },
     };
   }
 
@@ -87,6 +94,11 @@ export class LionField extends FormControlMixin(
       ...super.asyncObservers,
       _setDisabledClass: ['disabled'],
     };
+  }
+
+  firstUpdated(c) {
+    super.firstUpdated(c);
+    this._initialModelValue = this.modelValue;
   }
 
   connectedCallback() {
@@ -132,6 +144,11 @@ export class LionField extends FormControlMixin(
       super.resetInteractionState();
     }
     this.submitted = false;
+  }
+
+  reset() {
+    this.modelValue = this._initialModelValue;
+    this.resetInteractionState();
   }
 
   clear() {

--- a/packages/field/src/registration/LitPatchShadyMixin.js
+++ b/packages/field/src/registration/LitPatchShadyMixin.js
@@ -1,0 +1,54 @@
+import { UpdatingElement, dedupeMixin } from '@lion/core';
+
+/**
+ * This temporary mixin is needed until https://github.com/webcomponents/polyfills/issues/95 is
+ * fixed.
+ * It solves an issue that currently occurs when LitElement is combined with ShadyDOM.
+ *
+ * The flow below illustrates the problem:
+ * - 1. LitElement creates a shadowRoot first renders to it.
+ * - 2. It renders asynchronously (at an unpredictable time in case render gets postponed).
+ * All events sent between 1 and 2 (usually connectedCallback) are lost when ShadyDOM is used.
+ *
+ * This mixin solves the problem by creating the shadow root right before the first render,
+ * as suggested by Steve Orvell here: https://github.com/Polymer/lit-element/issues/658
+ */
+export const LitPatchShadyMixin = dedupeMixin(superclass =>
+  // eslint-disable-next-line no-shadow
+  class LitPatchShadyMixin extends superclass {
+    /**
+     * @override
+     */
+    initialize() {
+      // We must make sure we bypass initialize of LitElement, but call the one of UpdatingElement
+      const superInitialize = UpdatingElement.prototype.initialize.bind(this);
+      superInitialize();
+
+      // Before patch, in original LitElement.prototype.initialize, a shadow root was created here.
+      // This logic is now delayed until first render and put in
+      // this.__createRenderRootAndAdoptStyles.
+    }
+
+    __createRenderRootAndAdoptStyles() {
+      // Logic was extracted from LitElement.prototype.initialize
+      this.renderRoot = this.createRenderRoot();
+      if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {
+        this.adoptStyles();
+      }
+
+      this.__hasCreatedRenderRoot = true;
+    }
+
+    /**
+     * @override
+     */
+    update(changedProperties) {
+      // Right before LitElement calls render, create a shadow root
+      if(!this.__hasCreatedRenderRoot) {
+        this.__createRenderRootAndAdoptStyles();
+      }
+      // Now hand over to LitElement again
+      super.update(changedProperties);
+    }
+  }
+);

--- a/packages/field/src/registration/RegistrationChildMixin.js
+++ b/packages/field/src/registration/RegistrationChildMixin.js
@@ -1,13 +1,18 @@
-import { dedupeMixin } from '@lion/core';
+import { dedupeMixin, LitPatchShadyMixin } from '@lion/core';
 
 export const RegistrationChildMixin = dedupeMixin(superclass =>
   // eslint-disable-next-line no-shadow
-  class RegistrationChildMixin extends superclass {
+  class RegistrationChildMixin extends LitPatchShadyMixin(superclass) {
     connectedCallback() {
       if (super.connectedCallback) {
         super.connectedCallback();
       }
-      this.dispatchEvent(new CustomEvent('form-element-register', { bubbles: true, composed: true }));
+      this.dispatchEvent(
+        new CustomEvent('form-element-register', {
+          detail: { element: this },
+          bubbles: true,
+        }),
+      );
     }
 
     disconnectedCallback() {
@@ -15,7 +20,7 @@ export const RegistrationChildMixin = dedupeMixin(superclass =>
         super.disconnectedCallback();
       }
       if (this.__parentFormGroup) {
-        this.__parentFormGroup._unregisterChild(this);
+        this.__parentFormGroup.removeChild(this);
       }
     }
   }

--- a/packages/field/src/registration/RegistrationChildMixin.js
+++ b/packages/field/src/registration/RegistrationChildMixin.js
@@ -1,0 +1,22 @@
+import { dedupeMixin } from '@lion/core';
+
+export const RegistrationChildMixin = dedupeMixin(superclass =>
+  // eslint-disable-next-line no-shadow
+  class RegistrationChildMixin extends superclass {
+    connectedCallback() {
+      if (super.connectedCallback) {
+        super.connectedCallback();
+      }
+      this.dispatchEvent(new CustomEvent('form-element-register', { bubbles: true, composed: true }));
+    }
+
+    disconnectedCallback() {
+      if (super.disconnectedCallback) {
+        super.disconnectedCallback();
+      }
+      if (this.__parentFormGroup) {
+        this.__parentFormGroup._unregisterChild(this);
+      }
+    }
+  }
+);

--- a/packages/field/src/registration/RegistrationChildMixin.js
+++ b/packages/field/src/registration/RegistrationChildMixin.js
@@ -20,7 +20,7 @@ export const RegistrationChildMixin = dedupeMixin(superclass =>
         super.disconnectedCallback();
       }
       if (this.__parentFormGroup) {
-        this.__parentFormGroup.removeChild(this);
+        this.__parentFormGroup.removeFormElement(this);
       }
     }
   }

--- a/packages/field/src/registration/RegistrationParentMixin.js
+++ b/packages/field/src/registration/RegistrationParentMixin.js
@@ -1,0 +1,52 @@
+import { dedupeMixin } from '@lion/core';
+
+export const RegistrationParentMixin = dedupeMixin(superclass =>
+  // eslint-disable-next-line no-shadow
+  class RegistrationParentMixin extends superclass {
+    // TODO: this (if needed at all should be added in layers above)
+    get formElementsArray() {
+      return this.formElements;
+    }
+
+    constructor() {
+      super();
+      this.formElements = [];
+      this.addEventListener('form-element-register', ({ target }) => this._registerChild(target));
+      this.registrationReady = new Promise(resolve => {
+        this.__resolveRegistrationReady = resolve;
+      });
+    }
+
+    _registerChild(addEl) {
+      this.formElements.push(addEl);
+      addEl.__parentFormGroup = this; // eslint-disable-line no-param-reassign
+
+      this._onChildRegistered(addEl);
+      // TODO: this mixin should no nothing about modelValues. Call the hook in a layer that
+      // is allowed to know. Also, elements that are registered lazily should NOT
+      // completely reset the parentFormGroupArray, but only update for the new value
+      // this. ();
+    }
+
+    _unregisterChild(removeEl) {
+      const index = this.formElements.indexOf(removeEl);
+      if (index > -1) {
+        this.formElements.splice(index, 1);
+      }
+      this._onChildRegistered(removeEl);
+    }
+
+    _onChildRegistered(addEl) {} // eslint-disable-line
+
+    _onChildUnRegistered(removeEl) {} // eslint-disable-line
+
+    connectedCallback() {
+      if(super.connectedCallback) {
+        super.connectedCallback();
+      }
+      setTimeout(() => {
+        this.__resolveRegistrationReady();
+      });
+    }
+  }
+);

--- a/packages/field/src/registration/RegistrationParentMixin.js
+++ b/packages/field/src/registration/RegistrationParentMixin.js
@@ -3,7 +3,7 @@ import { dedupeMixin, LitPatchShadyMixin } from '@lion/core';
 export const RegistrationParentMixin = dedupeMixin(superclass =>
   // eslint-disable-next-line no-shadow
   class RegistrationParentMixin extends LitPatchShadyMixin(superclass) {
-    // TODO: this (if needed at all should be added in layers above)
+
     get formElementsArray() {
       return this.formElements;
     }
@@ -11,33 +11,11 @@ export const RegistrationParentMixin = dedupeMixin(superclass =>
     constructor() {
       super();
       this.formElements = [];
-      this.addEventListener('form-element-register', ({ target }) => this._registerChild(target));
+      this.addEventListener('form-element-register', this._onRequestToAddFormElement);
       this.registrationReady = new Promise(resolve => {
         this.__resolveRegistrationReady = resolve;
       });
     }
-
-    // _registerChild(addEl) {
-    //   this.formElements.push(addEl);
-    //   addEl.__parentFormGroup = this; // eslint-disable-line no-param-reassign
-
-    //   this._onChildRegistered(addEl);
-    //   // TODO: this mixin should know nothing about modelValues. Call the hook in a layer that
-    //   // is allowed to know. Also, elements that are registered lazily should NOT
-    //   // completely reset the parentFormGroupArray, but only update for the new value
-    // }
-
-    // _unregisterChild(removeEl) {
-    //   const index = this.formElements.indexOf(removeEl);
-    //   if (index > -1) {
-    //     this.formElements.splice(index, 1);
-    //   }
-    //   this._onChildUnregistered(removeEl);
-    // }
-
-    // _onChildRegistered(addEl) {} // eslint-disable-line
-
-    // _onChildUnRegistered(removeEl) {} // eslint-disable-line
 
     connectedCallback() {
       if(super.connectedCallback) {
@@ -53,11 +31,6 @@ export const RegistrationParentMixin = dedupeMixin(superclass =>
       // eslint-disable-next-line no-param-reassign
       child.__parentFormGroup = this;
       this.formElements.push(child);
-
-      // TODO: registration mixin should have no knowledge about modelValues.
-      // Make `.resetModelValue` a getter that fetches info from children, each of whom
-      // hold reset state: https://web.dev/more-capable-form-controls#restoring-form-state
-      this._updateResetModelValue();
     }
 
     removeFormElement(child) {
@@ -65,8 +38,6 @@ export const RegistrationParentMixin = dedupeMixin(superclass =>
       if (index > -1) {
         this.formElements.splice(index, 1);
       }
-      // TODO: registration mixin should have no knowledge about modelValues.
-      this._updateResetModelValue();
     }
 
     _onRequestToAddFormElement(ev) {
@@ -81,21 +52,6 @@ export const RegistrationParentMixin = dedupeMixin(superclass =>
       }
       ev.stopPropagation();
       this.addFormElement(child);
-    }
-
-    _onRequestToRemoveFormElement(ev) {
-      const child = ev.detail.element;
-      if (child === this) {
-        // as we fire and listen - don't add ourselves
-        return;
-      }
-      if (!this.isRegisteredFormElement(child)) {
-        // do not readd already existing elements
-        return;
-      }
-      ev.stopPropagation();
-
-      this.removeFormElement(child);
     }
 
     isRegisteredFormElement(el) {

--- a/packages/field/src/registration/RegistrationParentMixin.js
+++ b/packages/field/src/registration/RegistrationParentMixin.js
@@ -1,8 +1,8 @@
-import { dedupeMixin } from '@lion/core';
+import { dedupeMixin, LitPatchShadyMixin } from '@lion/core';
 
 export const RegistrationParentMixin = dedupeMixin(superclass =>
   // eslint-disable-next-line no-shadow
-  class RegistrationParentMixin extends superclass {
+  class RegistrationParentMixin extends LitPatchShadyMixin(superclass) {
     // TODO: this (if needed at all should be added in layers above)
     get formElementsArray() {
       return this.formElements;
@@ -17,28 +17,27 @@ export const RegistrationParentMixin = dedupeMixin(superclass =>
       });
     }
 
-    _registerChild(addEl) {
-      this.formElements.push(addEl);
-      addEl.__parentFormGroup = this; // eslint-disable-line no-param-reassign
+    // _registerChild(addEl) {
+    //   this.formElements.push(addEl);
+    //   addEl.__parentFormGroup = this; // eslint-disable-line no-param-reassign
 
-      this._onChildRegistered(addEl);
-      // TODO: this mixin should no nothing about modelValues. Call the hook in a layer that
-      // is allowed to know. Also, elements that are registered lazily should NOT
-      // completely reset the parentFormGroupArray, but only update for the new value
-      // this. ();
-    }
+    //   this._onChildRegistered(addEl);
+    //   // TODO: this mixin should know nothing about modelValues. Call the hook in a layer that
+    //   // is allowed to know. Also, elements that are registered lazily should NOT
+    //   // completely reset the parentFormGroupArray, but only update for the new value
+    // }
 
-    _unregisterChild(removeEl) {
-      const index = this.formElements.indexOf(removeEl);
-      if (index > -1) {
-        this.formElements.splice(index, 1);
-      }
-      this._onChildRegistered(removeEl);
-    }
+    // _unregisterChild(removeEl) {
+    //   const index = this.formElements.indexOf(removeEl);
+    //   if (index > -1) {
+    //     this.formElements.splice(index, 1);
+    //   }
+    //   this._onChildUnregistered(removeEl);
+    // }
 
-    _onChildRegistered(addEl) {} // eslint-disable-line
+    // _onChildRegistered(addEl) {} // eslint-disable-line
 
-    _onChildUnRegistered(removeEl) {} // eslint-disable-line
+    // _onChildUnRegistered(removeEl) {} // eslint-disable-line
 
     connectedCallback() {
       if(super.connectedCallback) {
@@ -47,6 +46,60 @@ export const RegistrationParentMixin = dedupeMixin(superclass =>
       setTimeout(() => {
         this.__resolveRegistrationReady();
       });
+    }
+
+    addFormElement(child) {
+      // This is a way to let the child element (a lion-fieldset or lion-field) know, about its parent
+      // eslint-disable-next-line no-param-reassign
+      child.__parentFormGroup = this;
+      this.formElements.push(child);
+
+      // TODO: registration mixin should have no knowledge about modelValues.
+      // Make `.resetModelValue` a getter that fetches info from children, each of whom
+      // hold reset state: https://web.dev/more-capable-form-controls#restoring-form-state
+      this._updateResetModelValue();
+    }
+
+    removeFormElement(child) {
+      const index = this.formElements.indexOf(child);
+      if (index > -1) {
+        this.formElements.splice(index, 1);
+      }
+      // TODO: registration mixin should have no knowledge about modelValues.
+      this._updateResetModelValue();
+    }
+
+    _onRequestToAddFormElement(ev) {
+      const child = ev.detail.element;
+      if (child === this) {
+        // as we fire and listen - don't add ourselves
+        return;
+      }
+      if (this.isRegisteredFormElement(child)) {
+        // do not readd already existing elements
+        return;
+      }
+      ev.stopPropagation();
+      this.addFormElement(child);
+    }
+
+    _onRequestToRemoveFormElement(ev) {
+      const child = ev.detail.element;
+      if (child === this) {
+        // as we fire and listen - don't add ourselves
+        return;
+      }
+      if (!this.isRegisteredFormElement(child)) {
+        // do not readd already existing elements
+        return;
+      }
+      ev.stopPropagation();
+
+      this.removeFormElement(child);
+    }
+
+    isRegisteredFormElement(el) {
+      return this.formElementsArray.some(exitingEl => exitingEl === el);
     }
   }
 );

--- a/packages/field/test/FormRegistrationMixins.suite.js
+++ b/packages/field/test/FormRegistrationMixins.suite.js
@@ -1,9 +1,8 @@
 import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
-import { LitElement } from '@lion/core';
+import { LitElement, LitPatchShadyMixin } from '@lion/core';
 
 import { RegistrationParentMixin } from '../src/registration/RegistrationParentMixin.js';
 import { RegistrationChildMixin } from '../src/registration/RegistrationChildMixin.js';
-import { LitPatchShadyMixin } from '../src/registration/LitPatchShadyMixin.js';
 
 function printSuffix(suffix) {
   return suffix ? ` (${suffix})` : '';
@@ -23,7 +22,7 @@ export const runRegistrationSuite = customConfig => {
   let parentTag;
   let childTag;
 
-  describe.only(`FormRegistrationMixins${printSuffix(cfg.suffix)}`, () => {
+  describe(`FormRegistrationMixins${printSuffix(cfg.suffix)}`, () => {
     before(async () => {
       if (!cfg.parentTagString) {
         cfg.parentTagString = defineCE(class extends cfg.parentMixin(cfg.baseElement) {});

--- a/packages/field/test/FormRegistrationMixins.suite.js
+++ b/packages/field/test/FormRegistrationMixins.suite.js
@@ -1,0 +1,131 @@
+import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
+import { LitElement } from '@lion/core';
+
+import { RegistrationParentMixin } from '../src/registration/RegistrationParentMixin.js';
+import { RegistrationChildMixin } from '../src/registration/RegistrationChildMixin.js';
+import { LitPatchShadyMixin } from '../src/registration/LitPatchShadyMixin.js';
+
+function printSuffix(suffix) {
+  return suffix ? ` (${suffix})` : '';
+}
+
+export const runRegistrationSuite = customConfig => {
+  const cfg = {
+    baseElement: HTMLElement,
+    suffix: null,
+    parentTagString: null,
+    childTagString: null,
+    parentMixin: RegistrationParentMixin,
+    childMixin: RegistrationChildMixin,
+    ...customConfig,
+  };
+
+  let parentTag;
+  let childTag;
+
+  describe.only(`FormRegistrationMixins${printSuffix(cfg.suffix)}`, () => {
+    before(async () => {
+      if (!cfg.parentTagString) {
+        cfg.parentTagString = defineCE(class extends cfg.parentMixin(cfg.baseElement) {});
+      }
+      if (!cfg.childTagString) {
+        cfg.childTagString = defineCE(class extends cfg.childMixin(cfg.baseElement) {});
+      }
+
+      parentTag = unsafeStatic(cfg.parentTagString);
+      childTag = unsafeStatic(cfg.childTagString);
+    });
+
+    it('can register a formElement', async () => {
+      const el = await fixture(html`
+        <${parentTag}>
+          <${childTag}></${childTag}>
+        </${parentTag}>
+      `);
+      await el.registrationReady;
+      expect(el.formElements.length).to.equal(1);
+    });
+
+    it('supports nested registrar', async () => {
+      const el = await fixture(html`
+        <${parentTag}>
+          <${parentTag}>
+            <${childTag}></${childTag}>
+          </${parentTag}>
+        </${parentTag}>
+      `);
+      await el.registrationReady;
+      expect(el.formElements.length).to.equal(1);
+      expect(el.querySelector(cfg.parentTagString).formElements.length).to.equal(1);
+    });
+
+    it('works for component that have a delayed render', async () => {
+      const tagWrapperString = defineCE(
+        class extends cfg.parentMixin(LitPatchShadyMixin(LitElement)) {
+          async performUpdate() {
+            await new Promise(resolve => setTimeout(() => resolve(), 10));
+            await super.performUpdate();
+          }
+
+          render() {
+            return html`
+              <slot></slot>
+            `;
+          }
+        },
+      );
+      const tagWrapper = unsafeStatic(tagWrapperString);
+      // const registerSpy = sinon.spy();
+      const el = await fixture(html`
+        <${tagWrapper}>
+          <${childTag}></${childTag}>
+        </${tagWrapper}>
+      `);
+      await el.registrationReady;
+      expect(el.formElements.length).to.equal(1);
+    });
+
+    // TODO: create registration hooks so this logic can be put along reset logic
+    it.skip('requests update of the resetModelValue function of its parent formGroup', async () => {
+      const ParentFormGroupClass = class extends RegistrationParentMixin(LitElement) {
+        _updateResetModelValue() {
+          this.resetModelValue = 'foo';
+        }
+      };
+      const ChildFormGroupClass = class extends RegistrationChildMixin(LitElement) {
+        constructor() {
+          super();
+          this.__parentFormGroup = this.parentNode;
+        }
+      };
+
+      const parentClass = defineCE(ParentFormGroupClass);
+      const formGroup = unsafeStatic(parentClass);
+      const childClass = defineCE(ChildFormGroupClass);
+      const childFormGroup = unsafeStatic(childClass);
+      const parentFormEl = await fixture(html`
+        <${formGroup}><${childFormGroup} id="child" name="child[]"></${childFormGroup}></${formGroup}>
+      `);
+      expect(parentFormEl.resetModelValue).to.equal('foo');
+    });
+
+    it('can dynamically add/remove elements', async () => {
+      const el = await fixture(html`
+        <${parentTag}>
+          <${childTag}></${childTag}>
+        </${parentTag}>
+      `);
+      const newField = await fixture(html`
+        <${childTag}></${childTag}>
+      `);
+
+      expect(el.formElements.length).to.equal(1);
+
+      el.appendChild(newField);
+      expect(el.formElements.length).to.equal(2);
+
+      el.removeChild(newField);
+      expect(el.formElements.length).to.equal(1);
+    });
+  });
+};

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -1,244 +1,26 @@
-import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
-import { LitElement, UpdatingElement, dedupeMixin } from '@lion/core';
+import { html } from '@open-wc/testing';
+import { UpdatingElement, LitElement } from '@lion/core';
+import { runRegistrationSuite } from './FormRegistrationMixins.suite.js';
+import { LitPatchShadyMixin } from '../src/registration/LitPatchShadyMixin.js';
 
-import { FormRegisteringMixin } from '../src/FormRegisteringMixin.js';
-import { FormRegistrarMixin } from '../src/FormRegistrarMixin.js';
+runRegistrationSuite({
+  suffix: 'with HTMLElement',
+  baseElement: HTMLElement ,
+});
 
+runRegistrationSuite({
+  suffix: 'with UpdatingElement',
+  baseElement: UpdatingElement,
+});
 
-const SDPolyfillFixin = dedupeMixin(superclass =>
-  class SDPolyfillFixin extends superclass {
-
-    /**
-     * @override
-     */
-    initialize() {
-      // we must make sure we bypass initialize of LitElement, but call the one of UpdatingElement
-      const superInitialize = UpdatingElement.prototype.initialize.bind(this);
-      superInitialize();
-
-      // Before, we created the shadowRoot here, but this causes bugs until
-      // https://github.com/webcomponents/polyfills/issues/95 is solved.
-      // Also see: https://github.com/Polymer/lit-element/issues/658
-      // As a temp workaround, we adopt the suggested change of sorvell:
-      // delay the creation of the shadowRoot (see __createRenderRootAndAdoptStyles())
+runRegistrationSuite({
+  suffix: 'with shadow dom',
+  baseElement: class ShadowElement extends LitPatchShadyMixin(LitElement) {
+    render() {
+      return html`<slot></slot>`;
     }
-
-    __createRenderRootAndAdoptStyles() {
-      this.renderRoot = this.createRenderRoot();
-
-      // Note, if renderRoot is not a shadowRoot, styles would/could apply to the
-      // element's getRootNode(). While this could be done, we're choosing not to
-      // support this now since it would require different logic around de-duping.
-      if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {
-        this.adoptStyles();
-      }
-
-      this.__hasCreatedRenderRoot = true;
-    }
-
-    /**
-     * @override
-     */
-    update(changedProperties) {
-      if(!this.__hasCreatedRenderRoot) {
-        this.__createRenderRootAndAdoptStyles();
-      }
-      super.update(changedProperties);
-    }
-  }
-);
-// eslint-disable-next-line no-shadow
-const RegistrationParentMixin = dedupeMixin(superclass =>
-  class RegistrationParentMixin extends superclass {
-    constructor() {
-      super();
-      this.formElements = [];
-      this.addEventListener('form-element-register', ({ target }) => this._addChild(target));
-      this.registrationReady = new Promise(resolve => {
-        this.__resolveRegistrationReady = resolve;
-      });
-    }
-
-    _addChild(addEl) {
-      this.formElements.push(addEl);
-      addEl.__parentFormGroup = this; // eslint-disable-line no-param-reassign
-    }
-
-    _removeChild(removeEl) {
-      const index = this.formElements.indexOf(removeEl);
-      if (index > -1) {
-        this.formElements.splice(index, 1);
-      }
-    }
-
-    connectedCallback() {
-      if(super.connectedCallback) {
-        super.connectedCallback();
-      }
-      setTimeout(() => {
-        this.__resolveRegistrationReady();
-      });
-    }
-  }
-);
-
-// eslint-disable-next-line no-shadow
-const RegistrationChildMixin = dedupeMixin(superclass =>
-  class RegistrationChildMixin extends superclass {
-    connectedCallback() {
-      if (super.connectedCallback) {
-        super.connectedCallback();
-      }
-      console.log('connected child');
-
-      this.dispatchEvent(new CustomEvent('form-element-register', { bubbles: true, composed: true }));
-    }
-
-    disconnectedCallback() {
-      if (super.disconnectedCallback) {
-        super.disconnectedCallback();
-      }
-      if (this.__parentFormGroup) {
-        this.__parentFormGroup._removeChild(this);
-      }
-    }
-  }
-);
-
-function printSuffix(suffix) {
-  return suffix ? ` (${suffix})` : '';
-}
-
-export const runRegistrationSuite = customConfig => {
-  const cfg = {
-    baseElement: HTMLElement,
-    suffix: null,
-    parentTagString: null,
-    childTagString: null,
-    parentMixin: RegistrationParentMixin,
-    childMixin: RegistrationChildMixin,
-    ...customConfig,
-  };
-
-  let parentTag;
-  let childTag;
-
-  describe.only(`FormRegistrationMixins${printSuffix(cfg.suffix)}`, () => {
-    before(async () => {
-      if (!cfg.parentTagString) {
-        cfg.parentTagString = defineCE(class extends cfg.parentMixin(cfg.baseElement) {});
-      }
-      if (!cfg.childTagString) {
-        cfg.childTagString = defineCE(class extends cfg.childMixin(cfg.baseElement) {});
-      }
-
-      parentTag = unsafeStatic(cfg.parentTagString);
-      childTag = unsafeStatic(cfg.childTagString);
-    });
-
-    it('can register a formElement', async () => {
-      const el = await fixture(html`
-        <${parentTag}>
-          <${childTag}></${childTag}>
-        </${parentTag}>
-      `);
-      await el.registrationReady;
-      expect(el.formElements.length).to.equal(1);
-    });
-
-    it('supports nested registrar', async () => {
-      const el = await fixture(html`
-        <${parentTag}>
-          <${parentTag}>
-            <${childTag}></${childTag}>
-          </${parentTag}>
-        </${parentTag}>
-      `);
-      await el.registrationReady;
-      expect(el.formElements.length).to.equal(1);
-      expect(el.querySelector(cfg.parentTagString).formElements.length).to.equal(1);
-    });
-
-    it('works for component that have a delayed render', async () => {
-      const tagWrapperString = defineCE(
-        class extends cfg.parentMixin(SDPolyfillFixin(LitElement)) {
-          async performUpdate() {
-            await new Promise(resolve => setTimeout(() => resolve(), 10));
-            await super.performUpdate();
-          }
-
-          render() {
-            return html`
-              <slot></slot>
-            `;
-          }
-        },
-      );
-      const tagWrapper = unsafeStatic(tagWrapperString);
-      // const registerSpy = sinon.spy();
-      const el = await fixture(html`
-        <${tagWrapper}>
-          <${childTag}></${childTag}>
-        </${tagWrapper}>
-      `);
-      await el.registrationReady;
-      expect(el.formElements.length).to.equal(1);
-    });
-
-    // TODO: create registration hooks so this logic can be put along reset logic
-    it.skip('requests update of the resetModelValue function of its parent formGroup', async () => {
-      const ParentFormGroupClass = class extends RegistrationParentMixin(LitElement) {
-        _updateResetModelValue() {
-          this.resetModelValue = 'foo';
-        }
-      };
-      const ChildFormGroupClass = class extends RegistrationChildMixin(LitElement) {
-        constructor() {
-          super();
-          this.__parentFormGroup = this.parentNode;
-        }
-      };
-
-      const parentClass = defineCE(ParentFormGroupClass);
-      const formGroup = unsafeStatic(parentClass);
-      const childClass = defineCE(ChildFormGroupClass);
-      const childFormGroup = unsafeStatic(childClass);
-      const parentFormEl = await fixture(html`
-        <${formGroup}><${childFormGroup} id="child" name="child[]"></${childFormGroup}></${formGroup}>
-      `);
-      expect(parentFormEl.resetModelValue).to.equal('foo');
-    });
-
-    it('can dynamically add/remove elements', async () => {
-      const el = await fixture(html`
-        <${parentTag}>
-          <${childTag}></${childTag}>
-        </${parentTag}>
-      `);
-      const newField = await fixture(html`
-        <${childTag}></${childTag}>
-      `);
-
-      expect(el.formElements.length).to.equal(1);
-
-      el.appendChild(newField);
-      expect(el.formElements.length).to.equal(2);
-
-      el.removeChild(newField);
-      expect(el.formElements.length).to.equal(1);
-    });
-  });
-};
-
-runRegistrationSuite({ baseElement: HTMLElement });
-
-runRegistrationSuite({ suffix: 'with UpdatingElement',  baseElement: UpdatingElement });
-
-runRegistrationSuite({ suffix: 'with shadow dom', baseElement: class ShadowElement extends SDPolyfillFixin(LitElement) {
-  render() {
-    return html`<slot></slot>`;
-  }
-}});
+  },
+});
 
 // runRegistrationSuite({
 //   suffix: 'with Registrar and UpdatingElement',

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -1,7 +1,6 @@
 import { html } from '@open-wc/testing';
-import { UpdatingElement, LitElement } from '@lion/core';
+import { UpdatingElement, LitElement, LitPatchShadyMixin } from '@lion/core';
 import { runRegistrationSuite } from './FormRegistrationMixins.suite.js';
-import { LitPatchShadyMixin } from '../src/registration/LitPatchShadyMixin.js';
 
 runRegistrationSuite({
   suffix: 'with HTMLElement',

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -1,25 +1,33 @@
 import { html } from '@open-wc/testing';
-import { UpdatingElement, LitElement, LitPatchShadyMixin } from '@lion/core';
+import { UpdatingElement, LitElement } from '@lion/core';
 import { runRegistrationSuite } from './FormRegistrationMixins.suite.js';
 
-runRegistrationSuite({
-  suffix: 'with HTMLElement',
-  baseElement: HTMLElement ,
-});
+// runRegistrationSuite({
+//   suffix: 'with HTMLElement',
+//   baseElement: HTMLElement ,
+// });
+describe('Registration Mixins', () => {
+  runRegistrationSuite({
+    suffix: 'with HTMLElement',
+    baseElement: HTMLElement,
+  });
 
-runRegistrationSuite({
-  suffix: 'with UpdatingElement',
-  baseElement: UpdatingElement,
-});
+  runRegistrationSuite({
+    suffix: 'with UpdatingElement',
+    baseElement: UpdatingElement,
+  });
 
-runRegistrationSuite({
-  suffix: 'with shadow dom',
-  baseElement: class ShadowElement extends LitPatchShadyMixin(LitElement) {
-    render() {
-      return html`<slot></slot>`;
-    }
-  },
-});
+  runRegistrationSuite({
+    suffix: 'with shadow dom',
+    baseElement: class ShadowElement extends LitElement {
+      render() {
+        return html`<slot></slot>`;
+      }
+    },
+  });
+})
+
+
 
 // runRegistrationSuite({
 //   suffix: 'with Registrar and UpdatingElement',

--- a/packages/field/test/FormRegistrationMixins.test.js
+++ b/packages/field/test/FormRegistrationMixins.test.js
@@ -1,106 +1,259 @@
 import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
-import sinon from 'sinon';
-import { LitElement, UpdatingElement } from '@lion/core';
+import { LitElement, UpdatingElement, dedupeMixin } from '@lion/core';
 
 import { FormRegisteringMixin } from '../src/FormRegisteringMixin.js';
 import { FormRegistrarMixin } from '../src/FormRegistrarMixin.js';
 
-describe('FormRegistrationMixins', () => {
-  before(async () => {
-    const FormRegistrarEl = class extends FormRegistrarMixin(UpdatingElement) {};
-    customElements.define('form-registrar', FormRegistrarEl);
-    const FormRegisteringEl = class extends FormRegisteringMixin(UpdatingElement) {};
-    customElements.define('form-registering', FormRegisteringEl);
-  });
 
-  it('can register a formElement', async () => {
-    const el = await fixture(html`
-      <form-registrar>
-        <form-registering></form-registering>
-      </form-registrar>
-    `);
-    await el.registrationReady;
-    expect(el.formElements.length).to.equal(1);
-  });
+const SDPolyfillFixin = dedupeMixin(superclass =>
+  class SDPolyfillFixin extends superclass {
 
-  it('supports nested registrar', async () => {
-    const el = await fixture(html`
-      <form-registrar>
-        <form-registrar>
-          <form-registering></form-registering>
-        </form-registrar>
-      </form-registrar>
-    `);
-    await el.registrationReady;
-    expect(el.formElements.length).to.equal(1);
-    expect(el.querySelector('form-registrar').formElements.length).to.equal(1);
-  });
+    /**
+     * @override
+     */
+    initialize() {
+      // we must make sure we bypass initialize of LitElement, but call the one of UpdatingElement
+      const superInitialize = UpdatingElement.prototype.initialize.bind(this);
+      superInitialize();
 
-  it('works for component that have a delayed render', async () => {
-    const tagWrapperString = defineCE(
-      class extends FormRegistrarMixin(LitElement) {
-        async performUpdate() {
-          await new Promise(resolve => setTimeout(() => resolve(), 10));
-          await super.performUpdate();
-        }
+      // Before, we created the shadowRoot here, but this causes bugs until
+      // https://github.com/webcomponents/polyfills/issues/95 is solved.
+      // Also see: https://github.com/Polymer/lit-element/issues/658
+      // As a temp workaround, we adopt the suggested change of sorvell:
+      // delay the creation of the shadowRoot (see __createRenderRootAndAdoptStyles())
+    }
 
-        render() {
-          return html`
-            <slot></slot>
-          `;
-        }
-      },
-    );
-    const tagWrapper = unsafeStatic(tagWrapperString);
-    const registerSpy = sinon.spy();
-    const el = await fixture(html`
-      <${tagWrapper} @form-element-register=${registerSpy}>
-        <form-registering></form-registering>
-      </${tagWrapper}>
-    `);
-    await el.registrationReady;
-    expect(el.formElements.length).to.equal(1);
-  });
+    __createRenderRootAndAdoptStyles() {
+      this.renderRoot = this.createRenderRoot();
 
-  it('requests update of the resetModelValue function of its parent formGroup', async () => {
-    const ParentFormGroupClass = class extends FormRegistrarMixin(LitElement) {
-      _updateResetModelValue() {
-        this.resetModelValue = 'foo';
+      // Note, if renderRoot is not a shadowRoot, styles would/could apply to the
+      // element's getRootNode(). While this could be done, we're choosing not to
+      // support this now since it would require different logic around de-duping.
+      if (window.ShadowRoot && this.renderRoot instanceof window.ShadowRoot) {
+        this.adoptStyles();
       }
-    };
-    const ChildFormGroupClass = class extends FormRegisteringMixin(LitElement) {
-      constructor() {
-        super();
-        this.__parentFormGroup = this.parentNode;
+
+      this.__hasCreatedRenderRoot = true;
+    }
+
+    /**
+     * @override
+     */
+    update(changedProperties) {
+      if(!this.__hasCreatedRenderRoot) {
+        this.__createRenderRootAndAdoptStyles();
       }
-    };
+      super.update(changedProperties);
+    }
+  }
+);
+// eslint-disable-next-line no-shadow
+const RegistrationParentMixin = dedupeMixin(superclass =>
+  class RegistrationParentMixin extends superclass {
+    constructor() {
+      super();
+      this.formElements = [];
+      this.addEventListener('form-element-register', ({ target }) => this._addChild(target));
+      this.registrationReady = new Promise(resolve => {
+        this.__resolveRegistrationReady = resolve;
+      });
+    }
 
-    const parentClass = defineCE(ParentFormGroupClass);
-    const formGroup = unsafeStatic(parentClass);
-    const childClass = defineCE(ChildFormGroupClass);
-    const childFormGroup = unsafeStatic(childClass);
-    const parentFormEl = await fixture(html`
-      <${formGroup}><${childFormGroup} id="child" name="child[]"></${childFormGroup}></${formGroup}>
-    `);
-    expect(parentFormEl.resetModelValue).to.equal('foo');
+    _addChild(addEl) {
+      this.formElements.push(addEl);
+      addEl.__parentFormGroup = this; // eslint-disable-line no-param-reassign
+    }
+
+    _removeChild(removeEl) {
+      const index = this.formElements.indexOf(removeEl);
+      if (index > -1) {
+        this.formElements.splice(index, 1);
+      }
+    }
+
+    connectedCallback() {
+      if(super.connectedCallback) {
+        super.connectedCallback();
+      }
+      setTimeout(() => {
+        this.__resolveRegistrationReady();
+      });
+    }
+  }
+);
+
+// eslint-disable-next-line no-shadow
+const RegistrationChildMixin = dedupeMixin(superclass =>
+  class RegistrationChildMixin extends superclass {
+    connectedCallback() {
+      if (super.connectedCallback) {
+        super.connectedCallback();
+      }
+      console.log('connected child');
+
+      this.dispatchEvent(new CustomEvent('form-element-register', { bubbles: true, composed: true }));
+    }
+
+    disconnectedCallback() {
+      if (super.disconnectedCallback) {
+        super.disconnectedCallback();
+      }
+      if (this.__parentFormGroup) {
+        this.__parentFormGroup._removeChild(this);
+      }
+    }
+  }
+);
+
+function printSuffix(suffix) {
+  return suffix ? ` (${suffix})` : '';
+}
+
+export const runRegistrationSuite = customConfig => {
+  const cfg = {
+    baseElement: HTMLElement,
+    suffix: null,
+    parentTagString: null,
+    childTagString: null,
+    parentMixin: RegistrationParentMixin,
+    childMixin: RegistrationChildMixin,
+    ...customConfig,
+  };
+
+  let parentTag;
+  let childTag;
+
+  describe.only(`FormRegistrationMixins${printSuffix(cfg.suffix)}`, () => {
+    before(async () => {
+      if (!cfg.parentTagString) {
+        cfg.parentTagString = defineCE(class extends cfg.parentMixin(cfg.baseElement) {});
+      }
+      if (!cfg.childTagString) {
+        cfg.childTagString = defineCE(class extends cfg.childMixin(cfg.baseElement) {});
+      }
+
+      parentTag = unsafeStatic(cfg.parentTagString);
+      childTag = unsafeStatic(cfg.childTagString);
+    });
+
+    it('can register a formElement', async () => {
+      const el = await fixture(html`
+        <${parentTag}>
+          <${childTag}></${childTag}>
+        </${parentTag}>
+      `);
+      await el.registrationReady;
+      expect(el.formElements.length).to.equal(1);
+    });
+
+    it('supports nested registrar', async () => {
+      const el = await fixture(html`
+        <${parentTag}>
+          <${parentTag}>
+            <${childTag}></${childTag}>
+          </${parentTag}>
+        </${parentTag}>
+      `);
+      await el.registrationReady;
+      expect(el.formElements.length).to.equal(1);
+      expect(el.querySelector(cfg.parentTagString).formElements.length).to.equal(1);
+    });
+
+    it('works for component that have a delayed render', async () => {
+      const tagWrapperString = defineCE(
+        class extends cfg.parentMixin(SDPolyfillFixin(LitElement)) {
+          async performUpdate() {
+            await new Promise(resolve => setTimeout(() => resolve(), 10));
+            await super.performUpdate();
+          }
+
+          render() {
+            return html`
+              <slot></slot>
+            `;
+          }
+        },
+      );
+      const tagWrapper = unsafeStatic(tagWrapperString);
+      // const registerSpy = sinon.spy();
+      const el = await fixture(html`
+        <${tagWrapper}>
+          <${childTag}></${childTag}>
+        </${tagWrapper}>
+      `);
+      await el.registrationReady;
+      expect(el.formElements.length).to.equal(1);
+    });
+
+    // TODO: create registration hooks so this logic can be put along reset logic
+    it.skip('requests update of the resetModelValue function of its parent formGroup', async () => {
+      const ParentFormGroupClass = class extends RegistrationParentMixin(LitElement) {
+        _updateResetModelValue() {
+          this.resetModelValue = 'foo';
+        }
+      };
+      const ChildFormGroupClass = class extends RegistrationChildMixin(LitElement) {
+        constructor() {
+          super();
+          this.__parentFormGroup = this.parentNode;
+        }
+      };
+
+      const parentClass = defineCE(ParentFormGroupClass);
+      const formGroup = unsafeStatic(parentClass);
+      const childClass = defineCE(ChildFormGroupClass);
+      const childFormGroup = unsafeStatic(childClass);
+      const parentFormEl = await fixture(html`
+        <${formGroup}><${childFormGroup} id="child" name="child[]"></${childFormGroup}></${formGroup}>
+      `);
+      expect(parentFormEl.resetModelValue).to.equal('foo');
+    });
+
+    it('can dynamically add/remove elements', async () => {
+      const el = await fixture(html`
+        <${parentTag}>
+          <${childTag}></${childTag}>
+        </${parentTag}>
+      `);
+      const newField = await fixture(html`
+        <${childTag}></${childTag}>
+      `);
+
+      expect(el.formElements.length).to.equal(1);
+
+      el.appendChild(newField);
+      expect(el.formElements.length).to.equal(2);
+
+      el.removeChild(newField);
+      expect(el.formElements.length).to.equal(1);
+    });
   });
+};
 
-  it('can dynamically add/remove elements', async () => {
-    const el = await fixture(html`
-      <form-registrar>
-        <form-registering></form-registering>
-      </form-registrar>
-    `);
-    const newField = await fixture(html`
-      <form-registering></form-registering>
-    `);
+runRegistrationSuite({ baseElement: HTMLElement });
 
-    expect(el.formElements.length).to.equal(1);
+runRegistrationSuite({ suffix: 'with UpdatingElement',  baseElement: UpdatingElement });
 
-    el.appendChild(newField);
-    expect(el.formElements.length).to.equal(2);
+runRegistrationSuite({ suffix: 'with shadow dom', baseElement: class ShadowElement extends SDPolyfillFixin(LitElement) {
+  render() {
+    return html`<slot></slot>`;
+  }
+}});
 
-    el.removeChild(newField);
-    expect(el.formElements.length).to.equal(1);
-  });
-});
+// runRegistrationSuite({
+//   suffix: 'with Registrar and UpdatingElement',
+//   baseElement: UpdatingElement,
+//   parentMixin: FormRegistrarMixin,
+//   childMixin: FormRegisteringMixin,
+// });
+
+// runRegistrationSuite({
+//   suffix: 'with Registrar and shadow dom',
+//   baseElement: class ShadowElement extends LitElement {
+//     render() {
+//       return html`<slot></slot>`;
+//     }
+//   },
+//   parentMixin: FormRegistrarMixin,
+//   childMixin: FormRegisteringMixin,
+// });

--- a/packages/field/test/lion-field.test.js
+++ b/packages/field/test/lion-field.test.js
@@ -227,7 +227,7 @@ describe('<lion-field>', () => {
     });
 
     // TODO: put this test on FormControlMixin test once there
-    it(`allows to add to aria description or label via addToAriaLabel() and
+    it.only(`allows to add to aria description or label via addToAriaLabel() and
       addToAriaDescription()`, async () => {
       const wrapper = await fixture(`
         <div id="wrapper">
@@ -242,32 +242,32 @@ describe('<lion-field>', () => {
       const el = wrapper.querySelector(`${tagString}`);
       // wait until the field element is done rendering
       await el.updateComplete;
+      await el.updateComplete;
 
       const { inputElement } = el;
-      const get = by => inputElement.getAttribute(`aria-${by}`);
 
       // 1. addToAriaLabel()
       // Check if the aria attr is filled initially
-      expect(get('labelledby')).to.contain(`label-${el._inputId}`);
+      expect(inputElement.getAttribute('aria-labelledby')).to.contain(`label-${el._inputId}`);
       el.addToAriaLabel('additionalLabel');
       // Now check if ids are added to the end (not overridden)
-      expect(get('labelledby')).to.contain(`label-${el._inputId}`);
+      expect(inputElement.getAttribute('aria-labelledby')).to.contain(`label-${el._inputId}`);
       // Should be placed in the end
       expect(
-        get('labelledby').indexOf(`label-${el._inputId}`) <
-          get('labelledby').indexOf('additionalLabel'),
+        inputElement.getAttribute('aria-labelledby').indexOf(`label-${el._inputId}`) <
+        inputElement.getAttribute('aria-labelledby').indexOf('additionalLabel'),
       );
 
       // 2. addToAriaDescription()
       // Check if the aria attr is filled initially
-      expect(get('describedby')).to.contain(`feedback-${el._inputId}`);
+      expect(inputElement.getAttribute('aria-describedby')).to.contain(`feedback-${el._inputId}`);
       el.addToAriaDescription('additionalDescription');
       // Now check if ids are added to the end (not overridden)
-      expect(get('describedby')).to.contain(`feedback-${el._inputId}`);
+      expect(inputElement.getAttribute('aria-describedby')).to.contain(`feedback-${el._inputId}`);
       // Should be placed in the end
       expect(
-        get('describedby').indexOf(`feedback-${el._inputId}`) <
-          get('describedby').indexOf('additionalDescription'),
+        inputElement.getAttribute('aria-describedby').indexOf(`feedback-${el._inputId}`) <
+        inputElement.getAttribute('aria-describedby').indexOf('additionalDescription'),
       );
     });
   });

--- a/packages/fieldset/src/LionFieldset.js
+++ b/packages/fieldset/src/LionFieldset.js
@@ -159,7 +159,15 @@ export class LionFieldset extends FormRegistrarMixin(
   }
 
   resetGroup() {
-    this.modelValue = this.resetModelValue;
+    this.formElementsArray.forEach(child => {
+      if (typeof child.resetGroup === 'function') {
+        child.resetGroup();
+      } else if (typeof child.reset === 'function') {
+        child.reset();
+      }
+    });
+
+    this.modelValue = this._initialModelValue;
     this.resetInteractionState();
   }
 
@@ -228,7 +236,7 @@ export class LionFieldset extends FormRegistrarMixin(
   }
 
   /**
-   * Get's triggered by event 'validatin-done' which enabled us to handle 2 different situations
+   * Gets triggered by event 'validation-done' which enabled us to handle 2 different situations
    *   - react on modelValue change, which says something about the validity as a whole
    *       (at least two checkboxes for instance) and nothing about the children's values
    *   - children validatity states have changed, so fieldset needs to update itself based on that
@@ -338,23 +346,16 @@ export class LionFieldset extends FormRegistrarMixin(
   }
 
   /**
-   * Updates the resetModelValue of this fieldset and asks it's parent fieldset/group to also
-   * update.
-   * This is needed as the upgrade order is not guaranteed. We have 3 main cases:
-   * 1. if `street-name` gets updated last then `address` and `details` needs to update their
-   *    resetModelValue to also incorporate the correct value of `street-name`/`address`.
-   * 2. If `address` get updated last then it already has the correct `street-name` so it
-   *    requests an update only for `details`.
-   * 3. If `details` get updated last nothing happens here as all data are up to date
-   *
-   * @example
-   * <lion-fieldset name="details">
-   *   <lion-fieldset name="address">
-   *     <lion-input name="street-name" .modelValue=${'street 1'}>
+   * Gathers initial model values of all children. Used
+   * when resetGroup() is called.
    */
-  _updateResetModelValue() {
-    this.resetModelValue = this.modelValue;
-    this._requestParentFormGroupUpdateOfResetModelValue();
+  get _initialModelValue() {
+    return this._getFromAllFormElements('_initialModelValue');
+  }
+
+  /** @deprecated */
+  get resetModelValue() {
+    return this._initialModelValue;
   }
 
   /**

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -22,7 +22,7 @@ function detectInteractionMode() {
 /**
  * LionSelectRich: wraps the <lion-listbox> element
  *
- * @customElement
+ * @customElement lion-select-rich
  * @extends LionField
  */
 export class LionSelectRich extends FormRegistrarMixin(
@@ -90,9 +90,7 @@ export class LionSelectRich extends FormRegistrarMixin(
   get slots() {
     return {
       ...super.slots,
-      invoker: () => {
-        return document.createElement('lion-select-invoker');
-      },
+      invoker: () => document.createElement('lion-select-invoker'),
     };
   }
 
@@ -145,10 +143,8 @@ export class LionSelectRich extends FormRegistrarMixin(
     this.__setupEventListeners();
   }
 
-  connectedCallback() {
-    if (super.connectedCallback) {
-      super.connectedCallback();
-    }
+  firstUpdated(c) {
+    super.firstUpdated(c);
 
     this.__setupOverlay();
     this.__setupInvokerNode();


### PR DESCRIPTION
Also see: https://github.com/ing-bank/lion/issues/215
Fixes https://github.com/ing-bank/lion/issues/231

Alternative approach to form registration mechanism that makes the registration code simple again and forwards compatible after this issue is handled: https://github.com/Polymer/lit-element/issues/658

### How it works
It patches LitElement, that creates a shadowRoot and then renders async, which causes all events in between those (shadowRoot creation and rendering) to get lost in polyfilled browsers

Until https://github.com/webcomponents/polyfills/issues/95 is released, we need to keep this patch for LitElement. After that, we can just remove the patch mixin and everything should work as before.

TODO:
- remove legacy code with form-element-unregister events
- split up code in separate files
- make the registering logic (including LitElement patch) less obtrusive in our form core(=field package) by putting it in a separate folder
- document migration strategy when shadydom polyfill is fixed
- clean up karma changes and/or make separate commits