### PR TITLE
fix(button): ie11 error when setting attribute in constructor

### DIFF
--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -162,7 +162,7 @@ export class LionButton extends DisabledWithTabIndexMixin(SlotMixin(LitElement))
       this._buttonId = `button-${Math.random()
         .toString(36)
         .substr(2, 10)}`;
-      this.setAttribute('aria-labelledby', this._buttonId);
+      this.updateComplete.then(() => this.setAttribute('aria-labelledby', this._buttonId));
     }
   }
 


### PR DESCRIPTION
Potentially resolves https://github.com/ing-bank/lion/issues/533