### PR TITLE
fix(select-rich): keyboard navigation should handle scrolling

### DIFF
--- a/packages/select-rich/stories/index.stories.js
+++ b/packages/select-rich/stories/index.stories.js
@@ -60,6 +60,40 @@ storiesOf('Forms|Select Rich', module)
     `,
   )
   .add(
+    'Many Options with scrolling',
+    () => html`
+      <style>
+        .demo-listbox {
+          max-height: 200px;
+          overflow-y: auto;
+          display: block;
+        }
+        ${selectRichDemoStyle}
+      </style>
+      <div class="demo-area">
+        <lion-select-rich label="Favorite color" name="color">
+          <lion-options slot="input" class="demo-listbox">
+            <lion-option .modelValue=${{ value: 'red', checked: false }}>
+              <p style="color: red;">I am red</p>
+            </lion-option>
+            <lion-option .modelValue=${{ value: 'hotpink', checked: true }}>
+              <p style="color: hotpink;">I am hotpink</p>
+            </lion-option>
+            <lion-option .modelValue=${{ value: 'teal', checked: false }}>
+              <p style="color: teal;">I am teal</p>
+            </lion-option>
+            <lion-option .modelValue=${{ value: 'green', checked: false }}>
+              <p style="color: green;">I am green</p>
+            </lion-option>
+            <lion-option .modelValue=${{ value: 'blue', checked: false }}>
+              <p style="color: blue;">I am blue</p>
+            </lion-option>
+          </lion-options>
+        </lion-select-rich>
+      </div>
+    `,
+  )
+  .add(
     'Read-only prefilled',
     () => html`
       <style>


### PR DESCRIPTION
Old:
![old](https://user-images.githubusercontent.com/24378/69438608-a0ce4a80-0d45-11ea-9f9c-904930969c98.gif)

New:
![Kapture 2019-11-22 at 16 29 38](https://user-images.githubusercontent.com/24378/69438442-5220b080-0d45-11ea-871a-2ec9870239f7.gif)

unfortunately, I could not add a test for it as apparently the scrolling is taking quite some time 😭 