### PR TITLE
Fix a11y - use proper minus sign unicode that most SRs understand

### DIFF
--- a/packages/input-amount/test/formatters.test.js
+++ b/packages/input-amount/test/formatters.test.js
@@ -60,7 +60,7 @@ describe('formatAmount()', () => {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       }),
-    ).to.equal('-12.35');
+    ).to.equal('−12.35');
   });
 
   it('formats the right amount of fraction digits for a certain currency', async () => {

--- a/packages/localize/src/number/formatNumberToParts.js
+++ b/packages/localize/src/number/formatNumberToParts.js
@@ -28,7 +28,14 @@ export function formatNumberToParts(number, options) {
   const formattedNumber = Intl.NumberFormat(computedLocale, options).format(parsedNumber);
   const regexSymbol = /[A-Z.,\s0-9]/;
   const regexCode = /[A-Z]/;
-  const regexMinusSign = /[-]/;
+
+  /**
+   * TODO: Preprocessor should convert other "dashes" unicodes to &minus;
+   * Then our regex should test for &minus;
+   * See also https://www.deque.com/blog/dont-screen-readers-read-whats-screen-part-1-punctuation-typographic-symbols/
+   */
+  const regexMinusSign = /[-]/; // U+002D, Hyphen-Minus, &#45;  is what we test on for now, since most keyboards give you this for dash
+
   const regexNum = /[0-9]/;
   const regexSeparator = /[.,]/;
   const regexSpace = /[\s]/;
@@ -38,7 +45,7 @@ export function formatNumberToParts(number, options) {
   for (let i = 0; i < formattedNumber.length; i += 1) {
     // detect minusSign
     if (regexMinusSign.test(formattedNumber[i])) {
-      formattedParts.push({ type: 'minusSign', value: formattedNumber[i] });
+      formattedParts.push({ type: 'minusSign', value: '−' /* U+2212, 'Minus-Sign', &minus; */ });
     }
     // detect numbers
     if (regexNum.test(formattedNumber[i])) {

--- a/packages/localize/src/number/formatNumberToParts.js
+++ b/packages/localize/src/number/formatNumberToParts.js
@@ -29,12 +29,8 @@ export function formatNumberToParts(number, options) {
   const regexSymbol = /[A-Z.,\s0-9]/;
   const regexCode = /[A-Z]/;
 
-  /**
-   * TODO: Preprocessor should convert other "dashes" unicodes to &minus;
-   * Then our regex should test for &minus;
-   * See also https://www.deque.com/blog/dont-screen-readers-read-whats-screen-part-1-punctuation-typographic-symbols/
-   */
-  const regexMinusSign = /[-]/; // U+002D, Hyphen-Minus, &#45;  is what we test on for now, since most keyboards give you this for dash
+  // U+002D, Hyphen-Minus, &#45;
+  const regexMinusSign = /[-]/;
 
   const regexNum = /[0-9]/;
   const regexSeparator = /[.,]/;

--- a/packages/localize/test/number/formatNumber.test.js
+++ b/packages/localize/test/number/formatNumber.test.js
@@ -27,32 +27,32 @@ describe('formatNumber', () => {
     expect(formatNumber(123456.789, currencySymbol('USD'))).to.equal('$123,456.79');
   });
 
-  it('uses minus (and not dash) to indicate negative numbers ', () => {
-    expect(formatNumber(-12, { style: 'decimal', maximumFractionDigits: 0 })).to.equal('-12');
+  it('uses minus U+2212 (and not dash) to indicate negative numbers ', () => {
+    expect(formatNumber(-12, { style: 'decimal', maximumFractionDigits: 0 })).to.equal('−12');
   });
 
   it('rounds (negative) numbers e.g. `roundMode: round`', () => {
     expect(formatNumber(12.4, { roundMode: 'round' })).to.equal('12');
     expect(formatNumber(12.6, { roundMode: 'round' })).to.equal('13');
 
-    expect(formatNumber(-12.4, { roundMode: 'round' })).to.equal('-12');
-    expect(formatNumber(-12.6, { roundMode: 'round' })).to.equal('-13');
+    expect(formatNumber(-12.4, { roundMode: 'round' })).to.equal('−12');
+    expect(formatNumber(-12.6, { roundMode: 'round' })).to.equal('−13');
   });
 
   it("rounds (negative) numbers up when `roundMode: 'ceiling'`", () => {
     expect(formatNumber(12.4, { roundMode: 'ceiling' })).to.equal('13');
     expect(formatNumber(12.6, { roundMode: 'ceiling' })).to.equal('13');
 
-    expect(formatNumber(-12.4, { roundMode: 'ceiling' })).to.equal('-12');
-    expect(formatNumber(-12.6, { roundMode: 'ceiling' })).to.equal('-12');
+    expect(formatNumber(-12.4, { roundMode: 'ceiling' })).to.equal('−12');
+    expect(formatNumber(-12.6, { roundMode: 'ceiling' })).to.equal('−12');
   });
 
   it('rounds (negative) numbers down when `roundMode: floor`', () => {
     expect(formatNumber(12.4, { roundMode: 'floor' })).to.equal('12');
     expect(formatNumber(12.6, { roundMode: 'floor' })).to.equal('12');
 
-    expect(formatNumber(-12.4, { roundMode: 'floor' })).to.equal('-13');
-    expect(formatNumber(-12.6, { roundMode: 'floor' })).to.equal('-13');
+    expect(formatNumber(-12.4, { roundMode: 'floor' })).to.equal('−13');
+    expect(formatNumber(-12.6, { roundMode: 'floor' })).to.equal('−13');
   });
 
   it('returns empty string when NaN', () => {

--- a/packages/localize/test/number/formatNumberToParts.test.js
+++ b/packages/localize/test/number/formatNumberToParts.test.js
@@ -10,7 +10,7 @@ const i = v => ({ type: 'integer', value: v });
 const f = v => ({ type: 'fraction', value: v });
 const g = v => ({ type: 'group', value: v });
 const l = v => ({ type: 'literal', value: v });
-const m = { type: 'minusSign', value: '-' };
+const m = { type: 'minusSign', value: '−' };
 
 const stringifyParts = parts => parts.map(part => part.value).join('');
 


### PR DESCRIPTION
It is important, mostly for screen readers, that when we format numbers, that we use proper minus sign unicode for negative numbers. 

https://www.deque.com/blog/dont-screen-readers-read-whats-screen-part-1-punctuation-typographic-symbols/

This goes into detail a bit more, but to me it seems like screen readers will have more success with this unicode, compared to the old unicode Hyphen-minus.

Old: https://www.compart.com/en/unicode/U+002D
New: https://www.compart.com/en/unicode/U+2212

Tagging a11y guru @erikkroes 

For discussion:
https://github.com/ing-bank/lion/issues/280