### PR TITLE
fix(localization): for tr currencycode must be on end

### DIFF
--- a/packages/localize/src/number/normalizeIntl.js
+++ b/packages/localize/src/number/normalizeIntl.js
@@ -38,6 +38,9 @@ export function normalizeIntl(formattedParts, options, _locale) {
     }
     if (_locale === 'tr-TR') {
       normalize = forceTryCurrencyCode(normalize, options);
+      if (options.currencyDisplay === 'code') {
+        normalize = forceCurrencyToEnd(normalize);
+      }
     }
     if (_locale === 'en-AU') {
       normalize = forceENAUSymbols(normalize, options);

--- a/packages/localize/test/number/formatNumber.test.js
+++ b/packages/localize/test/number/formatNumber.test.js
@@ -311,10 +311,10 @@ describe('formatNumber', () => {
 
     describe('tr-TR', () => {
       localize.locale = 'tr-TR';
-      expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123.456,79');
-      expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123.456,79');
-      expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123.457');
-      expect(formatNumber(123456.789, currencyCode('TRY'))).to.equal('TL 123.456,79');
+      expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123.456,79 EUR');
+      expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123.456,79 USD');
+      expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123.457 JPY');
+      expect(formatNumber(123456.789, currencyCode('TRY'))).to.equal('123.456,79 TL');
       expect(formatNumber(123456.789, currencySymbol('EUR'))).to.equal('€123.456,79');
       expect(formatNumber(123456.789, currencySymbol('USD'))).to.equal('$123.456,79');
       expect(formatNumber(123456.789, currencySymbol('JPY'))).to.equal('¥123.457');


### PR DESCRIPTION
It is uncommon for Turkish people to use currency code at the start of a number. This commit fixes that.