### PR TITLE
fix(form-registering-mixin): remove 'all-forms-open-for-registration' on disconnected

### DIFF
--- a/packages/field/src/FormRegisteringMixin.js
+++ b/packages/field/src/FormRegisteringMixin.js
@@ -26,7 +26,7 @@ export const FormRegisteringMixin = dedupeMixin(
         }
         formRegistrarManager.removeEventListener(
           'all-forms-open-for-registration',
-          this._dispatchRegistration(),
+          this._dispatchRegistration,
         );
         this._unregisterFormElement();
       }
@@ -37,7 +37,7 @@ export const FormRegisteringMixin = dedupeMixin(
         } else {
           formRegistrarManager.addEventListener(
             'all-forms-open-for-registration',
-            this._dispatchRegistration(),
+            this._dispatchRegistration,
           );
         }
       }

--- a/packages/field/src/FormRegisteringMixin.js
+++ b/packages/field/src/FormRegisteringMixin.js
@@ -24,6 +24,10 @@ export const FormRegisteringMixin = dedupeMixin(
         if (super.disconnectedCallback) {
           super.disconnectedCallback();
         }
+        formRegistrarManager.removeEventListener(
+          'all-forms-open-for-registration',
+          this._dispatchRegistration(),
+        );
         this._unregisterFormElement();
       }
 
@@ -31,9 +35,10 @@ export const FormRegisteringMixin = dedupeMixin(
         if (formRegistrarManager.ready) {
           this._dispatchRegistration();
         } else {
-          formRegistrarManager.addEventListener('all-forms-open-for-registration', () => {
-            this._dispatchRegistration();
-          });
+          formRegistrarManager.addEventListener(
+            'all-forms-open-for-registration',
+            this._dispatchRegistration(),
+          );
         }
       }
 


### PR DESCRIPTION
**Problem**
Listener 'all-forms-open-for-registration' from FormRegisteringMixin.js line 34 is never removed, causing memory leaks and errors in multiple component registration

I think it could be removed on `disconnectedCallback()` like many others.