### PR TITLE
fix: resetgroup

### DIFF
--- a/packages/fieldset/src/LionFieldset.js
+++ b/packages/fieldset/src/LionFieldset.js
@@ -223,9 +223,8 @@ export class LionFieldset extends FormRegistrarMixin(
   }
 
   async resetGroup() {
-    if (!this.submitted) {
-      await this.updateComplete;
-    }
+    // To ensure resetting happens after submission process, in case it was fired right before reset
+    await this.updateComplete;
     this.formElementsArray.forEach(child => {
       if (typeof child.resetGroup === 'function') {
         child.resetGroup();

--- a/packages/fieldset/src/LionFieldset.js
+++ b/packages/fieldset/src/LionFieldset.js
@@ -222,9 +222,7 @@ export class LionFieldset extends FormRegistrarMixin(
     return serializedValues;
   }
 
-  async resetGroup() {
-    // To ensure resetting happens after submission process, in case it was fired right before reset
-    await this.updateComplete;
+  resetGroup() {
     this.formElementsArray.forEach(child => {
       if (typeof child.resetGroup === 'function') {
         child.resetGroup();
@@ -236,7 +234,9 @@ export class LionFieldset extends FormRegistrarMixin(
     this.resetInteractionState();
   }
 
-  resetInteractionState() {
+  async resetInteractionState() {
+    // To ensure resetting happens after submission process, in case it was fired right before reset
+    await this.updateComplete;
     // TODO: add submitted prop to InteractionStateMixin
     this.submitted = false;
     this.touched = false;

--- a/packages/fieldset/src/LionFieldset.js
+++ b/packages/fieldset/src/LionFieldset.js
@@ -222,7 +222,10 @@ export class LionFieldset extends FormRegistrarMixin(
     return serializedValues;
   }
 
-  resetGroup() {
+  async resetGroup() {
+    if (!this.submitted) {
+      await this.updateComplete;
+    }
     this.formElementsArray.forEach(child => {
       if (typeof child.resetGroup === 'function') {
         child.resetGroup();

--- a/packages/fieldset/test/lion-fieldset.test.js
+++ b/packages/fieldset/test/lion-fieldset.test.js
@@ -646,6 +646,7 @@ describe('<lion-fieldset>', () => {
       expect(input.modelValue).to.equal('Bar');
 
       el.resetGroup();
+      await nextFrame();
       expect(el.modelValue).to.deep.equal({ firstName: 'Foo' });
       expect(input.modelValue).to.equal('Foo');
     });
@@ -665,6 +666,7 @@ describe('<lion-fieldset>', () => {
       expect(input.modelValue).to.equal('Bar');
 
       el.resetGroup();
+      await nextFrame();
       expect(el.modelValue).to.deep.equal({ 'firstName[]': ['Foo'] });
       expect(input.modelValue).to.equal('Foo');
     });
@@ -691,6 +693,7 @@ describe('<lion-fieldset>', () => {
       expect(input.modelValue).to.equal('Bar');
 
       el.resetGroup();
+      await nextFrame();
       expect(el.modelValue).to.deep.equal({ 'name[]': [{ firstName: 'Foo' }] });
       expect(nestedFieldset.modelValue).to.deep.equal({ firstName: 'Foo' });
       expect(input.modelValue).to.equal('Foo');
@@ -758,6 +761,7 @@ describe('<lion-fieldset>', () => {
       expect(el.errorState).to.be.false;
 
       el.resetGroup();
+      await nextFrame();
       expect(el.errorState).to.be.true;
       expect(el.error.containsA).to.be.true;
       expect(el.formElements.color.errorState).to.be.false;
@@ -806,6 +810,7 @@ describe('<lion-fieldset>', () => {
         const childFieldsetEl = el.querySelector(tagString);
         const resetGroupSpy = sinon.spy(childFieldsetEl, 'resetGroup');
         el.resetGroup();
+        await nextFrame();
         expect(resetGroupSpy.callCount).to.equal(1);
       });
 
@@ -821,6 +826,7 @@ describe('<lion-fieldset>', () => {
         const childFieldsetEl = el.querySelector(childTagString);
         const resetSpy = sinon.spy(childFieldsetEl, 'reset');
         el.resetGroup();
+        await nextFrame();
         expect(resetSpy.callCount).to.equal(1);
       });
     });

--- a/packages/fieldset/test/lion-fieldset.test.js
+++ b/packages/fieldset/test/lion-fieldset.test.js
@@ -645,7 +645,7 @@ describe('<lion-fieldset>', () => {
       expect(el.modelValue).to.deep.equal({ firstName: 'Bar' });
       expect(input.modelValue).to.equal('Bar');
 
-      await el.resetGroup();
+      el.resetGroup();
       expect(el.modelValue).to.deep.equal({ firstName: 'Foo' });
       expect(input.modelValue).to.equal('Foo');
     });
@@ -664,7 +664,7 @@ describe('<lion-fieldset>', () => {
       expect(el.modelValue).to.deep.equal({ 'firstName[]': ['Bar'] });
       expect(input.modelValue).to.equal('Bar');
 
-      await el.resetGroup();
+      el.resetGroup();
       expect(el.modelValue).to.deep.equal({ 'firstName[]': ['Foo'] });
       expect(input.modelValue).to.equal('Foo');
     });
@@ -690,8 +690,7 @@ describe('<lion-fieldset>', () => {
       expect(nestedFieldset.modelValue).to.deep.equal({ firstName: 'Bar' });
       expect(input.modelValue).to.equal('Bar');
 
-      await el.resetGroup();
-      await nextFrame();
+      el.resetGroup();
       expect(el.modelValue).to.deep.equal({ 'name[]': [{ firstName: 'Foo' }] });
       expect(nestedFieldset.modelValue).to.deep.equal({ firstName: 'Foo' });
       expect(input.modelValue).to.equal('Foo');
@@ -708,14 +707,14 @@ describe('<lion-fieldset>', () => {
 
       // Reset all children states, with prefilled false
       el._setValueForAllFormElements('modelValue', {});
-      el.resetInteractionState();
+      await el.resetInteractionState();
       expect(el.dirty).to.equal(false, 'not "dirty" after reset');
       expect(el.touched).to.equal(false, 'not "touched" after reset');
       expect(el.prefilled).to.equal(false, 'not "prefilled" after reset');
 
       // Reset all children states with prefilled true
       el._setValueForAllFormElements('modelValue', { checked: true }); // not prefilled
-      el.resetInteractionState();
+      await el.resetInteractionState();
       expect(el.dirty).to.equal(false, 'not "dirty" after 2nd reset');
       expect(el.touched).to.equal(false, 'not "touched" after 2nd reset');
       // prefilled state is dependant on value
@@ -739,9 +738,14 @@ describe('<lion-fieldset>', () => {
       });
 
       it('to reset interaction state', async () => {
-        const resetGroupPromise = fieldset
-          .resetGroup()
-          .then(() => expect(fieldset.submitted).to.equal(false));
+        const resetInteractionStatePromise = fieldset
+          .resetInteractionState()
+          .then(() =>
+            expect(fieldset.submitted).to.equal(
+              false,
+              'resetInteractionState should be triggered after submitted is set to false',
+            ),
+          );
         fieldset.submitted = true;
 
         const resolveUpdatePromise = async () => {
@@ -750,7 +754,7 @@ describe('<lion-fieldset>', () => {
 
         await resolveUpdatePromise();
 
-        return resetGroupPromise;
+        return resetInteractionStatePromise;
       });
     });
 
@@ -758,7 +762,8 @@ describe('<lion-fieldset>', () => {
       const fieldset = await fixture(html`<${tag}>${inputSlots}</${tag}>`);
       await nextFrame();
       fieldset.submitted = true;
-      await fieldset.resetGroup();
+      fieldset.resetGroup();
+      await fieldset.updateComplete;
       expect(fieldset.submitted).to.equal(false);
       fieldset.formElementsArray.forEach(el => {
         expect(el.submitted).to.equal(false);
@@ -790,7 +795,7 @@ describe('<lion-fieldset>', () => {
       el.formElements.color.modelValue = 'cat';
       expect(el.errorState).to.be.false;
 
-      await el.resetGroup();
+      el.resetGroup();
       expect(el.errorState).to.be.true;
       expect(el.error.containsA).to.be.true;
       expect(el.formElements.color.errorState).to.be.false;
@@ -838,7 +843,7 @@ describe('<lion-fieldset>', () => {
         `);
         const childFieldsetEl = el.querySelector(tagString);
         const resetGroupSpy = sinon.spy(childFieldsetEl, 'resetGroup');
-        await el.resetGroup();
+        el.resetGroup();
         expect(resetGroupSpy.callCount).to.equal(1);
       });
 
@@ -853,7 +858,7 @@ describe('<lion-fieldset>', () => {
         `);
         const childFieldsetEl = el.querySelector(childTagString);
         const resetSpy = sinon.spy(childFieldsetEl, 'reset');
-        await el.resetGroup();
+        el.resetGroup();
         expect(resetSpy.callCount).to.equal(1);
       });
     });

--- a/packages/form/test/lion-form.test.js
+++ b/packages/form/test/lion-form.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture, html, oneEvent } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent, nextFrame } from '@open-wc/testing';
 import { spy } from 'sinon';
 
 import '@lion/input/lion-input.js';
@@ -23,6 +23,7 @@ describe('<lion-form>', () => {
     });
 
     withDefaults.reset();
+    await nextFrame();
     expect(withDefaults.modelValue).to.deep.equal({
       firstName: 'Foo',
     });
@@ -34,6 +35,7 @@ describe('<lion-form>', () => {
     });
 
     resetButton.click();
+    await nextFrame();
     expect(withDefaults.modelValue).to.deep.equal({
       firstName: 'Foo',
     });

--- a/packages/form/test/lion-form.test.js
+++ b/packages/form/test/lion-form.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture, html, oneEvent, nextFrame } from '@open-wc/testing';
+import { expect, fixture, html, oneEvent } from '@open-wc/testing';
 import { spy } from 'sinon';
 
 import '@lion/input/lion-input.js';
@@ -23,7 +23,6 @@ describe('<lion-form>', () => {
     });
 
     withDefaults.reset();
-    await nextFrame();
     expect(withDefaults.modelValue).to.deep.equal({
       firstName: 'Foo',
     });
@@ -35,7 +34,6 @@ describe('<lion-form>', () => {
     });
 
     resetButton.click();
-    await nextFrame();
     expect(withDefaults.modelValue).to.deep.equal({
       firstName: 'Foo',
     });


### PR DESCRIPTION
Pull request with fix for issue https://github.com/ing-bank/lion/issues/336 as provided by @palash2601


> check of `updateComplete` can be also put up in resetGroup()
> 
> ```js
> async resetGroup() {
>     if (!this.submitted) {
>       await this.updateComplete;
>     }
>     this.formElementsArray.forEach(child => {
>       if (typeof child.resetGroup === 'function') {
>         child.resetGroup();
>       } else if (typeof child.reset === 'function') {
>         child.reset();
>       }
>     });
> 
>     this.resetInteractionState();
>   }
> ```