### PR TITLE
docs: added line to explain how to demo locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ For some more details see the [announcement blog post](https://medium.com/ing-bl
 
 We do have a [live Storybook](http://lion-web-components.netlify.com) which shows all our components.
 
+**Please note:** This project uses Yarn [Workspaces](https://classic.yarnpkg.com/en/docs/workspaces). If you want to run all demos locally you need to get [Yarn](https://classic.yarnpkg.com/en/docs/install) and install all depencies by executing `yarn install`.
+
 ## How to install
 
 ```bash


### PR DESCRIPTION
It is not clear for people which do not work with yarn workspaces that installing depencies with yarn is necessary.

Looked into README.md and expected something about it in the demo section so... here is a PR to explain short why and what to do.