### PR TITLE
feat(lion-tabs): added event details with the selected tab index

### DIFF
--- a/packages/tabs/src/LionTabs.js
+++ b/packages/tabs/src/LionTabs.js
@@ -200,7 +200,15 @@ export class LionTabs extends LitElement {
     const stale = this.__selectedIndex;
     this.__selectedIndex = value;
     this.__updateSelected();
-    this.dispatchEvent(new Event('selected-changed'));
+    this.dispatchEvent(
+      new CustomEvent('selected-changed', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          'selected-tab-index': value,
+        },
+      }),
+    );
     this.requestUpdate('selectedIndex', stale);
   }
 

--- a/packages/tabs/test/lion-tabs.test.js
+++ b/packages/tabs/test/lion-tabs.test.js
@@ -62,7 +62,9 @@ describe('<lion-tabs>', () => {
       const spy = sinon.spy();
       el.addEventListener('selected-changed', spy);
       el.selectedIndex = 1;
+
       expect(spy).to.have.been.calledOnce;
+      expect(spy.args[0][0].detail['selected-tab-index']).to.equal(1);
     });
 
     it('throws warning if unequal amount of tabs and panels', async () => {


### PR DESCRIPTION
The selected-changed event now also has event details indicating to which tab the selection has
changed to. The event details now contains the selected-tab-index value. In some cases the content of a tab might be interested in which tab context it is loaded. 