### PR TITLE
chore: update to storybook 1.9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@commitlint/cli": "^7.0.0",
     "@commitlint/config-conventional": "^7.0.0",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/eslint-config": "^1.0.0",
     "@open-wc/prettier-config": "^0.1.0",
     "@open-wc/testing": "^2.5.0",

--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -36,7 +36,7 @@
     "@lion/core": "0.4.3"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -35,7 +35,7 @@
     "@lion/core": "0.4.3"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "@polymer/iron-test-helpers": "^3.0.1",
     "sinon": "^7.2.2"

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -37,7 +37,7 @@
     "@lion/localize": "0.8.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -40,7 +40,7 @@
     "@lion/checkbox": "0.3.10",
     "@lion/localize": "0.8.6",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -37,7 +37,7 @@
     "@lion/input": "0.5.10"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/choice-input/package.json
+++ b/packages/choice-input/package.json
@@ -39,7 +39,7 @@
     "@lion/fieldset": "0.7.0",
     "@lion/input": "0.5.10",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,7 +35,7 @@
     "lit-html": "^1.0.0"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -34,7 +34,7 @@
     "@lion/overlays": "0.12.0"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/field/package.json
+++ b/packages/field/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@lion/localize": "0.8.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@lion/localize": "0.8.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/form-system/package.json
+++ b/packages/form-system/package.json
@@ -52,7 +52,7 @@
     "@lion/select-rich": "0.10.0",
     "@lion/textarea": "0.5.11",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   },
   "peerDependencies": {

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@lion/field": "0.9.0",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -35,7 +35,7 @@
     "@lion/core": "0.4.3"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -35,7 +35,7 @@
     "@lion/core": "0.4.3"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -39,7 +39,7 @@
     "@lion/validate": "0.6.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -39,7 +39,7 @@
     "@lion/validate": "0.6.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -45,7 +45,7 @@
     "@lion/validate": "0.6.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -39,7 +39,7 @@
     "@lion/validate": "0.6.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -40,7 +40,7 @@
     "ibantools": "^2.2.0"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/input-range/package.json
+++ b/packages/input-range/package.json
@@ -37,7 +37,7 @@
     "@lion/localize": "0.8.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@lion/localize": "0.8.6",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@bundled-es-modules/fetch-mock": "^6.5.2",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   },

--- a/packages/option/package.json
+++ b/packages/option/package.json
@@ -37,7 +37,7 @@
     "@lion/field": "0.9.0"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -38,7 +38,7 @@
     "popper.js": "^1.15.0"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "@open-wc/testing-helpers": "^1.0.0",
     "sinon": "^7.2.2"

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@lion/radio": "0.4.0",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/radio/package.json
+++ b/packages/radio/package.json
@@ -37,7 +37,7 @@
     "@lion/input": "0.5.10"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/select-rich/package.json
+++ b/packages/select-rich/package.json
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@lion/form": "0.4.10",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -35,7 +35,7 @@
     "@lion/core": "0.4.3"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@lion/localize": "0.8.6",
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -35,7 +35,7 @@
     "@lion/core": "0.4.3"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -38,7 +38,7 @@
   },
   "devDependencies": {
     "@lion/validate": "0.6.6",
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -36,7 +36,7 @@
     "@lion/overlays": "0.12.0"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0"
   }
 }

