### PR TITLE
WIP chore(overlays): refactor backdrop code, provide default backdrop styles

### DIFF
--- a/packages/overlays/src/OverlaysManager.js
+++ b/packages/overlays/src/OverlaysManager.js
@@ -1,5 +1,5 @@
-import { unsetSiblingsInert, setSiblingsInert } from './utils/inert-siblings.js';
 import { globalOverlaysStyle } from './globalOverlaysStyle.js';
+import { setSiblingsInert, unsetSiblingsInert } from './utils/inert-siblings.js';
 
 const isIOS = navigator.userAgent.match(/iPhone|iPad|iPod/i);
 

--- a/packages/overlays/src/localOverlaysStyle.js
+++ b/packages/overlays/src/localOverlaysStyle.js
@@ -1,0 +1,41 @@
+import { css } from '@lion/core';
+
+export const localOverlaysStyle = css`
+  .local-overlays__backdrop {
+    content: '';
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    background-color: #333333;
+    opacity: 0.3;
+    display: none;
+  }
+
+  .local-overlays__backdrop--visible {
+    display: block;
+  }
+
+  .local-overlays__backdrop--fade-in {
+    animation: local-overlays-backdrop-fade-in 300ms;
+  }
+
+  .local-overlays__backdrop--fade-out {
+    animation: local-overlays-backdrop-fade-out 300ms;
+    opacity: 0;
+  }
+
+  @keyframes local-overlays-backdrop-fade-in {
+    from {
+      opacity: 0;
+    }
+  }
+
+  @keyframes local-overlays-backdrop-fade-out {
+    from {
+      opacity: 0.3;
+    }
+  }
+`;

--- a/packages/overlays/stories/20-index.stories.mdx
+++ b/packages/overlays/stories/20-index.stories.mdx
@@ -587,32 +587,13 @@ Below an example is shown with the `isBlocking` option, which makes use of the O
 
 
 ## Local Backdrop
+
 We provide a possibility to add a backdrop to a locally placed overlay.
-You can pass your backdropNode as a configuration parameter and control its styling reacting upon OverlayController events.
-Here is the example below
 
 <Story name="Local backdrop">
