### PR TITLE
Localize: add expect to test consistent bg-BG group separator

### DIFF
--- a/packages/localize/test/number/getGroupSeparator.test.js
+++ b/packages/localize/test/number/getGroupSeparator.test.js
@@ -8,5 +8,6 @@ describe('getGroupSeparator', () => {
     expect(getGroupSeparator('nl-NL')).to.equal('.');
     expect(getGroupSeparator('fr-FR')).to.equal(' ');
     expect(getGroupSeparator('es-ES')).to.equal('.');
+    expect(getGroupSeparator('bg-BG')).to.equal(' ');
   });
 });


### PR DESCRIPTION
~We added a specific bg-BG rule, which now turns out to be:~
- ~Unnecessary, because Intl does it correctly if you get the group separator by formatting a 5 digit number, rather than a 4 digit number (1000-9999). This was fixed in https://github.com/ing-bank/lion/pull/245~
- ~Incorrect. You should not always force the space. For example, if the type is currency, for bg-BG, no spaces are ever added as group separator according to what Intl does at least..~

~This change fixes a bug where bg-BG currencies with 4 or more digits would display with space group separators, and it gets rid of quite some technical debt that we added to 'normalize' it.~