### PR TITLE
feat(core): export Part classes from lit-html

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -14,6 +14,12 @@ export {
   isDirective,
   TemplateResult,
   SVGTemplateResult,
+  AttributePart,
+  BooleanAttributePart,
+  EventPart,
+  NodePart,
+  PropertyPart,
+  isPrimitive,
 } from 'lit-html';
 export { render as renderShady } from 'lit-html/lib/shady-render.js';
 export { asyncAppend } from 'lit-html/directives/async-append.js';


### PR DESCRIPTION
I need to use lit-html Parts for directives I'm writing internally, but they're not exported by lion.

We don't need this if we decide to go for https://github.com/ing-bank/lion/pull/341 instead