### PR TITLE
Fix bug in serializeGroup and serializeElements

### DIFF
--- a/packages/fieldset/src/LionFieldset.js
+++ b/packages/fieldset/src/LionFieldset.js
@@ -210,7 +210,7 @@ export class LionFieldset extends FormRegistrarMixin(
         serializedValues[name] = this.__serializeElements(element);
       } else {
         const serializedValue = this.__serializeElement(element);
-        if (serializedValue) {
+        if (serializedValue || serializedValue === 0) {
           serializedValues[name] = serializedValue;
         }
       }
@@ -353,7 +353,7 @@ export class LionFieldset extends FormRegistrarMixin(
     const serializedValues = [];
     elements.forEach(element => {
       const serializedValue = this.__serializeElement(element);
-      if (serializedValue) {
+      if (serializedValue || serializedValue === 0) {
         serializedValues.push(serializedValue);
       }
     });

--- a/packages/fieldset/test/lion-fieldset.test.js
+++ b/packages/fieldset/test/lion-fieldset.test.js
@@ -566,6 +566,23 @@ describe('<lion-fieldset>', () => {
       });
     });
 
+    it('0 is a valid value to be serialized', async () => {
+      const fieldset = await fixture(html`
+      <${tag}>
+        <${childTag} name="price"></${childTag}>
+      </${tag}>`);
+      await nextFrame();
+      fieldset.formElements.price.modelValue = 0;
+      expect(fieldset.serializeGroup()).to.deep.equal({ price: 0 });
+    });
+
+    it('__serializeElements serializes 0 as a valid value', async () => {
+      const fieldset = await fixture(html`<${tag}></${tag}>`);
+      await nextFrame();
+      const elements = [{ serializedValue: 0 }];
+      expect(fieldset.__serializeElements(elements)).to.deep.equal([0]);
+    });
+
     it('form elements which are not disabled', async () => {
       const fieldset = await fixture(html`<${tag}>${inputSlots}</${tag}>`);
       await nextFrame();


### PR DESCRIPTION
0 (number) is considered as falsy by JavaScript. That means the previous check was ignoring the 0 when defining the `serializedValues`  in `serializeGroup`and `__serializeElements` methods.