### PR TITLE
Adding link to Overlay System - Configuration from Dialog storybook docs

### DIFF
--- a/packages/dialog/stories/index.stories.mdx
+++ b/packages/dialog/stories/index.stories.mdx
@@ -73,7 +73,7 @@ import '@lion/dialog/lion-dialog.js';
 ## Changing the configuration
 
 You can use the `config` property on the dialog to change the configuration.
-The documentation of the full config object can be found in the `lion/overlay` package.
+The documentation of the full config object can be found in the `lion/overlay` package or here in [Overlay System - Configuration](/?path=/docs/overlays-system-configuration--placement-mode-local).
 
 The `config` property uses a setter to merge the passed configuration with the current, so you only **overwrite what you pass** when updating `config`.
 

--- a/packages/overlays/stories/20-index.stories.mdx
+++ b/packages/overlays/stories/20-index.stories.mdx
@@ -19,7 +19,7 @@ dropdown, etc.
 It's designed to be highly flexible, while still delivering sensible defaults.
 On top of this, the system was built having accessibility in mind.
 
-For a detailed rationale, please consult [Rationale](?path=/docs/overlay-rationale--page).
+For a detailed rationale, please consult [Rationale](/?path=/docs/overlays-system-rationale--page).
 
 <Story name="Default">
   {html`


### PR DESCRIPTION
Hey there,

As discussed in Slack channel, I open this PR in order to make easier to find the docs regarding the `.config` object to be passed to `Dialog`.

Also, I fixed another link that was broken.

Any questions, please let me know.

Many thanks! ✌️