### PR TITLE
fix localize when combined with google translate

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,34 @@
+<html lang="en-US">
+
+<body>
+  <h3>Document level</h3>
+  <div id="documentLevelOutput"></div>
+  <hr />
+  <h3>Shadow</h3>
+  <div id="withinShadowRootOutput"></div>
+
+  <script>
+    const domToAdd = `
+  <p> Some English text </p>
+  <p> Een beetje Nederlandse tekst </p>
+  <button onclick="append('More English text', this)">append EN</button>
+  <button onclick="append('Meer Nederlandse tekst', this)">append NL</button>`;
+
+    const documentLevelOutput = document.getElementById('documentLevelOutput');
+    documentLevelOutput.innerHTML = domToAdd;
+
+    const withinShadowRootOutput = document.getElementById('withinShadowRootOutput');
+    withinShadowRootOutput.attachShadow({ mode: 'open' });
+    withinShadowRootOutput.shadowRoot.innerHTML = domToAdd;
+
+    function append(txt, buttonEl) {
+      const para = document.createElement('p');
+      para.innerText = txt;
+      const target = buttonEl.closest('[id]') || buttonEl.getRootNode();
+      target.appendChild(para);
+    }
+
+  </script>
+</body>
+
+</html>

--- a/packages/localize/test/LocalizeManager.test.js
+++ b/packages/localize/test/LocalizeManager.test.js
@@ -225,7 +225,7 @@ describe('LocalizeManager', () => {
         expect(e).to.be.instanceof(Error);
         expect(e.message).to.equal(
           'Data for namespace "my-component" and locale "en-GB" could not be loaded. ' +
-          'Make sure you have data for locale "en-GB" (and/or generic language "en").',
+            'Make sure you have data for locale "en-GB" (and/or generic language "en").',
         );
         return;
       }
@@ -280,7 +280,7 @@ describe('LocalizeManager', () => {
           expect(e).to.be.instanceof(Error);
           expect(e.message).to.equal(
             'Data for namespace "my-component" and current locale "nl-NL" or fallback locale "en-GB" could not be loaded. ' +
-            'Make sure you have data either for locale "nl-NL" (and/or generic language "nl") or for fallback "en-GB" (and/or "en").',
+              'Make sure you have data either for locale "nl-NL" (and/or generic language "nl") or for fallback "en-GB" (and/or "en").',
           );
           return;
         }
@@ -556,8 +556,6 @@ describe('LocalizeManager', () => {
   });
 });
 
