### PR TITLE
fix(remark-extend): add missing main entry point

### DIFF
--- a/packages/remark-extend/index.js
+++ b/packages/remark-extend/index.js
@@ -1,0 +1,5 @@
+const { remarkExtend } = require('./src/remarkExtend.js');
+
+module.exports = {
+  remarkExtend,
+};


### PR DESCRIPTION
without it this fails
```js
const { remarkExtend } = require('remark-extend');
```