### PR TITLE
fix(localize): for bg-BG locale, correct Intl output for group separator

### DIFF
--- a/packages/localize/src/number/forceSpaceInsteadOfZeroForGroup.js
+++ b/packages/localize/src/number/forceSpaceInsteadOfZeroForGroup.js
@@ -1,0 +1,14 @@
+/**
+ * @desc Intl uses 0 as group separator for bg-BG locale.
+ * This should be a ' '
+ * @param {{type,value}[]} formattedParts
+ * @returns {{type,value}[]} corrected formatted parts
+ */
+export function forceSpaceInsteadOfZeroForGroup(formattedParts) {
+  return formattedParts.map(p => {
+    if (p.type === 'group' && p.value === '0') {
+      p.value = ' '; // eslint-disable-line no-param-reassign
+    }
+    return p;
+  });
+}

--- a/packages/localize/src/number/normalizeIntl.js
+++ b/packages/localize/src/number/normalizeIntl.js
@@ -4,6 +4,7 @@ import { forceCurrencyToEnd } from './forceCurrencyToEnd.js';
 import { forceNormalSpaces } from './forceNormalSpaces.js';
 import { forceSpaceBetweenCurrencyCodeAndNumber } from './forceSpaceBetweenCurrencyCodeAndNumber.js';
 import { forceYenSymbol } from './forceYenSymbol.js';
+import { forceSpaceInsteadOfZeroForGroup } from './forceSpaceInsteadOfZeroForGroup.js';
 
 /**
  * Function with all fixes on localize
@@ -23,6 +24,7 @@ export function normalizeIntl(formattedParts, options, _locale) {
     // Add group separator for Bulgarian locale
     if (_locale === 'bg-BG') {
       normalize = forceAddGroupSeparators(normalize, getGroupSeparator());
+      normalize = forceSpaceInsteadOfZeroForGroup(normalize);
     }
     // Force space between currency code and number
     if (_locale === 'en-GB' || _locale === 'en-US' || _locale === 'en-AU') {


### PR DESCRIPTION
fixes https://github.com/ing-bank/lion/issues/229