### PR TITLE
fix(input-amount): set hint to use numeric on-screen keyboard

### DIFF
--- a/packages/input-amount/src/LionInputAmount.js
+++ b/packages/input-amount/src/LionInputAmount.js
@@ -82,6 +82,7 @@ export class LionInputAmount extends LocalizeMixin(LionInput) {
     // eslint-disable-next-line wc/guard-super-call
     super.connectedCallback();
     this.type = 'text';
+    this._inputNode.setAttribute('inputmode', 'decimal');
 
     if (this.currency) {
       this.__setCurrencyDisplayLabel();

--- a/packages/input-amount/test/lion-input-amount.test.js
+++ b/packages/input-amount/test/lion-input-amount.test.js
@@ -64,6 +64,11 @@ describe('<lion-input-amount>', () => {
     expect(el.parser).to.equal(parseAmount);
   });
 
+  it('sets inputmode attribute to decimal', async () => {
+    const el = await fixture(`<lion-input-amount></lion-input-amount>`);
+    expect(el._inputNode.inputMode).to.equal('decimal');
+  });
+
   it('has type="text" to activate default keyboard on mobile with all necessary symbols', async () => {
     const el = await fixture(`<lion-input-amount></lion-input-amount>`);
     expect(el._inputNode.type).to.equal('text');


### PR DESCRIPTION
Added inputmode='decimal' to improve experience on mobile devices (numeric keyboard with decimal signs opens automatically on supported browsers => see https://css-tricks.com/everything-you-ever-wanted-to-know-about-inputmode/ )