### PR TITLE
fix(calendar): render the calendar when min and max date are same date

### DIFF
--- a/packages/calendar/src/LionCalendar.js
+++ b/packages/calendar/src/LionCalendar.js
@@ -430,6 +430,13 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
       this.minDate && this.minDate > date ? new Date(this.minDate) : new Date(date);
     const pastDate = this.maxDate && this.maxDate < date ? new Date(this.maxDate) : new Date(date);
 
+    if (this.minDate && this.minDate > date) {
+      futureDate.setDate(futureDate.getDate() - 1);
+    }
+    if (this.maxDate && this.maxDate < date) {
+      pastDate.setDate(pastDate.getDate() + 1);
+    }
+
     let i = 0;
     do {
       i += 1;

--- a/packages/calendar/test/lion-calendar.test.js
+++ b/packages/calendar/test/lion-calendar.test.js
@@ -339,6 +339,20 @@ describe('<lion-calendar>', () => {
         clock.restore();
       });
 
+      it('should set centralDate to the unique valid value when minDate and maxDate are equal', async () => {
+        const clock = sinon.useFakeTimers({ now: new Date('2019/06/03').getTime() });
+
+        const el = await fixture(html`
+          <lion-calendar
+            .minDate="${new Date('2019/07/03')}"
+            .maxDate="${new Date('2019/07/03')}"
+          ></lion-calendar>
+        `);
+        expect(isSameDate(el.centralDate, new Date('2019/07/03')), 'central date').to.be.true;
+
+        clock.restore();
+      });
+
       describe('Normalization', () => {
         it('normalizes all generated dates', async () => {
           function isNormalizedDate(d) {
@@ -504,7 +518,7 @@ describe('<lion-calendar>', () => {
         elObj.previousMonthButtonEl.click();
         await el.updateComplete;
         expect(elObj.activeMonthAndYear).to.equal('November 2000');
-        expect(isSameDate(el.centralDate, new Date('2000/11/21'))).to.be.true;
+        expect(isSameDate(el.centralDate, new Date('2000/11/20'))).to.be.true;
 
         clock.restore();
       });
@@ -527,7 +541,7 @@ describe('<lion-calendar>', () => {
         elObj.nextMonthButtonEl.click();
         await el.updateComplete;
         expect(elObj.activeMonthAndYear).to.equal('January 2001');
-        expect(isSameDate(el.centralDate, new Date('2001/01/09'))).to.be.true;
+        expect(isSameDate(el.centralDate, new Date('2001/01/10'))).to.be.true;
 
         clock.restore();
       });


### PR DESCRIPTION
It is an edge case, but when trying to render a calendar which has `minDate` and `maxDate` with the same date, and this date is not today, the calendar can't render since tries to select a `centralDate` outside the valid date range.

When the date is "today", everything goes as expected, but when it is a future or a past date, the calendar throws an error at `__findBestEnabledDateFor`.

I'm providing a test to this feature, and I did change two values within two tests, which I think they make sense. `centralDate` was calculated as the next day from the `minDate` value, or the day before from the `maxDate` value, EXCEPT when `minDate` is lower than today, or `maxDate` is greater (and we only provide one validator), or when the range between `minDate` and `maxDate` contains today.

