### PR TITLE
fix(localize): format hungarian & bulgarian dates

### DIFF
--- a/packages/localize/src/date/addLeadingZero.js
+++ b/packages/localize/src/date/addLeadingZero.js
@@ -10,8 +10,8 @@ import { pad } from './pad.js';
 export function addLeadingZero(dateString) {
   const dateParts = splitDate(dateString);
   const delimiter = dateParts ? dateParts[2] : '';
-  const uniformDateString = dateString.replace(/[.\-/\s]/g, delimiter);
-  const dateArray = uniformDateString.split && uniformDateString.split(delimiter);
+  const dateArray =
+    dateString.split && dateString.split(delimiter).filter(str => str.trim().length > 0);
   if (!dateArray || dateArray.length !== 3) {
     // prevent fail on invalid dates
     return '';

--- a/packages/localize/src/date/pad.js
+++ b/packages/localize/src/date/pad.js
@@ -5,7 +5,8 @@
  * @returns {string}
  */
 export function pad(n) {
-  const v = Math.abs(n);
+  const digitRegex = /^\d+$/;
+  const v = digitRegex.test(n) ? Math.abs(n) : n;
 
   return String(v < 10 ? `0${v}` : v);
 }

--- a/packages/localize/src/date/parseDate.js
+++ b/packages/localize/src/date/parseDate.js
@@ -2,9 +2,9 @@ import { localize } from '../localize.js';
 import { getDateFormatBasedOnLocale } from './getDateFormatBasedOnLocale.js';
 import { addLeadingZero } from './addLeadingZero.js';
 
-const memoize = (fn, parm) => {
+const memoize = fn => {
   const cache = {};
-  return () => {
+  return parm => {
     const n = parm;
     if (n in cache) {
       return cache[n];
@@ -15,7 +15,7 @@ const memoize = (fn, parm) => {
   };
 };
 
-const memoizedGetDateFormatBasedOnLocale = memoize(getDateFormatBasedOnLocale, localize.locale);
+const memoizedGetDateFormatBasedOnLocale = memoize(getDateFormatBasedOnLocale);
 
 /**
  * To parse a date into the right format
@@ -26,7 +26,7 @@ const memoizedGetDateFormatBasedOnLocale = memoize(getDateFormatBasedOnLocale, l
 export function parseDate(date) {
   const stringToParse = addLeadingZero(date);
   let parsedString;
-  switch (memoizedGetDateFormatBasedOnLocale()) {
+  switch (memoizedGetDateFormatBasedOnLocale(localize.locale)) {
     case 'day-month-year':
       parsedString = `${stringToParse.slice(6, 10)}/${stringToParse.slice(
         3,

--- a/packages/localize/test/date/formatDate.test.js
+++ b/packages/localize/test/date/formatDate.test.js
@@ -48,6 +48,22 @@ describe('formatDate', () => {
     expect(formatDate(testDate, options)).to.equal('Monday, May 21, 2012');
   });
 
+  it('displays Hungarian dates correctly', async () => {
+    const options = {
+      weekday: 'long',
+      year: 'numeric',
+      month: 'long',
+      day: '2-digit',
+      locale: 'en-US',
+    };
+    localize.locale = 'hu-HU';
+    let date = parseDate('2018-5-28');
+    expect(formatDate(date)).to.equal('2018. 05. 28.');
+
+    date = parseDate('1970-11-3');
+    expect(formatDate(date, options)).to.equal('Tuesday, November 03, 1970');
+  });
+
   it('displays Bulgarian dates correctly', async () => {
     const options = {
       weekday: 'long',
@@ -76,13 +92,13 @@ describe('formatDate', () => {
       locale: 'en-US',
     };
     localize.locale = 'en-US';
-    let date = parseDate('29-12-1940');
+    let date = parseDate('12-29-1940');
     expect(formatDate(date)).to.equal('12/29/1940');
 
-    date = parseDate('13-01-1940');
+    date = parseDate('1-13-1940');
     expect(formatDate(date)).to.equal('01/13/1940');
 
-    date = parseDate('3-11-1970');
+    date = parseDate('11-3-1970');
     expect(formatDate(date, options)).to.equal('Tuesday, November 03, 1970');
   });
 

--- a/packages/localize/test/date/parseDate.test.js
+++ b/packages/localize/test/date/parseDate.test.js
@@ -29,11 +29,11 @@ describe('parseDate()', () => {
     expect(equalsDate(parseDate('31.12.1970'), new Date('1970/12/31'))).to.equal(true);
   });
   it('handles all kind of delimiters', () => {
-    expect(equalsDate(parseDate('12.12.1976'), new Date('1976/12/12'))).to.equal(true);
-    expect(equalsDate(parseDate('13.12.1976'), new Date('1976/12/13'))).to.equal(true);
+    expect(equalsDate(parseDate('12-12-1976'), new Date('1976/12/12'))).to.equal(true);
+    expect(equalsDate(parseDate('13 12 1976'), new Date('1976/12/13'))).to.equal(true);
     expect(equalsDate(parseDate('14.12.1976'), new Date('1976/12/14'))).to.equal(true);
-    expect(equalsDate(parseDate('14.12-1976'), new Date('1976/12/14'))).to.equal(true);
-    expect(equalsDate(parseDate('14-12/1976'), new Date('1976/12/14'))).to.equal(true);
+    expect(equalsDate(parseDate('14. 12. 1976.'), new Date('1976/12/14'))).to.equal(true);
+    expect(equalsDate(parseDate('14.12.1976 r.'), new Date('1976/12/14'))).to.equal(true);
   });
   it('return undefined when no valid date provided', () => {
     expect(parseDate('12.12.1976.,')).to.equal(undefined);

--- a/packages/validate-messages/translations/bg.js
+++ b/packages/validate-messages/translations/bg.js
@@ -10,7 +10,7 @@ export default {
     MinNumber: 'Моля, въведете {fieldName} повече от {params}.',
     MaxNumber: 'Моля, въведете {fieldName} по-малко от {params}.',
     MinMaxNumber: 'Моля, въведете {fieldName} между {params.min} и {params.max}.',
-    IsDate: 'Моля, въведете дата (ДД-ММ-ГГГГ).',
+    IsDate: 'Моля, въведете дата (ДД.ММ.ГГГГ r.).',
     MinDate: 'Моля, въведете {fieldName} след {params, date, YYYYMMDD}.',
     MaxDate: 'Моля, въведете {fieldName} преди {params, date, YYYYMMDD}.',
     MinMaxDate:
@@ -28,7 +28,7 @@ export default {
     MinNumber: 'Моля, въведете {fieldName} повече от {params}.',
     MaxNumber: 'Моля, въведете {fieldName} по-малко от {params}.',
     MinMaxNumber: 'Моля, въведете {fieldName} между {params.min} и {params.max}.',
-    IsDate: 'Моля, въведете дата (ДД-ММ-ГГГГ).',
+    IsDate: 'Моля, въведете дата (ДД.ММ.ГГГГ r.).',
     MinDate: 'Моля, въведете {fieldName} след {params, date, YYYYMMDD}.',
     MaxDate: 'Моля, въведете {fieldName} преди {params, date, YYYYMMDD}.',
     MinMaxDate:


### PR DESCRIPTION
    - fix memoize function & correct computation of date format
    - modify date format in bulgarian validation messages

BREAKING CHANGE: N

closes #540

Please refer previous PR https://github.com/ing-bank/lion/pull/780 for discussions. 