### PR TITLE
feat(overlay): close/hide events on dom (OverlayMixin) level

### DIFF
--- a/packages/dialog/src/LionDialog.js
+++ b/packages/dialog/src/LionDialog.js
@@ -2,11 +2,6 @@ import { withModalDialogConfig, OverlayMixin } from '@lion/overlays';
 import { LitElement, html } from '@lion/core';
 
 export class LionDialog extends OverlayMixin(LitElement) {
-  constructor() {
-    super();
-    this.closeEventName = 'dialog-close';
-  }
-
   // eslint-disable-next-line class-methods-use-this
   _defineOverlayConfig() {
     return {
@@ -15,6 +10,7 @@ export class LionDialog extends OverlayMixin(LitElement) {
   }
 
   _setupOpenCloseListeners() {
+    super._setupOpenCloseListeners();
     this.__toggle = () => {
       this.opened = !this.opened;
     };
@@ -25,6 +21,7 @@ export class LionDialog extends OverlayMixin(LitElement) {
   }
 
   _teardownOpenCloseListeners() {
+    super._teardownOpenCloseListeners();
     if (this._overlayInvokerNode) {
       this._overlayInvokerNode.removeEventListener('click', this.__toggle);
     }

--- a/packages/dialog/stories/index.stories.js
+++ b/packages/dialog/stories/index.stories.js
@@ -80,7 +80,7 @@ storiesOf('Overlays Specific WC | Dialog', module)
             Hello! You can close this notification here:
             <button
               class="close-button"
-              @click=${e => e.target.dispatchEvent(new Event('hide', { bubbles: true }))}
+              @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
             >
               ⨯
             </button>
@@ -97,7 +97,7 @@ storiesOf('Overlays Specific WC | Dialog', module)
           Hello! You can close this notification here:
           <button
             class="close-button"
-            @click=${e => e.target.dispatchEvent(new Event('hide', { bubbles: true }))}
+            @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
           >
             ⨯
           </button>
@@ -123,7 +123,7 @@ storiesOf('Overlays Specific WC | Dialog', module)
           Hello! You can close this notification here:
           <button
             class="close-button"
-            @click=${e => e.target.dispatchEvent(new Event('hide', { bubbles: true }))}
+            @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
           >
             ⨯
           </button>

--- a/packages/input-datepicker/src/LionCalendarOverlayFrame.js
+++ b/packages/input-datepicker/src/LionCalendarOverlayFrame.js
@@ -90,9 +90,8 @@ export class LionCalendarOverlayFrame extends LocalizeMixin(LitElement) {
     ];
   }
 
-  __dispatchHideEvent() {
-    // Designed to work in conjunction with ModalDialogController
-    this.dispatchEvent(new CustomEvent('hide'), { bubbles: true });
+  __dispatchCloseEvent() {
+    this.dispatchEvent(new Event('close-overlay'), { bubbles: true });
   }
 
   render() {
@@ -104,7 +103,7 @@ export class LionCalendarOverlayFrame extends LocalizeMixin(LitElement) {
             <slot name="heading"></slot>
           </h1>
           <button
-            @click="${this.__dispatchHideEvent}"
+            @click="${this.__dispatchCloseEvent}"
             id="close-button"
             title="${this.msgLit('lion-calendar-overlay-frame:close')}"
             aria-label="${this.msgLit('lion-calendar-overlay-frame:close')}"

--- a/packages/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/input-datepicker/src/LionInputDatepicker.js
@@ -343,6 +343,10 @@ export class LionInputDatepicker extends OverlayMixin(LionInputDate) {
    * @override Configures OverlayMixin
    */
   get _overlayContentNode() {
-    return this.shadowRoot.querySelector('lion-calendar-overlay-frame');
+    if (this._cachedOverlayContentNode) {
+      return this._cachedOverlayContentNode;
+    }
+    this._cachedOverlayContentNode = this.shadowRoot.querySelector('lion-calendar-overlay-frame');
+    return this._cachedOverlayContentNode;
   }
 }

--- a/packages/overlays/README.md
+++ b/packages/overlays/README.md
@@ -41,7 +41,7 @@ html`
     <div slot="content">
       This is an overlay
       <button
-        @click=${e => e.target.dispatchEvent(new Event('hide', { bubbles: true }))}
+        @click=${e => e.target.dispatchEvent(new Event('overlay-close', { bubbles: true }))}
       >x</button>
     <div>
     <button slot="invoker">

--- a/packages/overlays/test-suites/OverlayMixin.suite.js
+++ b/packages/overlays/test-suites/OverlayMixin.suite.js
@@ -1,4 +1,5 @@
 import { expect, fixture, html, aTimeout } from '@open-wc/testing';
+import sinon from 'sinon';
 
 export function runOverlayMixinSuite({ /* tagString, */ tag, suffix = '' }) {
   describe(`OverlayMixin${suffix}`, () => {
@@ -52,6 +53,88 @@ export function runOverlayMixinSuite({ /* tagString, */ tag, suffix = '' }) {
 
       itEl.config = { viewportConfig: { placement: 'left' } };
       expect(itEl._overlayCtrl.viewportConfig.placement).to.equal('left');
+    });
+
+    it('fires "opened-changed" event on hide', async () => {
+      const spy = sinon.spy();
+      el = await fixture(html`
+        <${tag} @opened-changed="${spy}">
+          <div slot="content">content of the overlay</div>
+          <button slot="invoker">invoker button</button>
+        </${tag}>
+      `);
+      expect(spy).not.to.have.been.called;
+      await el._overlayCtrl.show();
+      expect(spy.callCount).to.equal(1);
+      expect(el.opened).to.be.true;
+      await el._overlayCtrl.hide();
+      expect(spy.callCount).to.equal(2);
+      expect(el.opened).to.be.false;
+    });
+
+    it('fires "before-closed" event on hide', async () => {
+      const beforeSpy = sinon.spy();
+      el = await fixture(html`
+        <${tag} @before-closed="${beforeSpy}" .opened="${true}">
+          <div slot="content">content of the overlay</div>
+          <button slot="invoker">invoker button</button>
+        </${tag}>
+      `);
+      expect(beforeSpy).not.to.have.been.called;
+      await el._overlayCtrl.hide();
+      expect(beforeSpy).to.have.been.called;
+      expect(el.opened).to.be.false;
+    });
+
+    it('fires before-opened" event on show', async () => {
+      const beforeSpy = sinon.spy();
+      el = await fixture(html`
+        <${tag} @before-opened="${beforeSpy}">
+          <div slot="content">content of the overlay</div>
+          <button slot="invoker">invoker button</button>
+        </${tag}>
+      `);
+      expect(beforeSpy).not.to.have.been.called;
+      await el._overlayCtrl.show();
+      expect(beforeSpy).to.have.been.called;
+      expect(el.opened).to.be.true;
+    });
+
+    it('allows to call `preventDefault()` on "before-opened"/"before-closed" events', async () => {
+      function preventer(ev) {
+        ev.preventDefault();
+      }
+      el = await fixture(html`
+        <${tag} @before-opened="${preventer}" @before-closed="${preventer}">
+          <div slot="content">content of the overlay</div>
+          <button slot="invoker">invoker button</button>
+        </${tag}>
+      `);
+      await el._overlayCtrl.show();
+      expect(el.opened).to.be.false;
+    });
+
+    it('hides content on "close-overlay" event within the content ', async () => {
+      function sendCloseEvent(e) {
+        e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }));
+      }
+      const closeBtn = await fixture(html`
+        <button @click=${sendCloseEvent}>
+          close
+        </button>
+      `);
+
+      el = await fixture(html`
+        <${tag} opened>
+          <div slot="content">
+            content of the overlay
+            ${closeBtn}
+          </div>
+          <button slot="invoker">invoker button</button>
+        </${tag}>
+      `);
+      closeBtn.click();
+      expect(el.opened).to.be.false;
     });
   });
 }

--- a/packages/overlays/test/OverlayController.test.js
+++ b/packages/overlays/test/OverlayController.test.js
@@ -314,33 +314,6 @@ describe('OverlayController', () => {
       });
     });
 
-    describe('hidesOnHideEventInContentNode', () => {
-      it('hides content on hide event within the content ', async () => {
-        const ctrl = new OverlayController({
-          ...withGlobalTestConfig(),
-          hidesOnHideEventInContentNode: true,
-          contentNode: fixtureSync(html`
-            <div>
-              my content
-              <button @click=${e => e.target.dispatchEvent(new Event('hide', { bubbles: true }))}>
-                x
-              </button>
-            </div>
-          `),
-        });
-        await ctrl.show();
-
-        const closeBtn = ctrl.contentNode.querySelector('button');
-        closeBtn.click();
-
-        expect(ctrl.isShown).to.be.false;
-      });
-
-      it('does stop propagation of the "hide" event to not pollute the event stack and to prevent side effects', () => {
-        // TODO: how to test this?
-      });
-    });
-
     describe('hidesOnOutsideClick', () => {
       it('hides on outside click', async () => {
         const contentNode = await fixture('<div>Content</div>');

--- a/packages/tooltip/src/LionTooltip.js
+++ b/packages/tooltip/src/LionTooltip.js
@@ -4,7 +4,6 @@ import { LitElement, html } from '@lion/core';
 export class LionTooltip extends OverlayMixin(LitElement) {
   constructor() {
     super();
-    this.closeEventName = 'tooltip-close';
     this.mouseActive = false;
     this.keyActive = false;
   }
@@ -19,6 +18,7 @@ export class LionTooltip extends OverlayMixin(LitElement) {
   }
 
   _setupOpenCloseListeners() {
+    super._setupOpenCloseListeners();
     this.__resetActive = () => {
       this.mouseActive = false;
       this.keyActive = false;
@@ -58,6 +58,7 @@ export class LionTooltip extends OverlayMixin(LitElement) {
   }
 
   _teardownOpenCloseListeners() {
+    super._teardownOpenCloseListeners();
     this._overlayCtrl.removeEventListener('hide', this.__resetActive);
     this.removeEventListener('mouseenter', this.__showMouse);
     this.removeEventListener('mouseleave', this._hideMouse);


### PR DESCRIPTION
@LarsDenBakker requested a way to synchronize and intercept open/close state in an api similar to:

```javascript
render() {
  return html`
    <lion-dialog .opened=${this.opened} @close="${() => this.opened = false;}" @before-close=${(e) => {
       if (shouldIntercept) {
          e.preventDefault();
       } 
     }}></ing-dialog>
  `;
}
```





