### PR TITLE
fix(localize): if locale is set to tr, currency TRY should display TL

### DIFF
--- a/packages/localize/src/number/forceTryCurrencyCode.js
+++ b/packages/localize/src/number/forceTryCurrencyCode.js
@@ -1,0 +1,10 @@
+export function forceTryCurrencyCode(formattedParts, options) {
+  const result = formattedParts;
+  // Chage the currencycode from TRY to TL, for Turkey
+  if (options.currency === 'TRY' && options.currencyDisplay === 'code') {
+    if (result[0].value === 'TRY') {
+      result[0].value = 'TL';
+    }
+  }
+  return result;
+}

--- a/packages/localize/src/number/normalizeIntl.js
+++ b/packages/localize/src/number/normalizeIntl.js
@@ -5,6 +5,7 @@ import { forceNormalSpaces } from './forceNormalSpaces.js';
 import { forceSpaceBetweenCurrencyCodeAndNumber } from './forceSpaceBetweenCurrencyCodeAndNumber.js';
 import { forceYenSymbol } from './forceYenSymbol.js';
 import { forceSpaceInsteadOfZeroForGroup } from './forceSpaceInsteadOfZeroForGroup.js';
+import { forceTryCurrencyCode } from './forceTryCurrencyCode.js';
 
 /**
  * Function with all fixes on localize
@@ -33,6 +34,9 @@ export function normalizeIntl(formattedParts, options, _locale) {
     // Force missing Japanese Yen symbol
     if (_locale === 'fr-FR' || _locale === 'fr-BE') {
       normalize = forceYenSymbol(normalize, options);
+    }
+    if (_locale === 'tr-TR') {
+      normalize = forceTryCurrencyCode(normalize, options);
     }
   }
   return normalize;

--- a/packages/localize/test/number/formatNumber.test.js
+++ b/packages/localize/test/number/formatNumber.test.js
@@ -308,5 +308,17 @@ describe('formatNumber', () => {
         expect(formatNumber(123456.789, currencySymbol('CZK'))).to.equal('123 456,79 Kč');
       });
     });
+
+    describe('tr-TR', () => {
+      localize.locale = 'tr-TR';
+      expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123.456,79');
+      expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123.456,79');
+      expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123.457');
+      expect(formatNumber(123456.789, currencyCode('TRY'))).to.equal('TL 123.456,79');
+      expect(formatNumber(123456.789, currencySymbol('EUR'))).to.equal('€123.456,79');
+      expect(formatNumber(123456.789, currencySymbol('USD'))).to.equal('$123.456,79');
+      expect(formatNumber(123456.789, currencySymbol('JPY'))).to.equal('¥123.457');
+      expect(formatNumber(123456.789, currencySymbol('TRY'))).to.equal('₺123.456,79');
+    });
   });
 });


### PR DESCRIPTION
TRY is the universal currency name for Turkish Liras, but in Turkey it is known as TL. This commit fixes this issue for Turkish localization.