### PR TITLE
feat(core): use export star for lit-html and lit-element

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -4,17 +4,7 @@
  */
 
 // lit-html
-export {
-  html,
-  svg,
-  render,
-  noChange,
-  nothing,
-  directive,
-  isDirective,
-  TemplateResult,
-  SVGTemplateResult,
-} from 'lit-html';
+export * from 'lit-html';
 export { render as renderShady } from 'lit-html/lib/shady-render.js';
 export { asyncAppend } from 'lit-html/directives/async-append.js';
 export { asyncReplace } from 'lit-html/directives/async-replace.js';
@@ -27,24 +17,7 @@ export { styleMap } from 'lit-html/directives/style-map.js';
 export { unsafeHTML } from 'lit-html/directives/unsafe-html.js';
 export { until } from 'lit-html/directives/until.js';
 // lit-element
-export {
-  LitElement,
-  // css-tag.js
-  supportsAdoptingStyleSheets,
-  CSSResult,
-  unsafeCSS,
-  css,
-  // updating-element.js
-  defaultConverter,
-  notEqual,
-  UpdatingElement,
-  // decorators.js
-  customElement,
-  property,
-  query,
-  queryAll,
-  eventOptions,
-} from 'lit-element';
+export * from 'lit-element';
 // ours
 export { dedupeMixin } from './src/dedupeMixin.js';
 export { DelegateMixin } from './src/DelegateMixin.js';

--- a/packages/core/test/DisabledMixin.test.js
+++ b/packages/core/test/DisabledMixin.test.js
@@ -1,5 +1,6 @@
 import { expect, fixture, html } from '@open-wc/testing';
 
+/* eslint-disable import/named */
 import { LitElement } from '../index.js';
 import { DisabledMixin } from '../src/DisabledMixin.js';
 

--- a/packages/core/test/DisabledWithTabIndexMixin.test.js
+++ b/packages/core/test/DisabledWithTabIndexMixin.test.js
@@ -1,5 +1,6 @@
 import { expect, fixture, html } from '@open-wc/testing';
 
+/* eslint-disable import/named */
 import { LitElement } from '../index.js';
 import { DisabledWithTabIndexMixin } from '../src/DisabledWithTabIndexMixin.js';
 


### PR DESCRIPTION
A followup from https://github.com/ing-bank/lion/pull/340

I think we can just proxy all exports from `lit-html` and `lit-element`. Surprisingly the browser is able to dedupe the conflicting `html` exports from both packages because they eventually point to the same variable.

For some reason eslint doesn't like this setup when importing from `index.js` inside core, while it runs fine in the browser and for other packages importing from core it's fine as well.