### PR TITLE
fix(localize): update the way to obtain the group separator for a number

### DIFF
--- a/packages/localize/src/number/getGroupSeparator.js
+++ b/packages/localize/src/number/getGroupSeparator.js
@@ -12,6 +12,6 @@ export function getGroupSeparator(locale) {
   const formattedNumber = Intl.NumberFormat(computedLocale, {
     style: 'decimal',
     minimumFractionDigits: 0,
-  }).format('1000');
-  return normalSpaces(formattedNumber[1]);
+  }).format('10000');
+  return normalSpaces(formattedNumber[2]);
 }

--- a/packages/localize/test/number/getGroupSeparator.test.js
+++ b/packages/localize/test/number/getGroupSeparator.test.js
@@ -7,5 +7,6 @@ describe('getGroupSeparator', () => {
     expect(getGroupSeparator('en-GB')).to.equal(',');
     expect(getGroupSeparator('nl-NL')).to.equal('.');
     expect(getGroupSeparator('fr-FR')).to.equal(' ');
+    expect(getGroupSeparator('es-ES')).to.equal('.');
   });
 });


### PR DESCRIPTION
four digit numbers can be written without separator, so it would be
safer to obtain the separator by formatting a five digit number. The bug
was found with the locale 'es-ES', where the format returned for '1000'
was '1000' instead of the expected '1.000'. We add the specific expect
clause on the test for it.

 On branch fix/numberGroupSeparator
 Changes to be committed:
	modified:   packages/localize/src/number/getGroupSeparator.js
	modified:   packages/localize/test/number/getGroupSeparator.test.js