### PR TITLE
fix(field): implement FormRegistrarPortalMixin

### DIFF
--- a/packages/field/index.js
+++ b/packages/field/index.js
@@ -6,3 +6,4 @@ export { InteractionStateMixin } from './src/InteractionStateMixin.js'; // appli
 export { LionField } from './src/LionField.js';
 export { FormRegisteringMixin } from './src/FormRegisteringMixin.js';
 export { FormRegistrarMixin } from './src/FormRegistrarMixin.js';
+export { FormRegistrarPortalMixin } from './src/FormRegistrarPortalMixin.js';

--- a/packages/field/src/FormRegistrarPortalMixin.js
+++ b/packages/field/src/FormRegistrarPortalMixin.js
@@ -1,0 +1,55 @@
+import { dedupeMixin } from '@lion/core';
+import { formRegistrarManager } from './formRegistrarManager.js';
+
+/**
+ * This will forward
+ */
+export const FormRegistrarPortalMixin = dedupeMixin(
+  superclass =>
+    // eslint-disable-next-line no-shadow, no-unused-vars
+    class FormRegistrarPortalMixin extends superclass {
+      constructor() {
+        super();
+        this.formElements = [];
+        this.__readyForRegistration = false;
+        this.registrationReady = new Promise(resolve => {
+          this.__resolveRegistrationReady = resolve;
+        });
+      }
+
+      connectedCallback() {
+        if (super.connectedCallback) {
+          super.connectedCallback();
+        }
+        formRegistrarManager.add(this);
+        this.__redispatchEventForFormRegistrarPortalMixin = ev => {
+          ev.stopPropagation();
+          // TODO: fire event with changed ev.target
+          this.dispatchEvent(
+            new CustomEvent('form-element-register', {
+              detail: { element: ev.element },
+              bubbles: true,
+            }),
+          );
+        };
+        this.addEventListener(
+          'form-element-register',
+          this.__redispatchEventForFormRegistrarPortalMixin,
+        );
+      }
+
+      disconnectedCallback() {
+        if (super.disconnectedCallback) {
+          super.disconnectedCallback();
+        }
+        formRegistrarManager.remove(this);
+      }
+
+      firstUpdated(changedProperties) {
+        super.firstUpdated(changedProperties);
+        this.__resolveRegistrationReady();
+        this.__readyForRegistration = true;
+        formRegistrarManager.becomesReady(this);
+      }
+    },
+);

