### PR TITLE
fix(tabs): prevent scrolling when initially focussing a tab

### DIFF
--- a/packages/tabs/src/LionTabs.js
+++ b/packages/tabs/src/LionTabs.js
@@ -37,8 +37,12 @@ const cleanButton = (element, clickHandler, keydownHandler) => {
   element.removeEventListener('keydown', e => e.preventDefault());
 };
 
-const selectButton = element => {
-  element.focus();
+const selectButton = (element, firstUpdate = false) => {
+  // Don't focus on first update, as the component might be lower on the page
+  if (!firstUpdate) {
+    element.focus();
+  }
+
   element.setAttribute('selected', true);
   element.setAttribute('aria-selected', true);
   element.setAttribute('tabindex', 0);
@@ -109,6 +113,7 @@ export class LionTabs extends LitElement {
 
   firstUpdated() {
     super.firstUpdated();
+    this.__firstUpdate = true;
     this.__setupSlots();
   }
 
@@ -198,6 +203,7 @@ export class LionTabs extends LitElement {
   }
 
   set selectedIndex(value) {
+    this.__firstUpdate = false;
     const stale = this.__selectedIndex;
     this.__selectedIndex = value;
     this.__updateSelected();
@@ -231,7 +237,7 @@ export class LionTabs extends LitElement {
     }
     const { button: currentButton, panel: currentPanel } = this.__store[this.selectedIndex];
     if (currentButton) {
-      selectButton(currentButton);
+      selectButton(currentButton, this.__firstUpdate);
     }
     if (currentPanel) {
       selectPanel(currentPanel);

--- a/packages/tabs/test/lion-tabs.test.js
+++ b/packages/tabs/test/lion-tabs.test.js
@@ -243,6 +243,50 @@ describe('<lion-tabs>', () => {
     });
   });
 
+  describe('Initializing without Focus', () => {
+    it('keeps track of when the component is updated', async () => {
+      const el = await fixture(html`
+        <lion-tabs>
+          <button slot="tab">tab 1</button>
+          <div slot="panel">panel 1</div>
+          <button slot="tab">tab 2</button>
+          <div slot="panel">panel 2</div>
+        </lion-tabs>
+      `);
+
+      expect(el.__firstUpdate).to.be.true;
+      el.selectedIndex = 1;
+      expect(el.__firstUpdate).to.be.false;
+    });
+
+    it('does not focus a tab on firstUpdate', async () => {
+      const el = await fixture(html`
+        <lion-tabs>
+          <button slot="tab">tab 1</button>
+          <div slot="panel">panel 1</div>
+          <button slot="tab">tab 2</button>
+          <div slot="panel">panel 2</div>
+        </lion-tabs>
+      `);
+      const tabs = Array.from(el.children).filter(child => child.slot === 'tab');
+      expect(tabs.some(tab => tab === document.activeElement)).to.be.false;
+    });
+
+    it('focuses on a tab when switching the selectedIndex', async () => {
+      const el = await fixture(html`
+        <lion-tabs>
+          <button slot="tab">tab 1</button>
+          <div slot="panel">panel 1</div>
+          <button slot="tab">tab 2</button>
+          <div slot="panel">panel 2</div>
+        </lion-tabs>
+      `);
+      el.selectedIndex = 1;
+      const tab = Array.from(el.children).filter(child => child.slot === 'tab')[1];
+      expect(tab).to.equal(document.activeElement);
+    });
+  });
+
   describe('Accessibility', () => {
     it('does not make panels focusable', async () => {
       const el = await fixture(html`


### PR DESCRIPTION
Resolves https://github.com/ing-bank/lion/issues/587

## Input needed
Is it desired that focussing on a tab after a selectedIndex change does _not_ scroll to the element anymore? I am not sure from an accessibility point of view how this should behave.

## How to reproduce the issue before the fix

Here's a hacky way to see the issue. In the selected index tabs storybook, just a while bunch of whitespace on top of the tabs component. Then, refresh the page and you will see it scrolls down to the selected tab. After the fix, it does not behave like that anymore.

```
### Selected Index

You can set the `selectedIndex` to select a certain tab.

<Preview>
  <Story name="Selected index">
    {html`
    <br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/><br/>
      <lea-tabs .selectedIndex=${1}>
        <lea-tab slot="tab">Info</lea-tab>
        <lea-tab-panel slot="panel">
          Info page with lots of information about us.
        </lea-tab-panel>
        <lea-tab slot="tab">Work</lea-tab>
        <lea-tab-panel slot="panel">
          Work page that showcases our work.
        </lea-tab-panel>
      </lea-tabs>
    `}
  </Story>
</Preview>
```