### PR TITLE
fix(radio-group): change check of value to only null or undefined

### DIFF
--- a/packages/radio-group/src/LionRadioGroup.js
+++ b/packages/radio-group/src/LionRadioGroup.js
@@ -94,7 +94,7 @@ export class LionRadioGroup extends LionFieldset {
 
   __triggerCheckedValueChanged() {
     const value = this.checkedValue;
-    if (value && value !== this.__previousCheckedValue) {
+    if (value != null && value !== this.__previousCheckedValue) {
       this.dispatchEvent(
         new CustomEvent('checked-value-changed', { bubbles: true, composed: true }),
       );

--- a/packages/radio-group/test/lion-radio-group.test.js
+++ b/packages/radio-group/test/lion-radio-group.test.js
@@ -36,6 +36,20 @@ describe('<lion-radio-group>', () => {
     expect(el.checkedValue).to.deep.equal({ some: 'data' });
   });
 
+  it('can handle 0 and empty string as valid values ', async () => {
+    const el = await fixture(html`
+      <lion-radio-group>
+        <lion-radio name="data[]" .choiceValue=${0} .choiceChecked=${true}></lion-radio>
+        <lion-radio name="data[]" .choiceValue=${''}></lion-radio>
+      </lion-radio-group>
+    `);
+    await nextFrame();
+
+    expect(el.checkedValue).to.equal(0);
+    el.formElementsArray[1].choiceChecked = true;
+    expect(el.checkedValue).to.equal('');
+  });
+
   it('still has a full modelValue ', async () => {
     const el = await fixture(html`
       <lion-radio-group>


### PR DESCRIPTION
When a radio-button has a modelValue.value of number 0, then the radio-button-group fails to send 'checked-value-changed' event.

This change checks only for null or undefined. I saw at line 30 in the get checkedValue() that if no el is present, there it returns an empty string. That empty string will not be caught with this fix and will sent the 'checked-value-changed' event. I am not sure if that would be ok or not so I haven't yet changed that.