### PR TITLE
WIP: POC removal shadow outlet for local

### DIFF
--- a/packages/overlays/src/OverlayController.js
+++ b/packages/overlays/src/OverlayController.js
@@ -68,7 +68,9 @@ export class OverlayController {
 
     this.manager.add(this);
 
-    this._contentNodeWrapper = document.createElement('div');
+    this._contentNodeWrapper =
+      config.placementMode === 'global' ? document.createElement('div') : config.contentNode;
+
     this._contentId = `overlay-content--${Math.random()
       .toString(36)
       .substr(2, 10)}`;
@@ -178,6 +180,7 @@ export class OverlayController {
   async _init({ cfgToAdd }) {
     this.__initContentNodeWrapper();
     this.__initConnectionTarget();
+
     if (this.handlesAccessibility) {
       this.__initAccessibility({ cfgToAdd });
     }
@@ -195,11 +198,13 @@ export class OverlayController {
 
   __initConnectionTarget() {
     // Now, add our node to the right place in dom (rendeTarget)
-    if (this.contentNode !== this.__prevConfig.contentNode) {
-      this._contentNodeWrapper.appendChild(this.contentNode);
-    }
-    if (this._renderTarget && this._renderTarget !== this._contentNodeWrapper.parentNode) {
-      this._renderTarget.appendChild(this._contentNodeWrapper);
+    if (this.config.placementMode === 'global') {
+      if (this.contentNode !== this.__prevConfig.contentNode) {
+        this._contentNodeWrapper.appendChild(this.contentNode);
+      }
+      if (this._renderTarget && this._renderTarget !== this._contentNodeWrapper.parentNode) {
+        this._renderTarget.appendChild(this._contentNodeWrapper);
+      }
     }
   }
 
@@ -209,14 +214,19 @@ export class OverlayController {
    * can lead to problems with event listeners...
    */
   __initContentNodeWrapper() {
-    Array.from(this._contentNodeWrapper.attributes).forEach(attrObj => {
-      this._contentNodeWrapper.removeAttribute(attrObj.name);
-    });
-    this._contentNodeWrapper.style.cssText = null;
+    if (this.config.placementMode === 'global') {
+      Array.from(this._contentNodeWrapper.attributes).forEach(attrObj => {
+        this._contentNodeWrapper.removeAttribute(attrObj.name);
+      });
+      this._contentNodeWrapper.style.cssText = null;
+    }
+
     this._contentNodeWrapper.style.display = 'none';
 
     // Make sure that your shadow dom contains this outlet, when we are adding to light dom
-    this._contentNodeWrapper.slot = '_overlay-shadow-outlet';
+    if (this.config.placementMode === 'global') {
+      this._contentNodeWrapper.slot = '_overlay-shadow-outlet';
+    }
 
     if (getComputedStyle(this.contentNode).position === 'absolute') {
       // Having a _contWrapperNode and a contentNode with 'position:absolute' results in

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -168,7 +168,9 @@ export const OverlayMixin = dedupeMixin(
       }
 
       get _overlayContentNodeWrapper() {
-        return this._overlayContentNode.parentElement;
+        return this.config.placementMode === 'global'
+          ? this._overlayContentNode.parentElement
+          : this._overlayContentNode;
       }
 
       _setupOverlayCtrl() {

--- a/packages/overlays/stories/demo-overlay-system.js
+++ b/packages/overlays/stories/demo-overlay-system.js
@@ -31,7 +31,6 @@ class DemoOverlaySystem extends OverlayMixin(LitElement) {
     return html`
       <slot name="invoker"></slot>
       <slot name="content"></slot>
-      <slot name="_overlay-shadow-outlet"></slot>
     `;
   }
 }

--- a/packages/tooltip/src/LionTooltip.js
+++ b/packages/tooltip/src/LionTooltip.js
@@ -25,7 +25,6 @@ export class LionTooltip extends OverlayMixin(LitElement) {
       <slot name="invoker"></slot>
       <slot name="content"></slot>
       <slot name="arrow"></slot>
-      <slot name="_overlay-shadow-outlet"></slot>
     `;
   }
 

--- a/packages/tooltip/src/LionTooltipArrow.js
+++ b/packages/tooltip/src/LionTooltipArrow.js
@@ -21,6 +21,10 @@ export class LionTooltipArrow extends LitElement {
         display: block;
       }
 
+      :host([placement^='top']) {
+        bottom: calc(-1 * var(--tooltip-arrow-height));
+      }
+
       :host([placement^='bottom']) {
         top: calc(-1 * var(--tooltip-arrow-height));
         transform: rotate(180deg);


### PR DESCRIPTION
So far I was able to get rid of the shadow outlet in local overlays, and I could not find issues from a first investigation. @tlouisse  you should take a look since you know more what the shadow outlet is useful for ;).

For global overlays, currently we use flexbox which requires the use of at least a parent elem and a child elem (the elem to be positioned), therefore the outlet is quite useful for global overlays.

There is also a proposal to make the global-overlays container div a custom element and to append global overlay content nodes to its shadow root, so we can easily style it without leakage.

Very very pseudo
```html
<lion-global-overlays>
  #shadow-root
    <div class="backdrop"></div>
    <div slot="_shadow-outlet" class="overlay--center"> // display: flex, justify-content: center; align-items: center;
      <div class="overlay-content-node">
      </div>
    </div>
</lion-global-overlays>
```