### PR TITLE
fix(dialog): teardown open close listeners after initial updateComplete

### DIFF
--- a/packages/dialog/src/LionDialog.js
+++ b/packages/dialog/src/LionDialog.js
@@ -1,5 +1,5 @@
-import { withModalDialogConfig, OverlayMixin } from '@lion/overlays';
-import { LitElement, html } from '@lion/core';
+import { html, LitElement } from '@lion/core';
+import { OverlayMixin, withModalDialogConfig } from '@lion/overlays';
 
 export class LionDialog extends OverlayMixin(LitElement) {
   // eslint-disable-next-line class-methods-use-this

--- a/packages/dialog/test/lion-dialog.test.js
+++ b/packages/dialog/test/lion-dialog.test.js
@@ -1,6 +1,5 @@
-import { expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import { runOverlayMixinSuite } from '@lion/overlays/test-suites/OverlayMixin.suite.js';
-
+import { expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import '../lion-dialog.js';
 
 describe('lion-dialog', () => {
@@ -29,6 +28,31 @@ describe('lion-dialog', () => {
       invoker.click();
 
       expect(el.opened).to.be.true;
+    });
+
+    it('supports nested overlays', async () => {
+      const el = await fixture(html`
+        <lion-dialog>
+          <div slot="content">
+            open nested overlay:
+            <lion-dialog>
+              <div slot="content">
+                Nested content
+              </div>
+              <button slot="invoker">nested invoker button</button>
+            </lion-dialog>
+          </div>
+          <button slot="invoker">invoker button</button>
+        </lion-dialog>
+      `);
+
+      el._overlayInvokerNode.click();
+      expect(el.opened).to.be.true;
+
+      const wrapperNode = Array.from(document.querySelector('.global-overlays').children)[1];
+      const nestedDialog = wrapperNode.querySelector('lion-dialog');
+      nestedDialog._overlayInvokerNode.click();
+      expect(nestedDialog.opened).to.be.true;
     });
   });
 });

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -147,8 +147,8 @@ export const OverlayMixin = dedupeMixin(
         if (this._overlayCtrl) {
           this.__tornDown = true;
           this.__overlayContentNodeWrapperBeforeTeardown = this._overlayContentNodeWrapper;
-          this._teardownOverlayCtrl();
         }
+        this._teardownOverlayCtrl();
       }
 
       get _overlayInvokerNode() {
@@ -206,10 +206,13 @@ export const OverlayMixin = dedupeMixin(
         this.__overlaySetupCompleteResolve();
       }
 
-      _teardownOverlayCtrl() {
+      async _teardownOverlayCtrl() {
+        if (this._overlayCtrl) {
+          this.__teardownSyncFromOverlayController();
+          this._overlayCtrl.teardown();
+        }
+        await this.updateComplete;
         this._teardownOpenCloseListeners();
-        this.__teardownSyncFromOverlayController();
-        this._overlayCtrl.teardown();
       }
 
       async _setOpenedWithoutPropertyEffects(newOpened) {


### PR DESCRIPTION
fixes https://github.com/ing-bank/lion/issues/676

The reason this bug was here is because open/close event listeners were added on a nested dialog, but then the nested dialog would be moved through the DOM **before** finishing setting up the overlay controller. So then disconnectedCallback would happen and not tear down the open/close event listeners (because of the overlay controller guard). 

And then you get duplicate open/close listeners on the nested dialog, resulting in a double toggle on click, which means it opens and instantly closes.