-
-
 describe('When supporting external translation tools like Google Translate', () => {
   let manager;
   const originalLang = document.documentElement.lang;
@@ -575,13 +573,16 @@ describe('When supporting external translation tools like Google Translate', () 
       LocalizeManager.resetInstance();
     }
     return LocalizeManager.getInstance({
-      autoLoadOnLocaleChange: true,
-      fallbackLocale: 'en-GB',
       supportExternalTranslationTools: true,
     });
   }
 
   afterEach(async () => {
+    document.documentElement.removeAttribute('lang');
+    document.documentElement.removeAttribute('data-localize-lang');
+  });
+
+  after(async () => {
     document.documentElement.lang = originalLang;
     document.documentElement.removeAttribute('data-localize-lang');
   });
@@ -591,10 +592,6 @@ describe('When supporting external translation tools like Google Translate', () 
       manager.reset();
       manager.teardown();
       LocalizeManager.resetInstance();
-
-      // This simulates a default setup: <html data-localize-lang="en-GB" lang="en-GB">
-      document.documentElement.lang = 'en-GB'; // needed for a11y, can be altered by Google Translate
-      document.documentElement.setAttribute('data-localize-lang', 'en-GB'); // read by manager
     });
 
     it(`restores html[lang] when 3rd party translation tool is turned off again`, async () => {
@@ -608,19 +605,19 @@ describe('When supporting external translation tools like Google Translate', () 
 
     it(`synchronizes from LocalizeManager to html[lang] when
       3rd party translation tool is NOT in control (default scenario)`, async () => {
-        manager = getInstance();
-        manager.locale = 'nl-NL';
-        expect(document.documentElement.lang).to.equal('nl-NL');
-      });
+      manager = getInstance();
+      manager.locale = 'nl-NL';
+      expect(document.documentElement.lang).to.equal('nl-NL');
+    });
 
     // TODO: works when run in isolation. Find out which side effects to get rid of...
-    it.skip(`doesn't synchronize from LocalizeManager to html[lang] when
+    it(`doesn't synchronize from LocalizeManager to html[lang] when
       3rd party translation tool is in control`, async () => {
-        manager = getInstance();
-        await simulateGoogleTranslateOn('fr');
-        manager.locale = 'nl-NL';
-        expect(document.documentElement.lang).to.equal('fr');
-      });
+      manager = getInstance();
+      await simulateGoogleTranslateOn('fr');
+      manager.locale = 'nl-NL';
+      expect(document.documentElement.lang).to.equal('fr');
+    });
 
     it(`doesn't synchronize from html[lang] attribute to LocalizeManager`, async () => {
       manager = getInstance();
@@ -630,13 +627,11 @@ describe('When supporting external translation tools like Google Translate', () 
       await simulateGoogleTranslateOn('fr');
       expect(manager.locale).to.equal('nl-NL');
     });
-
-
   });
 
   describe('On initialization', () => {
     /** A default scenario */
-    it("synchronizes from html[data-localize-lang] attribute to LocalizeManager", async () => {
+    it('synchronizes from html[data-localize-lang] attribute to LocalizeManager', async () => {
       document.documentElement.setAttribute('data-localize-lang', 'nl-NL');
       document.documentElement.lang = 'nl-NL';
       manager = getInstance();
@@ -645,18 +640,17 @@ describe('When supporting external translation tools like Google Translate', () 
 
     /** A scenario where Google Translate kicked in before initialization */
     it(`synchronizes from html[data-localize-lang] attribute to LocalizeManager when html[lang]
-      has a different value` , async () => {
-        document.documentElement.setAttribute('data-localize-lang', 'en-GB');
-        document.documentElement.lang = 'fr';
-        manager = getInstance();
-        expect(manager.locale).to.equal('en-GB');
-      });
-
-    // TODO: works when run in isolation. Find out which side effects to get rid of...
-    it.skip("doesn't synchronize from html[lang] attribute to LocalizeManager", async () => {
+      has a different value`, async () => {
+      document.documentElement.setAttribute('data-localize-lang', 'en-GB');
+      document.documentElement.lang = 'fr';
       manager = getInstance();
-      document.documentElement.lang = 'en-GB';
-      expect(manager.locale).to.be.undefined;
+      expect(manager.locale).to.equal('en-GB');
+    });
+
+    it("doesn't synchronize from html[lang] attribute to LocalizeManager", async () => {
+      manager = getInstance();
+      document.documentElement.lang = 'nl-NL';
+      expect(manager.locale).to.not.equal('nl-NL');
     });
   });
 });
@@ -699,7 +693,7 @@ describe('[deprecated] When not supporting external translation tools like Googl
 
     manager = new LocalizeManager({
       supportExternalTranslationTools: false,
-      autoLoadOnLocaleChange: true
+      autoLoadOnLocaleChange: true,
     });
 
     await manager.loadNamespace({
@@ -719,5 +713,4 @@ describe('[deprecated] When not supporting external translation tools like Googl
       'nl-NL': { 'my-component': { greeting: 'Hallo!' } },
     });
   });
-
 });

--- a/packages/localize/test/number/formatNumber.test.js
+++ b/packages/localize/test/number/formatNumber.test.js
@@ -310,15 +310,17 @@ describe('formatNumber', () => {
     });
 
     describe('tr-TR', () => {
-      localize.locale = 'tr-TR';
-      expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123.456,79');
-      expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123.456,79');
-      expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123.457');
-      expect(formatNumber(123456.789, currencyCode('TRY'))).to.equal('TL 123.456,79');
-      expect(formatNumber(123456.789, currencySymbol('EUR'))).to.equal('€123.456,79');
-      expect(formatNumber(123456.789, currencySymbol('USD'))).to.equal('$123.456,79');
-      expect(formatNumber(123456.789, currencySymbol('JPY'))).to.equal('¥123.457');
-      expect(formatNumber(123456.789, currencySymbol('TRY'))).to.equal('₺123.456,79');
+      it('supports basics', () => {
+        localize.locale = 'tr-TR';
+        expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123.456,79');
+        expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123.456,79');
+        expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123.457');
+        expect(formatNumber(123456.789, currencyCode('TRY'))).to.equal('TL 123.456,79');
+        expect(formatNumber(123456.789, currencySymbol('EUR'))).to.equal('€123.456,79');
+        expect(formatNumber(123456.789, currencySymbol('USD'))).to.equal('$123.456,79');
+        expect(formatNumber(123456.789, currencySymbol('JPY'))).to.equal('¥123.457');
+        expect(formatNumber(123456.789, currencySymbol('TRY'))).to.equal('₺123.456,79');
+      });
     });
   });
 });


### PR DESCRIPTION
## Support for Google Translate

closes https://github.com/ing-bank/lion/issues/234

**!! update !!**
An enhanced (non breaking/backwards compatible because of automatic feature detection) version of this merge request has been implemented in our extension layer in the meantime. Whenever proceeding this mr, please make sure to use that solution as a fundament.

-------------------------------------------

All options are behind an opt-in flag `supportExternalTranslationTools`, since it's a breaking change.

## The flow explained

```
/**
 * Support for Google Translate (or other 3rd parties taking control
 * of the html[lang] attribute).
 *
 * Have the following scenario in mind:
 * 1. locale is initialized by developer via html[data-localize-lang="en-US"] and
 * html[lang="en-US"]. When localize is loaded (note that this also can be after step 2 below),
 * it will sync its initial state from html[data-localize-lang]
 * 2. Google Translate kicks in for the French language. It will set html[lang="fr"].
 * This new language is not one known by us, so we most likely don't have translations for
 * this file. Therefore, we do NOT sync this value to LocalizeManager. The manager should
 * still ask for known resources (in this case for locale 'en-US')
 * 3. locale is changed (think of a language dropdown)
 * It's a bit of a weird case, because we would not expect an end user to do this. If he/she
 * does, make sure that we do not go against Google Translate, so we maintain accessibility
 * (by not altering html[lang]). We detect this by reading _langAttrSetByTranslationTool:
 * when its value is null, we consider Google translate 'not active'.
 *
 * When Google Translate is turned off by the user (html[lang=auto]),
 * `localize.locale` will be synced to html[lang] again
 *
 *
 * Keep in mind that all of the above also works with other tools than Google Translate,
 * but this is most widely used tool and therefore used as an example.
 */
``` 

_Open question: do we enable this flag by default (this allows to disable it in our extension layer and keep it backward compatible) or do we disable it by default on Lion as well?_

Currently it's enabled and then we have 17 failing tests throughout Lion in packages that depend on `localize`.

### To do
- [ ] I seperated the the 'Google Translate' test in a distinct describe to make it easier to review. They need to be integrated into the other tests
- [ ] fix failing tests in other packages (assuming we go for `supportExternalTranslationTools` enabled by default)
- [ ] clean up commit history
