### PR TITLE
fix(field): remove validation toggled disable

### DIFF
--- a/packages/form-core/src/validate/ValidateMixin.js
+++ b/packages/form-core/src/validate/ValidateMixin.js
@@ -265,7 +265,7 @@ export const ValidateMixin = dedupeMixin(
       async validate({ clearCurrentResult } = {}) {
         if (this.disabled) {
           this.__clearValidationResults();
-          this.__validationResult = [];
+          this.__finishValidation({ source: 'sync', hasAsync: true });
           this._updateFeedbackComponent();
           return;
         }

--- a/packages/form-core/test/lion-field.test.js
+++ b/packages/form-core/test/lion-field.test.js
@@ -380,7 +380,36 @@ describe('<lion-field>', () => {
       expect(el.validationStates.error).to.have.a.property('HasX');
 
       expect(disabledEl.hasFeedbackFor).to.deep.equal([]);
-      expect(disabledEl.validationStates.error).to.equal(undefined);
+      expect(disabledEl.validationStates.error).to.deep.equal({});
+    });
+
+    it('should remove validation when disabled state toggles', async () => {
+      const HasX = class extends Validator {
+        constructor() {
+          super();
+          this.name = 'HasX';
+        }
+
+        execute(value) {
+          const result = value.indexOf('x') === -1;
+          return result;
+        }
+      };
+      const el = await fixture(html`
+        <${tag}
+          .validators=${[new HasX()]}
+          .modelValue=${'a@b.nl'}
+        >
+          ${inputSlot}
+        </${tag}>
+      `);
+      expect(el.hasFeedbackFor).to.deep.equal(['error']);
+      expect(el.validationStates.error).to.have.a.property('HasX');
+
+      el.disabled = true;
+      await el.updateComplete;
+      expect(el.hasFeedbackFor).to.deep.equal([]);
+      expect(el.validationStates.error).to.deep.equal({});
     });
 
     it('can be required', async () => {


### PR DESCRIPTION
Closes #705 

When a field is enabled and then toggled to disabled while being invalid, it still had the `validationStates` and `hasFeedbackFor` properties set from when it was enabled.

Calling `this.__finishValidation` synchronously after `this.__clearValidationResults`, ensures that those properties are reset.