### PR TITLE
[button] Guard against _nativeButton not defined

### DIFF
--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -175,7 +175,7 @@ export class LionButton extends DisabledWithTabIndexMixin(SlotMixin(LitElement))
    * Dispatch submit event and invoke submit on the native form when clicked
    */
   __clickDelegationHandler() {
-    if (this.type === 'submit' && this._nativeButtonNode.form) {
+    if (this.type === 'submit' && this._nativeButtonNode && this._nativeButtonNode.form) {
       this._nativeButtonNode.form.dispatchEvent(new Event('submit'));
       this._nativeButtonNode.form.submit();
     }


### PR DESCRIPTION
Not sure how I produced an error using this but I managed to get errors "cannot read form of undefined" so I figured adding this guard is probably a good idea.