### PR TITLE
fix: improve yarn lock scan, always run

### DIFF
--- a/husky.config.js
+++ b/husky.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   hooks: {
-    'pre-commit': 'lint-staged',
+    'pre-commit': 'lint-staged && node ./scripts/yarn-lock-scan.js',
     'commit-msg': 'commitlint -E HUSKY_GIT_PARAMS',
   },
 };

--- a/package.json
+++ b/package.json
@@ -74,9 +74,6 @@
     ],
     "*package.json": [
       "node ./scripts/lint-versions.js"
-    ],
-    "yarn.lock": [
-      "node ./scripts/yarn-lock-scan.js"
     ]
   },
   "bundlesize": [


### PR DESCRIPTION
Changing it to always run, not just if yarn.lock is staged.

Today ran into the issue that a new "bad" yarn.lock got committed with no-verify somewhere, then later another commit was done on top with verify, but then yarn.lock was no longer staged, so the yarn lock scan never ran, and the code was pushed to github.. 

Always running the verification on yarn.lock, whether it is staged or not, seems like a better security practice.