### PR TITLE
Fix en-US translations in lion-validate

### DIFF
--- a/packages/validate/translations/en-US.js
+++ b/packages/validate/translations/en-US.js
@@ -3,9 +3,11 @@ import en from './en.js';
 export default {
   ...en,
   error: {
+    ...en.error,
     isDate: 'Please enter a valid date (MM/DD/YYYY).',
   },
   warning: {
+    ...en.warning,
     isDate: 'Please enter a valid date (MM/DD/YYYY).',
   },
 };


### PR DESCRIPTION
Currently the "error" and "warning" sub-objects are completely overridden. This fixes it by inheriting them from 'en.js'