--- a/packages/input-email/stories/index.stories.js
+++ b/packages/input-email/stories/index.stories.js
@@ -19,7 +19,7 @@ storiesOf('Forms|Input Email', module)
   )
   .add('Use own validator', () => {
     const gmailOnly = modelValue => ({ gmailOnly: modelValue.indexOf('gmail.com') !== -1 });
-    localize.locale = 'en';
+    localize.locale = 'en-GB';
 
     try {
       localize.addData('en', 'lion-validate+gmailOnly', {

--- a/packages/localize/RATIONALE.md
+++ b/packages/localize/RATIONALE.md
@@ -46,6 +46,8 @@ We chose `Intl MessageFormat` as a format for translation parts because:
 
 ### Fallbacks
 
+> Important: language-only locales are now deprecated, and cause a warning. This is because language only locales cause bugs with date and number formatting. It also makes writing locale based tooling harder and more cumbersome. Usage is highly discouraged.
+
 We decided to have a fallback mechanism in case a dialect (e.g. `nl-NL.js`) is not defined, but generic language (e.g. `nl.js`) is, because we wanted to support legacy applications which used [Polymer's AppLocalizeBehavior](https://polymer-library.polymer-project.org/3.0/docs/apps/localize) and could not instantly switch to using full dialects.
 
 We decided to have a fallback locale (`en-GB` by default):

--- a/packages/localize/README.md
+++ b/packages/localize/README.md
@@ -177,6 +177,8 @@ Due to the need to develop application code with not everything translated (yet)
 By default the fallback is `en-GB`, meaning that if some namespace does not have data for the current page locale, the `en-GB` will be loaded, making it an important foundation for all other locales data.
 In addition to that the fallback is a necessary mechanism to allow some features of the browsers like Google Chrome translate to work and use the same original data for translations into all not officially supported languages.
 
+> We highly discourage using fallback locales as a user, because it is bug-prone with things like date and number formatting. Please use full locales whenever possible.
+
 ### Rendering data
 
 When all necessary data are loaded and you want to show localized content on the page you need to format the data.

--- a/packages/localize/src/LocalizeManager.js
+++ b/packages/localize/src/LocalizeManager.js
@@ -42,6 +42,14 @@ export class LocalizeManager extends LionSingleton {
     document.documentElement.lang = value;
     this._setupHtmlLangAttributeObserver();
 
+    if (!value.includes('-')) {
+      console.warn(`
+        Locale was set to ${value}.
+        Language only locales are deprecated, please use the full language locale e.g. 'en-GB' instead of 'en'.
+        See https://github.com/ing-bank/lion/issues/187 for more information.
+      `);
+    }
+
     this._onLocaleChanged(value, oldLocale);
   }
 

--- a/packages/localize/test/LocalizeManager.test.js
+++ b/packages/localize/test/LocalizeManager.test.js
@@ -302,6 +302,25 @@ describe('LocalizeManager', () => {
 
         throw new Error('did not throw');
       });
+
+      it('throws a warning if the locale set by the user is not a full language locale', async () => {
+        const spy = sinon.spy(console, 'warn');
+        manager = new LocalizeManager();
+        manager.locale = 'nl';
+
+        expect(spy.callCount).to.equal(1);
+        console.warn.restore();
+      });
+
+      it('does not throw a warning if locale was set through the html lang attribute', async () => {
+        const spy = sinon.spy(console, 'warn');
+        manager = new LocalizeManager();
+        document.documentElement.lang = 'nl';
+        await aTimeout(50); // wait for mutation observer to be called
+
+        expect(spy.callCount).to.equal(0);
+        console.warn.restore();
+      });
     });
   });
 

--- a/packages/localize/test/date/formatDate.test.js
+++ b/packages/localize/test/date/formatDate.test.js
@@ -56,7 +56,7 @@ describe('formatDate', () => {
       day: '2-digit',
       locale: 'en-US',
     };
-    localize.locale = 'bg';
+    localize.locale = 'bg-BG';
     let date = parseDate('29-12-2017');
     expect(formatDate(date)).to.equal('29.12.2017 г.');
 

--- a/packages/steps/stories/index.stories.js
+++ b/packages/steps/stories/index.stories.js
@@ -8,47 +8,77 @@ storiesOf('Steps|Steps', module)
   .add(
     'Default',
     () => html`
-      <lion-steps id="stepsController">
+      <lion-steps>
         <lion-step initial-step>
           <p>Welcome</p>
           <button disabled>previous</button> &nbsp;
-          <input type="button" value="next" @click=${() => stepsController.next()} />
+          <input
+            type="button"
+            value="next"
+            @click=${ev => ev.target.parentElement.controller.next()}
+          />
         </lion-step>
         <lion-step>
           <p>Are you single?</p>
           <input
             type="button"
             value="yes"
-            @click=${() => {
-              stepsController.data.isSingle = true;
-              stepsController.next();
+            @click=${ev => {
+              ev.target.parentElement.controller.data.isSingle = true;
+              ev.target.parentElement.controller.next();
             }}
           />
           &nbsp;
           <input
             type="button"
             value="no"
-            @click=${() => {
-              stepsController.data.isSingle = false;
-              stepsController.next();
+            @click=${ev => {
+              ev.target.parentElement.controller.data.isSingle = false;
+              ev.target.parentElement.controller.next();
             }}
           />
           <br /><br />
-          <input type="button" value="previous" @click=${() => stepsController.previous()} />
+          <input
+            type="button"
+            value="previous"
+            @click=${ev => ev.target.parentElement.controller.previous()}
+          />
         </lion-step>
         <lion-step id="is-single" .condition="${data => data.isSingle}">
           <p>You are single</p>
-          <input type="button" value="previous" @click=${() => stepsController.previous()} /> &nbsp;
-          <input type="button" value="next" @click=${() => stepsController.next()} />
+          <input
+            type="button"
+            value="previous"
+            @click=${ev => ev.target.parentElement.controller.previous()}
+          />
+          &nbsp;
+          <input
+            type="button"
+            value="next"
+            @click=${ev => ev.target.parentElement.controller.next()}
+          />
         </lion-step>
         <lion-step id="is-not-single" .condition="${data => data.isSingle}" invert-condition>
           <p>You are NOT single.</p>
-          <input type="button" value="previous" @click=${() => stepsController.previous()} /> &nbsp;
-          <input type="button" value="next" @click=${() => stepsController.next()} />
+          <input
+            type="button"
+            value="previous"
+            @click=${ev => ev.target.parentElement.controller.previous()}
+          />
+          &nbsp;
+          <input
+            type="button"
+            value="next"
+            @click=${ev => ev.target.parentElement.controller.next()}
+          />
         </lion-step>
         <lion-step>
           <p>Finish</p>
-          <input type="button" value="previous" @click=${() => stepsController.previous()} />
+          <input
+            type="button"
+            value="previous"
+            @click=${ev => ev.target.parentElement.controller.previous()}
+          />
         </lion-step>
       </lion-steps>
     `,


### PR DESCRIPTION
Proposal for `FormRegistrationMixins.js`.
the `FormRegistrarPortalMixin` forwards the event to a specific target node so Registering Child does not need to be in the dom tree of the Registrar Parent.