### PR TITLE
fix: define side effects for demo files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,6 @@ module.exports = {
         '**/test/**/*.js',
         '**/test-node/**/*.js',
         '**/demo/**/*.js',
-        '**/stories/**/*.js',
         '**/docs/**/*.js',
         '**/*.config.js',
       ],

--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "test-helpers",
     "translations",

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test-helpers",
     "translations",
     "*.js"

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -28,13 +28,13 @@
   "module": "index.js",
   "files": [
     "src",
-    "stories",
+    "docs",
     "test",
     "*.js"
   ],
   "sideEffects": [
     "lion-dialog.js",
-    "./stories/styled-dialog-content.js"
+    "./docs/styled-dialog-content.js"
   ],
   "dependencies": {
     "@lion/core": "0.6.0",

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -28,14 +28,13 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"
   ],
   "sideEffects": [
     "lion-fieldset.js",
-    "./stories/helpers/demo-fieldset-child.js"
+    "./docs/helpers/demo-fieldset-child.js"
   ],
   "dependencies": {
     "@lion/core": "0.6.0",

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "test-suites",
     "test-helpers",

--- a/packages/form-integrations/package.json
+++ b/packages/form-integrations/package.json
@@ -27,13 +27,12 @@
     "dev-assets",
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"
   ],
   "sideEffects": [
-    "./stories/helper-wc/h-output.js"
+    "./docs/helper-wc/h-output.js"
   ],
   "dependencies": {
     "@lion/button": "0.7.1",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -28,14 +28,13 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"
   ],
   "sideEffects": [
     "lion-icon.js",
-    "./stories/icon-resolvers.js"
+    "./docs/icon-resolvers.js"
   ],
   "dependencies": {
     "@lion/core": "0.6.0",

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -31,7 +31,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "test-helpers",
     "translations",

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/input-range/package.json
+++ b/packages/input-range/package.json
@@ -28,7 +28,6 @@
   "module": "index.js",
   "files": [
     "src",
-    "stories",
     "test",
     "*.js"
   ],

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "test-helpers",
     "translations",

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -36,8 +36,8 @@
     "*.js"
   ],
   "sideEffects": [
-    "./stories/demo-overlay-system.js",
-    "./stories/applyDemoOverlayStyles.js"
+    "./docs/demo-overlay-system.js",
+    "./docs/applyDemoOverlayStyles.js"
   ],
   "dependencies": {
     "@lion/core": "0.6.0",

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "test-helpers",
     "test-suites",

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/remark-extend/package.json
+++ b/packages/remark-extend/package.json
@@ -26,7 +26,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "*.js"
   ],

--- a/packages/select-rich/package.json
+++ b/packages/select-rich/package.json
@@ -32,7 +32,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -29,7 +29,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -28,7 +28,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"

--- a/packages/validate-messages/package.json
+++ b/packages/validate-messages/package.json
@@ -31,7 +31,6 @@
   "files": [
     "docs",
     "src",
-    "stories",
     "test",
     "translations",
     "*.js"


### PR DESCRIPTION
closes https://github.com/ing-bank/lion/pull/742

that will release almost everything 😅

```
 - @lion/checkbox-group: 0.10.0 => 0.10.1
 - @lion/dialog: 0.7.0 => 0.7.1
 - @lion/fieldset: 0.13.0 => 0.13.1
 - @lion/form-core: 0.1.0 => 0.1.1
 - @lion/form-integrations: 0.1.1 => 0.1.2
 - @lion/form: 0.6.0 => 0.6.1
 - @lion/icon: 0.6.0 => 0.6.1
 - @lion/input-amount: 0.7.0 => 0.7.1
 - @lion/input-date: 0.7.0 => 0.7.1
 - @lion/input-datepicker: 0.14.0 => 0.14.1
 - @lion/input-email: 0.8.0 => 0.8.1
 - @lion/input-iban: 0.9.0 => 0.9.1
 - @lion/input-range: 0.4.0 => 0.4.1
 - @lion/input: 0.7.0 => 0.7.1
 - @lion/overlays: 0.16.0 => 0.16.1
 - @lion/radio-group: 0.10.0 => 0.10.1
 - @lion/select-rich: 0.18.1 => 0.18.2
 - @lion/select: 0.7.0 => 0.7.1
 - @lion/switch: 0.10.1 => 0.10.2
 - @lion/textarea: 0.7.0 => 0.7.1
 - @lion/tooltip: 0.11.0 => 0.11.1
 - @lion/validate-messages: 0.1.0 => 0.1.1
```