### PR TITLE
Fix: pass string instead of object in input-amount parser

### DIFF
--- a/packages/input-amount/src/parsers.js
+++ b/packages/input-amount/src/parsers.js
@@ -60,7 +60,8 @@ function getParseMode(value) {
  * @param {object} options Locale Options
  */
 function parseWithLocale(value, options) {
-  const separator = getDecimalSeparator(options);
+  const locale = options && options.locale ? options.locale : null;
+  const separator = getDecimalSeparator(locale);
   const regexNumberAndLocaleSeparator = new RegExp(`[0-9${separator}-]`, 'g');
   let numberAndLocaleSeparator = value.match(regexNumberAndLocaleSeparator).join('');
   if (separator === ',') {

--- a/packages/input-amount/test/parsers.test.js
+++ b/packages/input-amount/test/parsers.test.js
@@ -145,4 +145,17 @@ describe('parseAmount()', () => {
   it('returns undefined when value is empty string', () => {
     expect(parseAmount('')).to.equal(undefined);
   });
+
+  it('parseAmount with locale set and length is more than four', () => {
+    expect(
+      parseAmount('6,000', {
+        locale: 'gb-GB',
+      }),
+    ).to.equal(6000);
+    expect(
+      parseAmount('6.000', {
+        locale: 'es-ES',
+      }),
+    ).to.equal(6000);
+  });
 });


### PR DESCRIPTION
Fix parseWithLocale function: Pass a string instead of an object to getDecimalSeparator and getLocale. Test added that fails before the fix.

fixes https://github.com/ing-bank/lion/issues/258