--- a/packages/validate/package.json
+++ b/packages/validate/package.json
@@ -38,7 +38,7 @@
     "@lion/localize": "0.8.6"
   },
   "devDependencies": {
-    "@open-wc/demoing-storybook": "^1.8.3",
+    "@open-wc/demoing-storybook": "^1.9.0",
     "@open-wc/testing": "^2.5.0",
     "sinon": "^7.2.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2249,10 +2249,10 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@open-wc/building-rollup@^0.20.2":
-  version "0.20.2"
-  resolved "https://registry.yarnpkg.com/@open-wc/building-rollup/-/building-rollup-0.20.2.tgz#d7c62aa16a33262b72a5be7129dc2e4ade91a034"
-  integrity sha512-XjWqj3PKrbX2NxZQKF5yv1+sl5mcTVOo5MWiwPG/DHYg7wsNqQaB1OabL2rywxz/kUfFnyds87BQMIvuVUuhhg==
+"@open-wc/building-rollup@^0.20.4":
+  version "0.20.4"
+  resolved "https://registry.yarnpkg.com/@open-wc/building-rollup/-/building-rollup-0.20.4.tgz#189e6ac3e7d28bf7587bb3421a2b73f95ffc8e39"
+  integrity sha512-iebY0MrrQX8nSV7PrgUF32nkeCptvHk36WAyPJcOWpt15Fj3GPWNOgkKg8WGRHfzA+S1BZSDGReBHcoXtzWRwg==
   dependencies:
     "@babel/core" "^7.8.3"
     "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
@@ -2260,12 +2260,12 @@
     "@babel/plugin-syntax-dynamic-import" "^7.8.3"
     "@babel/plugin-syntax-import-meta" "^7.8.3"
     "@babel/preset-env" "^7.8.3"
-    "@open-wc/building-utils" "^2.13.1"
+    "@open-wc/building-utils" "^2.14.0"
     "@rollup/plugin-node-resolve" "^6.1.0"
     babel-plugin-bundled-import-meta "^0.3.0"
     babel-plugin-template-html-minifier "^3.0.0"
     rollup-plugin-babel "^4.3.2"
-    rollup-plugin-index-html "^1.8.2"
+    rollup-plugin-index-html "^1.9.0"
     rollup-plugin-terser "^5.1.0"
     rollup-plugin-workbox "^4.0.0"
 
@@ -2299,6 +2299,38 @@
     whatwg-fetch "^3.0.0"
     whatwg-url "^7.0.0"
 
+"@open-wc/building-utils@^2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/building-utils/-/building-utils-2.14.0.tgz#7f7d85ffe3e637d072bbff7162ac1aecb79e3a79"
+  integrity sha512-sAVzd7CImhNNqS9EXYBSQOKxndBH6YWOtnOHApkud89MI+9LW2TyNfPkNVaWhuScYu7YLv+gXA7Y4zWCj5dStg==
+  dependencies:
+    "@babel/core" "^7.8.3"
+    "@babel/plugin-syntax-dynamic-import" "^7.8.3"
+    "@webcomponents/shadycss" "^1.9.4"
+    "@webcomponents/webcomponentsjs" "^2.4.0"
+    arrify "^2.0.1"
+    browserslist "^4.7.2"
+    chokidar "^3.0.0"
+    clean-css "^4.2.1"
+    clone "^2.1.2"
+    core-js-bundle "^3.6.0"
+    deepmerge "^3.2.0"
+    es-module-shims "^0.4.6"
+    html-minifier "^4.0.0"
+    lru-cache "^5.1.1"
+    minimatch "^3.0.4"
+    parse5 "^5.1.0"
+    path-is-inside "^1.0.2"
+    regenerator-runtime "^0.13.3"
+    resolve "^1.11.1"
+    rimraf "^3.0.0"
+    shady-css-scoped-element "^0.0.1"
+    systemjs "^4.0.0"
+    terser "^4.0.0"
+    valid-url "^1.0.9"
+    whatwg-fetch "^3.0.0"
+    whatwg-url "^7.0.0"
+
 "@open-wc/chai-dom-equals@^0.12.36":
   version "0.12.36"
   resolved "https://registry.yarnpkg.com/@open-wc/chai-dom-equals/-/chai-dom-equals-0.12.36.tgz#ed0eb56b9e98c4d7f7280facce6215654aae9f4c"
@@ -2307,27 +2339,27 @@
     "@open-wc/semantic-dom-diff" "^0.13.16"
     "@types/chai" "^4.1.7"
 
-"@open-wc/demoing-storybook@^1.8.3":
-  version "1.9.4"
-  resolved "https://registry.yarnpkg.com/@open-wc/demoing-storybook/-/demoing-storybook-1.9.4.tgz#256d18e73c409504033fbdd8a9f0b22c39d76456"
-  integrity sha512-KZ3dkN5f1cg8FQmEeOckThSyR+hfMULP+WBy5UfDj2pvHxbNMwrsz5FjT/lZyro856sYXFUTRRsrKoaVCj97eg==
+"@open-wc/demoing-storybook@^1.9.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/demoing-storybook/-/demoing-storybook-1.10.0.tgz#ad4976362cbc87fe96d21071141d482812348423"
+  integrity sha512-5cAF3bw5Mlyx5Pu9SkaS7nN6Z6d1UvON77s80e1gpnqsQwjqg8of5igqFpJseMDvn6wQfuyEyjv0+69oiPhK4g==
   dependencies:
     "@babel/core" "^7.8.3"
     "@babel/plugin-transform-react-jsx" "^7.8.3"
     "@mdx-js/mdx" "^1.5.1"
-    "@open-wc/building-rollup" "^0.20.2"
+    "@open-wc/building-rollup" "^0.20.4"
     "@storybook/addon-docs" "5.3.1"
     command-line-args "^5.0.2"
     command-line-usage "^6.1.0"
     deepmerge "^3.2.0"
-    es-dev-server "^1.38.2"
+    es-dev-server "^1.39.0"
     es-module-lexer "^0.3.13"
     fs-extra "^8.1.0"
     glob "^7.1.3"
     lit-html "^1.0.0"
     magic-string "^0.25.4"
     rollup "^1.15.6"
-    rollup-plugin-index-html "^1.8.2"
+    rollup-plugin-index-html "^1.9.0"
     storybook-prebuilt "^1.3.0"
 
 "@open-wc/eslint-config@^1.0.0":
@@ -3137,7 +3169,7 @@
     "@webassemblyjs/wast-parser" "1.8.5"
     "@xtuc/long" "4.2.2"
 
-"@webcomponents/shadycss@^1.9.1":
+"@webcomponents/shadycss@^1.9.1", "@webcomponents/shadycss@^1.9.4":
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/@webcomponents/shadycss/-/shadycss-1.9.4.tgz#4f9d8ea1526bab084c60b53d4854dc39fdb2bb48"
   integrity sha512-tgNcVEaKssyeZPbUBjVQf4aryO5Fi7fxRvOxV982ZJuRVDcefmIblBh0SXAbcvAAlQ2zpNEP4SuQUnr8uApIpw==
@@ -5946,6 +5978,56 @@ es-dev-server@^1.38.2:
     parse5 "^5.1.0"
     path-is-inside "^1.0.2"
     polyfills-loader "^1.1.2"
+    portfinder "^1.0.21"
+    strip-ansi "^5.2.0"
+    useragent "^2.3.0"
+    whatwg-url "^7.0.0"
+
+es-dev-server@^1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/es-dev-server/-/es-dev-server-1.39.0.tgz#2efc9bd51a5989904334cbe2d1c1399aec1bc56e"
+  integrity sha512-Z/+XePaOJOlKtwOC1ok2A6rcq5FS6pls4N0sQNuJg9j+RtElK03vU84iQ+W92Pxq+/ReAwSfuYy95X/676BpHA==
+  dependencies:
+    "@babel/core" "^7.8.3"
+    "@babel/plugin-proposal-dynamic-import" "^7.8.3"
+    "@babel/plugin-proposal-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-proposal-optional-chaining" "^7.8.3"
+    "@babel/plugin-syntax-class-properties" "^7.8.3"
+    "@babel/plugin-syntax-import-meta" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.3"
+    "@babel/plugin-syntax-numeric-separator" "^7.8.3"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.3"
+    "@babel/plugin-transform-template-literals" "^7.8.3"
+    "@babel/preset-env" "^7.8.3"
+    "@open-wc/building-utils" "^2.14.0"
+    "@rollup/plugin-node-resolve" "^6.1.0"
+    "@rollup/pluginutils" "^3.0.0"
+    "@types/minimatch" "^3.0.3"
+    browserslist "^4.7.2"
+    browserslist-useragent "^3.0.2"
+    builtin-modules "^3.1.0"
+    camelcase "^5.3.1"
+    caniuse-api "^3.0.0"
+    caniuse-lite "^1.0.30001008"
+    chokidar "^3.0.0"
+    command-line-args "^5.0.2"
+    command-line-usage "^6.1.0"
+    debounce "^1.2.0"
+    deepmerge "^3.2.0"
+    es-module-lexer "^0.3.13"
+    get-stream "^5.1.0"
+    is-stream "^2.0.0"
+    isbinaryfile "^4.0.2"
+    koa "^2.7.0"
+    koa-compress "^3.0.0"
+    koa-etag "^3.0.0"
+    koa-static "^5.0.0"
+    lru-cache "^5.1.1"
+    minimatch "^3.0.4"
+    opn "^5.4.0"
+    parse5 "^5.1.0"
+    path-is-inside "^1.0.2"
+    polyfills-loader "^1.2.0"
     portfinder "^1.0.21"
     strip-ansi "^5.2.0"
     useragent "^2.3.0"
@@ -8936,17 +9018,10 @@ listr@^0.14.2:
     p-map "^2.0.0"
     rxjs "^6.3.3"
 
-lit-element@^2.0.1:
+lit-element@^2.0.1, lit-element@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.2.1.tgz#79c94d8cfdc2d73b245656e37991bd1e4811d96f"
   integrity sha512-ipDcgQ1EpW6Va2Z6dWm79jYdimVepO5GL0eYkZrFvdr0OD/1N260Q9DH+K5HXHFrRoC7dOg+ZpED2XE0TgGdXw==
-  dependencies:
-    lit-html "^1.0.0"
-
-lit-element@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.1.0.tgz#85bc3f1da0227f4b13de8a1be978229b9fa327e9"
-  integrity sha512-0z/KHm1xZweivfOVRr8AKR06+D3k02u15m9s4jkuRdnGe5wfmEwePzrQQBsSZNILdnfJvfo3TJOeGhBCVZaPbw==
   dependencies:
     lit-html "^1.0.0"
 
@@ -10807,6 +10882,27 @@ polyfills-loader@^1.1.2:
     valid-url "^1.0.9"
     whatwg-fetch "^3.0.0"
 
+polyfills-loader@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/polyfills-loader/-/polyfills-loader-1.2.0.tgz#ec96cece2a42e46650b866318bc0b4dae2a1cd2b"
+  integrity sha512-gCQ188nyG8cArgA4YmdoS2r9N7blSxp2X7hXFwdHcBz9vMPkoEfHTBPSZu8jwQc/LLqx/qowKXyvYVGP7wjWLQ==
+  dependencies:
+    "@babel/core" "^7.8.3"
+    "@open-wc/building-utils" "^2.14.0"
+    "@webcomponents/webcomponentsjs" "^2.4.0"
+    core-js-bundle "^3.6.0"
+    deepmerge "^3.2.0"
+    dynamic-import-polyfill "^0.1.1"
+    es-module-shims "^0.4.6"
+    html-minifier "^4.0.0"
+    intersection-observer "^0.7.0"
+    parse5 "^5.1.0"
+    regenerator-runtime "^0.13.3"
+    systemjs "^4.0.0"
+    terser "^4.0.0"
+    valid-url "^1.0.9"
+    whatwg-fetch "^3.0.0"
+
 popper.js@^1.14.4, popper.js@^1.14.7, popper.js@^1.15.0:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
@@ -12009,13 +12105,13 @@ rollup-plugin-babel@^4.3.2:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-index-html@^1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-index-html/-/rollup-plugin-index-html-1.8.2.tgz#549bbba9f91f0bbc40649a71cafe55829c78bfce"
-  integrity sha512-CgLVUP3sul7evQqRxZVyrmgEyv93w07/8V2aO0IE+7JuAVgNNLzQ208vjs+53nfeTJPwchfwyFlYuIuXaMF0Vw==
+rollup-plugin-index-html@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-index-html/-/rollup-plugin-index-html-1.9.0.tgz#15544fe48cd0dbbbaa5026052baf226272c13e6c"
+  integrity sha512-lKAfdwOI0rpldvR6TjR5WhAyg+2NqeoaGFrgSsmgRnPrF5V3ojB3VdkaJQIBE8uyHdkZ+Jko6Ftz4l1j3/HgUw==
   dependencies:
     "@import-maps/resolve" "^0.2.3"
-    "@open-wc/building-utils" "^2.13.1"
+    "@open-wc/building-utils" "^2.14.0"
     deepmerge "^3.2.0"
     lit-element "^2.0.1"
     lit-html "^1.0.0"
@@ -12215,6 +12311,11 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+shady-css-scoped-element@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/shady-css-scoped-element/-/shady-css-scoped-element-0.0.1.tgz#e386ff2228bb3677376985a34d65101372ed66dc"
+  integrity sha512-86NPanHuXXTayw0psXbqMBU11rptlhAU17N3ZVxWYm6/KxMc02M/l6gGAEUb2Jff7W3Ur/ARWufPKmm/nNOU2g==
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Updates `@open-wc/demoing-storybook` to 1.9.x.
- Adds reload when renaming story files
- Regenerate list of stories on reload, so you don't need to restart the server when adding stories
- Uses static imports instead of dynamic imports for stories, drastically reducing filecount after build

I made this PR to do a confidence check the new release works correctly in a big project, but useful to merge this in master as well :)