### PR TITLE
fix(form): remove correct reset event listener on teardown

### DIFF
--- a/packages/form/src/LionForm.js
+++ b/packages/form/src/LionForm.js
@@ -57,6 +57,6 @@ export class LionForm extends LionFieldset {
 
   __teardownEventsForLionForm() {
     this._formNode.removeEventListener('submit', this._submit);
-    this._formNode.removeEventListener('rest', this._reset);
+    this._formNode.removeEventListener('reset', this._reset);
   }
 }


### PR DESCRIPTION
Spotted this small typo while looking into for LionForm works.

Doesn't cause big issues, but long-term it might allocate too much memory to unused event listeners :)