### PR TITLE
fix(#423): prevent default behavior on keyboard interaction

### DIFF
--- a/packages/calendar/src/LionCalendar.js
+++ b/packages/calendar/src/LionCalendar.js
@@ -518,6 +518,12 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
 
   __addEventForKeyboardNavigation() {
     this.__keyNavigationEvent = this.__contentWrapperElement.addEventListener('keydown', ev => {
+      const preventedKeys = ['ArrowUp', 'ArrowDown', 'PageDown', 'PageUp'];
+
+      if (preventedKeys.includes(ev.key)) {
+        ev.preventDefault();
+      }
+
       switch (ev.key) {
         case 'ArrowUp':
           this.__modifyDate(-7, { dateType: '__focusedDate', type: 'Date', mode: 'past' });


### PR DESCRIPTION
- [x] Chrome
- [x] IE 11