### PR TITLE
fix(validate): reset validation result on validators change

### DIFF
--- a/packages/validate/src/ValidateMixin.js
+++ b/packages/validate/src/ValidateMixin.js
@@ -200,7 +200,7 @@ export const ValidateMixin = dedupeMixin(
         if (name === 'validators') {
           // trigger validation (ideally only for the new or changed validator)
           this.__setupValidators();
-          this.validate();
+          this.validate({ clearCurrentResult: true });
         } else if (name === 'modelValue') {
           this.validate({ clearCurrentResult: true });
         }

--- a/packages/validate/test-suites/ValidateMixin.suite.js
+++ b/packages/validate/test-suites/ValidateMixin.suite.js
@@ -812,6 +812,28 @@ export function runValidateMixinSuite(customConfig) {
         expect(el.validationStates.error).to.eql({});
       });
 
+      it('clears current validation results when validators array updated', async () => {
+        const validators = [new Required()];
+        const el = await fixture(html`
+          <${tag}
+            .validators=${validators}
+          >${lightDom}</${tag}>
+        `);
+        el.modelValue = undefined;
+        expect(el.hasFeedbackFor).to.deep.equal(['error']);
+        expect(el.validationStates.error).to.eql({ Required: true });
+
+        el.validators = [];
+        el.modelValue = undefined;
+        expect(el.hasFeedbackFor).to.not.deep.equal(['error']);
+        expect(el.validationStates.error).to.eql({});
+
+        el.validators = [new Required()];
+        el.modelValue = undefined;
+        expect(el.hasFeedbackFor).to.deep.equal(['error']);
+        expect(el.validationStates.error).to.not.eql({});
+      });
+
       describe('Events', () => {
         it('fires "showsFeedbackForChanged" event async after feedbackData got synced to feedbackElement', async () => {
           const spy = sinon.spy();


### PR DESCRIPTION
When removing a validator from an element, the results of the validation should be reset.
Otherwise the old validation result will stay and the validation will always fail.