### PR TITLE
wip: fix(overlays): synchronize intercepted opened state OverlayMixin

### DIFF
--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -223,6 +223,10 @@ export const OverlayMixin = dedupeMixin(
           const event = new CustomEvent('before-opened', { cancelable: true });
           this.dispatchEvent(event);
           if (event.defaultPrevented) {
+            // Check whether our current opened state is not out of sync with overlayCtrl
+            // TODO: quick and dirty way to bypass prop effects (updated). Fix in a nice
+            // way, wihtoutrelying on implementation details of UpdatingElement.
+            this.__opened = this._overlayCtrl.isShown;
             beforeShowEvent.preventDefault();
           }
         };
@@ -231,6 +235,10 @@ export const OverlayMixin = dedupeMixin(
           const event = new CustomEvent('before-closed', { cancelable: true });
           this.dispatchEvent(event);
           if (event.defaultPrevented) {
+            // Check whether our current opened state is not out of sync with overlayCtrl
+            // TODO: quick and dirty way to bypass prop effects (updated). Fix in a nice
+            // way, wihtoutrelying on implementation details of UpdatingElement.
+            this.__opened = this._overlayCtrl.isShown;
             beforeHideEvent.preventDefault();
           }
         };


### PR DESCRIPTION
Proposal to fix https://github.com/ing-bank/lion/issues/469

TODO:
- It currently relies on setting `this.__opened` to synchronize `this.opened`. This is an implementation detail of UpdatingElement, so preferably we add a way to take ownership of the implementation detail (for instance by overriding the getter/setter, making us in control of the private variable name.
- add a unit test