### PR TITLE
feat(localize): allow overriding of translations

### DIFF
--- a/packages/localize/stories/12-features-overview.stories.mdx
+++ b/packages/localize/stories/12-features-overview.stories.mdx
@@ -97,3 +97,41 @@ To format dates you can use `formatDate`. For more details see [Dates](?path=/do
     return wrapper;
   }}
 </Story>
+
+## Override translations
+
+Sometimes you want to reuse a web component but you may need to change the translations so it fits your use case
+
+```js
+localize.addData('en-GB', 'lit-html-example', {
+  header: '{ locale }: Localize message example (Overrided)',
+  body: 'I am English (Overrided)',
+}, true);
+```
+
+<Story name="Override">
+  {() => {
+    localize.addData('en-GB', 'override-example', {
+        text: 'The translations can be overrided',
+    }, true);
+    
+    function overrideTranslations() {
+      localize.addData('en-GB', 'override-example', {
+        text: 'This translations has been overrided',
+      }, true);
+      update();
+    }
+    const wrapper = document.createElement('div');
+    function update() {
+      render(
+        html`
+          <button type="button" @click=${() => overrideTranslations()}>Override translations</button>
+          <p>${localize.msg('override-example:text')}</p>
+        `,
+        wrapper,
+      );
+    }
+    update();
+    return wrapper;
+  }}
+</Story>

--- a/packages/localize/stories/12-features-overview.stories.mdx
+++ b/packages/localize/stories/12-features-overview.stories.mdx
@@ -112,12 +112,12 @@ localize.addData('en-GB', 'lit-html-example', {
 <Story name="Override">
   {() => {
     localize.addData('en-GB', 'override-example', {
-        text: 'The translations can be overrided',
+        text: 'The translations can be overrode',
     }, true);
     
     function overrideTranslations() {
       localize.addData('en-GB', 'override-example', {
-        text: 'This translations has been overrided',
+        text: 'This translations has been overridden',
       }, true);
       update();
     }

--- a/packages/localize/test/LocalizeManager.test.js
+++ b/packages/localize/test/LocalizeManager.test.js
@@ -132,6 +132,20 @@ describe('LocalizeManager', () => {
         'en-GB': { 'lion-hello': { greeting: 'Hi!' } },
       });
     });
+
+    it('allows to override previously loaded data for the same locale & namespace if the override parameter is set to true', () => {
+      manager = new LocalizeManager();
+
+      manager.addData('en-GB', 'lion-hello', { greeting: 'Hi!' });
+
+      expect(() => {
+        manager.addData('en-GB', 'lion-hello', { greeting: 'Hello!' }, true);
+      }).to.not.throw();
+
+      expect(manager.__storage).to.deep.equal({
+        'en-GB': { 'lion-hello': { greeting: 'Hello!' } },
+      });
+    });
   });
 
   describe('loading via dynamic imports', () => {
@@ -490,6 +504,25 @@ describe('LocalizeManager', () => {
       ]);
 
       expect(called).to.equal(1);
+    });
+
+    it('loads namespace more than once if the override property is set to true', async () => {
+      let called = 0;
+      const myNamespace = {
+        'my-namespace': () => {
+          called += 1;
+          return Promise.resolve({ default: {} });
+        },
+      };
+      manager = new LocalizeManager();
+
+      await Promise.all([
+        manager.loadNamespace(myNamespace, manager.locale, true),
+        manager.loadNamespace(myNamespace, manager.locale, true),
+        manager.loadNamespace(myNamespace, manager.locale, true),
+      ]);
+
+      expect(called).to.equal(3);
     });
 
     it('does not load inlined data', async () => {


### PR DESCRIPTION
This pull request allows the possibility to override the translations defined by a component so it can be fully reused.