### PR TITLE
fix: throw when passing unconnected contentNode

### DIFF
--- a/packages/overlays/docs/20-index.md
+++ b/packages/overlays/docs/20-index.md
@@ -59,8 +59,10 @@ and has the following public functions:
 
 All overlays contain an invokerNode and a contentNode
 
-- **contentNode**, the toggleable content of the overlay
+- **contentNode**, the toggleable content of the overlay.
 - **invokerNode**, the element toggles the visibility of the content. For local overlays, this is the relative element the content is positioned to
+
+> Make sure you pass a DOM-connected contentNode, an offline rendered (e.g. with just `document.createElement` or `renderLitAsNode`) will not work, because then we cannot determine the renderTarget to render the content to.
 
 For DOM position, local refers to overlays where the content is positioned next to the invokers they are related to, DOM-wise.
 Global refers to overlays where the content is positioned in a global root node at the bottom of `<body>`.

--- a/packages/overlays/src/OverlayController.js
+++ b/packages/overlays/src/OverlayController.js
@@ -135,6 +135,11 @@ export class OverlayController {
     this._contentId = `overlay-content--${Math.random().toString(36).substr(2, 10)}`;
 
     if (this._defaultConfig.contentNode) {
+      if (!this._defaultConfig.contentNode.isConnected) {
+        throw new Error(
+          '[OverlayController] Could not find a render target, since the provided contentNode is not connected to the DOM. Make sure that it is connected, e.g. by doing "document.body.appendChild(contentNode)", before passing it on.',
+        );
+      }
       this.__isContentNodeProjected = Boolean(this._defaultConfig.contentNode.assignedSlot);
     }
     this.updateConfig(config);

--- a/packages/overlays/test/OverlaysManager.test.js
+++ b/packages/overlays/test/OverlaysManager.test.js
@@ -6,16 +6,13 @@ describe('OverlaysManager', () => {
   let defaultOptions;
   let mngr;
 
-  before(async () => {
+  beforeEach(async () => {
     const contentNode = await fixture(html`<p>my content</p>`);
 
     defaultOptions = {
       placementMode: 'global',
       contentNode,
     };
-  });
-
-  beforeEach(() => {
     mngr = new OverlaysManager();
   });
 


### PR DESCRIPTION
This was already not working and would give you problems, now we explicitly mention why it fails by throwing an error