### PR TITLE
fix: unregister form element when disconnected

### DIFF
--- a/packages/textarea/src/LionTextarea.js
+++ b/packages/textarea/src/LionTextarea.js
@@ -57,6 +57,8 @@ export class LionTextarea extends LionField {
   }
 
   disconnectedCallback() {
+    // eslint-disable-next-line wc/guard-super-call
+    super.disconnectedCallback();
     autosize.destroy(this._inputNode);
   }
 


### PR DESCRIPTION
When `lion-textarea` is removed from DOM it is not unregistered from parent form (`lion-form`) (`_unregisterFormElement` from `FormRegisteringMixin` is not called).

Trying to add the same `lion-textarea` to the form at a later stage will throw an error:
"Name "${name}" is already registered - if you want an array add [] to the end"

I stumbled across this issue when trying to display a textarea based on a boolean condition:
```
<lion-form>
  <form>
    <lion-input name="name"></lion-input>
    <button @click=${() => this._optionalTextarea = !this._optionalTextarea}></button>
    ${this._optionalTextarea
      ? html`
          <lion-textarea name="comment"></lion-textarea>
        `
      : ""}
  </form>
</lion-form>
```