-  {() => {
-    let backdropNode = document.createElement('div');
-    backdropNode.classList.add('local-backdrop-01');
-    return html`
-    <style>
-      .local-backdrop-01 {
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        z-index: 1;
-        background-color: red;
-        opacity: 0.3;
-        display: none;
-      }
-    </style>
+  {() => html`
     <demo-overlay-system
-      @before-opened=${(e) => backdropNode.style.display = 'block'}
-      @before-closed=${(e) => backdropNode.style.display = 'none'}
-      .config=${{ hasBackdrop: true, placementMode: 'local', backdropNode }}
+      .config=${{ hasBackdrop: true, placementMode: 'local' }}
     >
       <button slot="invoker">Click me to open the overlay!</button>
       <div slot="content" class="demo-overlay">
@@ -624,15 +605,77 @@ Here is the example below
         </button>
       </div>
     </demo-overlay-system>
-  `}}
+  `}
+</Story>
+
+```html
+<demo-overlay-system
+  .config=${{ hasBackdrop: true, placementMode: 'local', }}
+>
+  <button slot="invoker">Click me to open the overlay!</button>
+  <div slot="content" class="demo-overlay">
+    Hello! You can close this notification here:
+    <button
+      @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
+    >
+      ⨯
+    </button>
+  </div>
+</demo-overlay-system>
+```
+
+### Pass a backdropNode
+
+You can, optionally, pass your own `backdropNode` as a configuration parameter and control its styling and how it responds to OverlayController events.
+Passing your own `backdropNode` will mean you do not get any of the default styling that we provide if you do not pass a node.
+
+Here is the example below.
+
+<Story name="Passing local backdrop">
+  {() => {
+    let backdropNode = document.createElement('div');
+    backdropNode.classList.add('custom-backdrop');
+    return html`
+      <style>
+        .custom-backdrop {
+          content: '';
+          position: fixed;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          z-index: 1;
+          background-color: red;
+          opacity: 0.3;
+          display: none;
+        }
+      </style>
+      <demo-overlay-system
+        @before-opened=${(e) => backdropNode.style.display = 'block'}
+        @before-closed=${(e) => backdropNode.style.display = 'none'}
+        .config=${{ hasBackdrop: true, placementMode: 'local', backdropNode }}
+      >
+        <button slot="invoker">Click me to open the overlay!</button>
+        <div slot="content" class="demo-overlay">
+          Hello! You can close this notification here:
+          <button
+            @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
+          >
+            ⨯
+          </button>
+        </div>
+      </demo-overlay-system>
+    `;
+  }}
 </Story>
 
 ```js
-  let backdropNode = document.createElement('div');
-  backdropNode.classList.add('local-backdrop-01');
-  return html`
+let backdropNode = document.createElement('div');
+backdropNode.classList.add('custom-backdrop');
+return html`
   <style>
-    .local-backdrop-01 {
+    .custom-backdrop {
+      content: '';
       position: fixed;
       top: 0;
       left: 0;
@@ -659,22 +702,19 @@ Here is the example below
       </button>
     </div>
   </demo-overlay-system>
+`;
 ```
 
-## Declarative Local Backdrop
+### Declarative Local Backdrop
+
 Another way to add custom backdrop is declaratively add an element with `slot="backdrop"`.
 
 <Story name="Declarative Local Backdrop">
   {() => {
-    const beforeOpened = () => {
-      document.querySelector('.local-backdrop-02').style.display = 'block';
-    }
-    const beforeClosed = () => {
-      document.querySelector('.local-backdrop-02').style.display = 'none';
-    }
     return html`
     <style>
-      .local-backdrop-02 {
+      .custom-backdrop-declarative {
+        content: '';
         position: fixed;
         top: 0;
         left: 0;
@@ -687,11 +727,11 @@ Another way to add custom backdrop is declaratively add an element with `slot="b
       }
     </style>
     <demo-overlay-system
-      @before-opened=${beforeOpened}
-      @before-closed=${beforeClosed}
+      @before-opened=${(e) => document.querySelector('.custom-backdrop-declarative').style.display = 'block'}
+      @before-closed=${(e) => document.querySelector('.custom-backdrop-declarative').style.display = 'none'}
       .config=${{ hasBackdrop: true, placementMode: 'local' }}
     >
-      <div slot="backdrop" class="local-backdrop-02"></div>
+      <div slot="backdrop" class="custom-backdrop-declarative"></div>
       <button slot="invoker">Click me to open the overlay!</button>
       <div slot="content" class="demo-overlay">
         Hello! You can close this notification here:
@@ -706,15 +746,10 @@ Another way to add custom backdrop is declaratively add an element with `slot="b
 </Story>
 
 ```js
-  const beforeOpened = () => {
-    document.querySelector('.local-backdrop-02').style.display = 'block';
-  }
-  const beforeClosed = () => {
-    document.querySelector('.local-backdrop-02').style.display = 'none';
-  }
-  return html`
+return html`
   <style>
-    .local-backdrop-02 {
+    .custom-backdrop-declarative {
+      content: '';
       position: fixed;
       top: 0;
       left: 0;
@@ -727,11 +762,9 @@ Another way to add custom backdrop is declaratively add an element with `slot="b
     }
   </style>
   <demo-overlay-system
-    @before-opened=${beforeOpened}
-    @before-closed=${beforeClosed}
     .config=${{ hasBackdrop: true, placementMode: 'local' }}
   >
-    <div slot="backdrop" class="local-backdrop-02"></div>
+    <div slot="backdrop" class="custom-backdrop-declarative"></div>
     <button slot="invoker">Click me to open the overlay!</button>
     <div slot="content" class="demo-overlay">
       Hello! You can close this notification here:
@@ -742,4 +775,5 @@ Another way to add custom backdrop is declaratively add an element with `slot="b
       </button>
     </div>
   </demo-overlay-system>
+`;
 ```

--- a/packages/overlays/test/OverlayController.test.js
+++ b/packages/overlays/test/OverlayController.test.js
@@ -1,20 +1,20 @@
 /* eslint-disable no-new */
+import '@lion/core/test-helpers/keyboardEventShimIE.js';
 import {
-  expect,
-  html,
-  fixture,
   aTimeout,
   defineCE,
-  unsafeStatic,
+  expect,
+  fixture,
+  html,
   nextFrame,
+  unsafeStatic,
 } from '@open-wc/testing';
 import { fixtureSync } from '@open-wc/testing-helpers';
-import '@lion/core/test-helpers/keyboardEventShimIE.js';
 import sinon from 'sinon';
-import { keyCodes } from '../src/utils/key-codes.js';
-import { simulateTab } from '../src/utils/simulate-tab.js';
 import { OverlayController } from '../src/OverlayController.js';
 import { overlays } from '../src/overlays.js';
+import { keyCodes } from '../src/utils/key-codes.js';
+import { simulateTab } from '../src/utils/simulate-tab.js';
 
 const withGlobalTestConfig = () => ({
   placementMode: 'global',
@@ -689,6 +689,18 @@ describe('OverlayController', () => {
         expect(ctrl.backdropNode).to.be.undefined;
         await ctrl.hide();
 
+        const controllerWithBackdrop = new OverlayController({
+          ...withLocalTestConfig(),
+          hasBackdrop: true,
+        });
+        await controllerWithBackdrop.show();
+        expect(controllerWithBackdrop.backdropNode).to.have.class('local-overlays__backdrop');
+        expect(controllerWithBackdrop.backdropNode).to.have.class(
+          'local-overlays__backdrop--visible',
+        );
+      });
+
+      it('supports passing your own backdrop node', async () => {
         const backdropNode = document.createElement('div');
         backdropNode.classList.add('custom-backdrop');
 
@@ -699,22 +711,21 @@ describe('OverlayController', () => {
         });
         await controllerWithBackdrop.show();
         expect(controllerWithBackdrop.backdropNode).to.have.class('custom-backdrop');
+        expect(controllerWithBackdrop.backdropNode).to.not.have.class('local-overlays__backdrop');
       });
 
       it('reenables the backdrop when shown/hidden/shown', async () => {
-        const backdropNode = document.createElement('div');
-        backdropNode.classList.add('custom-backdrop');
-
         const ctrl = new OverlayController({
           ...withLocalTestConfig(),
           hasBackdrop: true,
-          backdropNode,
         });
         await ctrl.show();
-        expect(ctrl.backdropNode).to.have.class('custom-backdrop');
+        expect(ctrl.backdropNode).to.have.class('local-overlays__backdrop--visible');
         await ctrl.hide();
+        await aTimeout(300); // animation fade out is 300ms before the class is removed to make it display none
+        expect(ctrl.backdropNode).to.not.have.class('local-overlays__backdrop--visible');
         await ctrl.show();
-        expect(ctrl.backdropNode).to.have.class('custom-backdrop');
+        expect(ctrl.backdropNode).to.have.class('local-overlays__backdrop--visible');
       });
 
       it('adds and stacks backdrops if .hasBackdrop is enabled', async () => {


### PR DESCRIPTION
I was looking at the demos, and wanted to give an example where you don't pass your own node.

Then I saw we don't give any default styling like we do for the global overlay backdrop, so I implemented that. And then I refactored some of the code in OverlayController to be cleaner / more DRY :)