### PR TITLE
feat(fieldset): expose filter on serializedValue

### DIFF
--- a/packages/fieldset/src/FormGroupMixin.js
+++ b/packages/fieldset/src/FormGroupMixin.js
@@ -203,6 +203,13 @@ export const FormGroupMixin = dedupeMixin(
       }
 
       /**
+       * @param {Function} filter Filter for form elements (default: el => !el.disabled)
+       */
+      filterSerializedValue(filter) {
+        return this._getFromAllFormElements('serializedValue', filter);
+      }
+
+      /**
        * @desc Handles interaction state 'submitted'.
        * This allows children to enable visibility of validation feedback
        */

--- a/packages/fieldset/test/lion-fieldset.test.js
+++ b/packages/fieldset/test/lion-fieldset.test.js
@@ -757,6 +757,38 @@ describe('<lion-fieldset>', () => {
       });
     });
 
+    it('does not serialize disabled values when no filter is given to `filterSerializedValue`', async () => {
+      const fieldset = await fixture(html`
+        <${tag}>
+          <${childTag} name="custom[]"></${childTag}>
+          <${childTag} name="custom[]"></${childTag}>
+        </${tag}>
+      `);
+      await nextFrame();
+      fieldset.formElements['custom[]'][0].modelValue = 'custom 1';
+      fieldset.formElements['custom[]'][1].disabled = true;
+
+      expect(fieldset.filterSerializedValue()).to.deep.equal({
+        'custom[]': ['custom 1'],
+      });
+    });
+
+    it('only serializes values matching the filter given to `filterSerializedValue`', async () => {
+      const fieldset = await fixture(html`
+        <${tag}>
+          <${childTag} name="custom[]"></${childTag}>
+          <${childTag} name="custom[]"></${childTag}>
+        </${tag}>
+      `);
+      await nextFrame();
+      fieldset.formElements['custom[]'][0].modelValue = 'custom 1';
+      fieldset.formElements['custom[]'][1].readonly = true;
+
+      expect(fieldset.filterSerializedValue(el => !el.readonly)).to.deep.equal({
+        'custom[]': ['custom 1'],
+      });
+    });
+
     it('will exclude form elements within a disabled fieldset', async () => {
       const fieldset = await fixture(html`
         <${tag} name="userData">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,6 +2266,11 @@
   resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.1.1.tgz#3ac8e498422ef316276bbe4aa687e35bd10c6871"
   integrity sha512-Y1+h5nQjJnDHP+8OceZB47I4D7iOiYnM0jXYLGEi96IusR93et30BIyEEQAJ4AvYfbuIrdbf0L5vQWfszU6/Jg==
 
+"@open-wc/dedupe-mixin@^1.2.1":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@open-wc/dedupe-mixin/-/dedupe-mixin-1.2.8.tgz#91acaf34e2e9978230c6b337d208aec9168d731c"
+  integrity sha512-hbv6c4Lcn+Nx+z+9wsFAC1WYsS2Lf/BXmb7hv++3eJltfkRtrPlxb/aCJ5FcdJiNKTE+CAY+OBvrfi3ao1YYGA==
+
 "@open-wc/demoing-storybook@^1.10.4":
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/@open-wc/demoing-storybook/-/demoing-storybook-1.10.5.tgz#3886e01fcc3b13485d5bdb4904f4ec627895609f"


### PR DESCRIPTION
Hi,

I noticed that there is a default filter of non-disabled elements when returning the serialized value, one of my use cases is that I would need to also filter by non-readonly elements. For this purpose I propose the exposure of the filter under a new method `filterSerializedValue(filter)`  to allow more flexibility in handling serializedValue:

```js
form.filterSerializedValue(el => !el.disabled && !el.readOnly);
```