### PR TITLE
fix(overlays): synchronize intercepted opened state OverlayMixin

### DIFF
--- a/packages/overlays/stories/demo-overlay-system.js
+++ b/packages/overlays/stories/demo-overlay-system.js
@@ -32,6 +32,7 @@ class DemoOverlaySystem extends OverlayMixin(LitElement) {
       <slot name="invoker"></slot>
       <slot name="content"></slot>
       <slot name="_overlay-shadow-outlet"></slot>
+      <div>popup is ${this.opened ? 'opened' : 'closed'}</div>
     `;
   }
 }

--- a/packages/overlays/test-suites/OverlayMixin.suite.js
+++ b/packages/overlays/test-suites/OverlayMixin.suite.js
@@ -113,7 +113,14 @@ export function runOverlayMixinSuite({ /* tagString, */ tag, suffix = '' }) {
           <button slot="invoker">invoker button</button>
         </${tag}>
       `);
-      await el._overlayCtrl.show();
+      el.querySelector('[slot="invoker"]').click();
+      await nextFrame();
+      expect(el.opened).to.be.false;
+
+      // Also, the opened state should be synced back to that of the OverlayController
+      el.opened = true;
+      expect(el.opened).to.be.true;
+      await nextFrame();
       expect(el.opened).to.be.false;
     });
 


### PR DESCRIPTION
this MR fixes issue 469 
Thanks to @tlouisse for the fix. I added a test to cover the real use case (clicking on the invoker and not calling the show directly)