### PR TITLE
feat(providence-analytics): allow target dependencies via cli

### DIFF
--- a/.changeset/sharp-rules-tell.md
+++ b/.changeset/sharp-rules-tell.md
@@ -1,0 +1,5 @@
+---
+'providence-analytics': patch
+---
+
+feat: allow target dependencies via cli

--- a/packages/providence-analytics/src/cli/cli-helpers.js
+++ b/packages/providence-analytics/src/cli/cli-helpers.js
@@ -113,7 +113,13 @@ function targetDefault() {
 async function appendProjectDependencyPaths(rootPaths, matchPattern, modes = ['npm', 'bower']) {
   let matchFn;
   if (matchPattern) {
-    matchFn = (_, d) => new RegExp(matchPattern).test(d);
+    if (matchPattern.startsWith('/') && matchPattern.endsWith('/')) {
+      matchFn = (_, d) => new RegExp(matchPattern.slice(1, -1)).test(d);
+    } else {
+      LogService.error(
+        `[appendProjectDependencyPaths] Please provide a matchPattern enclosed by '/'. Found: ${matchPattern}`,
+      );
+    }
   }
   const depProjectPaths = [];
   await aForEach(rootPaths, async targetPath => {

--- a/packages/providence-analytics/src/cli/cli-helpers.js
+++ b/packages/providence-analytics/src/cli/cli-helpers.js
@@ -60,7 +60,7 @@ function pathsArrayFromCs(t, cwd = process.cwd()) {
  * @param {object} eCfg external configuration. Usually providence.conf.js
  * @returns {string[]}
  */
-function pathsArrayFromCollectionName(name, colType = 'search-target', eCfg) {
+function pathsArrayFromCollectionName(name, colType = 'search-target', eCfg, cwd) {
   let collection;
   if (colType === 'search-target') {
     collection = eCfg.searchTargetCollections;
@@ -68,7 +68,7 @@ function pathsArrayFromCollectionName(name, colType = 'search-target', eCfg) {
     collection = eCfg.referenceCollections;
   }
   if (collection && collection[name]) {
-    return pathsArrayFromCs(collection[name].join(','));
+    return pathsArrayFromCs(collection[name].join(','), cwd);
   }
   return undefined;
 }
@@ -107,10 +107,14 @@ function targetDefault() {
 /**
  * @desc Returns all sub projects matching condition supplied in matchFn
  * @param {string[]} searchTargetPaths all search-target project paths
- * @param {function} matchFn filters out packages we're interested in
+ * @param {string} matchPattern base for RegExp
  * @param {string[]} modes
  */
-async function appendProjectDependencyPaths(rootPaths, matchFn, modes = ['npm', 'bower']) {
+async function appendProjectDependencyPaths(rootPaths, matchPattern, modes = ['npm', 'bower']) {
+  let matchFn;
+  if (matchPattern) {
+    matchFn = (_, d) => new RegExp(matchPattern).test(d);
+  }
   const depProjectPaths = [];
   await aForEach(rootPaths, async targetPath => {
     await aForEach(modes, async mode => {

--- a/packages/providence-analytics/src/cli/cli.js
+++ b/packages/providence-analytics/src/cli/cli.js
@@ -99,10 +99,10 @@ async function cli({ cwd } = {}) {
      * @type {string[]}
      */
     let totalSearchTargets;
-    if (commander.includeTargetDeps) {
+    if (commander.targetDependencies !== undefined) {
       totalSearchTargets = await cliHelpers.appendProjectDependencyPaths(
         searchTargetPaths,
-        commander.targetDepsFilter,
+        commander.targetDependencies,
       );
     } else {
       totalSearchTargets = searchTargetPaths;
@@ -195,14 +195,12 @@ async function cli({ cwd } = {}) {
     )
     .option('--write-log-file', `Writes all logs to 'providence.log' file`)
     .option(
-      '--include-target-deps',
+      '--target-dependencies [target-dependencies]',
       `For all search targets, will include all its dependencies
-    (node_modules and bower_components). When --target-deps-filter is applied, a subset
-    will be applied that matches the filter condition`,
-    )
-    .option(
-      '--target-deps-filter [target-deps-filter]',
-      `Regex condition to be applied to dependencies of search targets.`,
+    (node_modules and bower_components). When --target-dependencies is applied
+    without argument, it will act as boolean and include all dependencies.
+    When a regex is supplied like --target-dependencies /^my-brand-/, it will filter
+    all packages that comply with the regex`,
     );
 
   commander

--- a/packages/providence-analytics/src/program/analyzers/helpers/Analyzer.js
+++ b/packages/providence-analytics/src/program/analyzers/helpers/Analyzer.js
@@ -48,7 +48,7 @@ async function analyzePerAstEntry(projectData, astAnalysis) {
 }
 
 /**
- * @desc This method ensures that the result returned by an analyzer always has a consitent format,
+ * @desc This method ensures that the result returned by an analyzer always has a consistent format.
  * By returning the configuration for the queryOutput, it will be possible to run later queries
  * under the same circumstances
  * @param {array} queryOutput

--- a/packages/providence-analytics/src/program/analyzers/helpers/from-import-to-export-perspective.js
+++ b/packages/providence-analytics/src/program/analyzers/helpers/from-import-to-export-perspective.js
@@ -49,17 +49,21 @@ function fromImportToExportPerspective({
     // we still need to check if we're not dealing with a folder.
     // - '@open-wc/x/y.js' -> '@open-wc/x/y.js' or... '@open-wc/x/y.js/index.js' ?
     // - or 'lion-based-ui/test' -> 'lion-based-ui/test/index.js' or 'lion-based-ui/test' ?
-    const pathToCheck = pathLib.resolve(externalRootPath, `./${localPath}`);
+    if (externalRootPath) {
+      const pathToCheck = pathLib.resolve(externalRootPath, `./${localPath}`);
 
-    if (fs.existsSync(pathToCheck)) {
-      const stat = fs.statSync(pathToCheck);
-      if (stat && stat.isFile()) {
-        return `./${localPath}`; // '/path/to/lion-based-ui/fol.der' is a file
+      if (fs.existsSync(pathToCheck)) {
+        const stat = fs.statSync(pathToCheck);
+        if (stat && stat.isFile()) {
+          return `./${localPath}`; // '/path/to/lion-based-ui/fol.der' is a file
+        }
+        return `./${localPath}/index.js`; // '/path/to/lion-based-ui/fol.der' is a folder
+        // eslint-disable-next-line no-else-return
+      } else if (fs.existsSync(`${pathToCheck}.js`)) {
+        return `./${localPath}.js`; // '/path/to/lion-based-ui/fol.der' is file '/path/to/lion-based-ui/fol.der.js'
       }
-      return `./${localPath}/index.js`; // '/path/to/lion-based-ui/fol.der' is a folder
-      // eslint-disable-next-line no-else-return
-    } else if (fs.existsSync(`${pathToCheck}.js`)) {
-      return `./${localPath}.js`; // '/path/to/lion-based-ui/fol.der' is file '/path/to/lion-based-ui/fol.der.js'
+    } else {
+      return `./${localPath}`;
     }
   } else {
     // like '@lion/core'

--- a/packages/providence-analytics/src/program/analyzers/match-imports.js
+++ b/packages/providence-analytics/src/program/analyzers/match-imports.js
@@ -20,6 +20,20 @@ function storeResult(resultsObj, exportId, filteredList, meta) {
 }
 
 /**
+ * Needed in case fromImportToExportPerspective does not have a
+ * externalRootPath supplied.
+ * @param {string} exportPath exportEntry.file
+ * @param {string} translatedImportPath result of fromImportToExportPerspective
+ */
+function compareImportAndExportPaths(exportPath, translatedImportPath) {
+  return (
+    exportPath === translatedImportPath ||
+    exportPath === `${translatedImportPath}.js` ||
+    exportPath === `${translatedImportPath}/index.js`
+  );
+}
+
+/**
  * @param {FindExportsAnalyzerResult} exportsAnalyzerResult
  * @param {FindImportsAnalyzerResult} importsAnalyzerResult
  * @param {matchImportsConfig} customConfig
@@ -94,13 +108,15 @@ function matchImportsPostprocess(exportsAnalyzerResult, importsAnalyzerResult, c
              * importFile 'importing-target-project/file.js'
              * => import { z } from '@reference/foo.js'
              */
-            const isFromSameSource =
-              exportEntry.file ===
-              fromImportToExportPerspective({
-                requestedExternalSource: importEntryResult.normalizedSource,
-                externalProjectMeta: exportsProjectObj,
-                externalRootPath: cfg.referenceProjectPath,
-              });
+            const fromImportToExport = fromImportToExportPerspective({
+              requestedExternalSource: importEntryResult.normalizedSource,
+              externalProjectMeta: exportsProjectObj,
+              externalRootPath: cfg.referenceProjectResult ? null : cfg.referenceProjectPath,
+            });
+            const isFromSameSource = compareImportAndExportPaths(
+              exportEntry.file,
+              fromImportToExport,
+            );
 
             if (!isFromSameSource) {
               return;

--- a/packages/providence-analytics/src/program/analyzers/match-paths.js
+++ b/packages/providence-analytics/src/program/analyzers/match-paths.js
@@ -329,7 +329,7 @@ function matchPathsPostprocess(
 }
 
 /**
- * Designed to work in conjunction with npm package `extend-docs`.
+ * Designed to work in conjunction with npm package `babel-plugin-extend-docs`.
  * It will lookup all class exports from reference project A (and store their available paths) and
  * matches them against all imports of project B that extend exported class (and store their
  * available paths).
@@ -426,7 +426,8 @@ class MatchPathsAnalyzer extends Analyzer {
     const targetMatchSubclassesResult = await targetMatchSubclassesAnalyzer.execute({
       targetProjectPath: cfg.targetProjectPath,
       referenceProjectPath: cfg.referenceProjectPath,
-      gatherFilesConfig: cfg.gatherFilesConfigReference,
+      gatherFilesConfig: cfg.gatherFilesConfig,
+      gatherFilesConfigReference: cfg.gatherFilesConfigReference,
     });
 
     // [A2]
@@ -434,6 +435,7 @@ class MatchPathsAnalyzer extends Analyzer {
     /** @type {FindExportsAnalyzerResult} */
     const targetExportsResult = await targetFindExportsAnalyzer.execute({
       targetProjectPath: cfg.targetProjectPath,
+      gatherFilesConfig: cfg.gatherFilesConfig,
     });
 
     // [A3]
@@ -441,6 +443,7 @@ class MatchPathsAnalyzer extends Analyzer {
     /** @type {FindExportsAnalyzerResult} */
     const refFindExportsResult = await refFindExportsAnalyzer.execute({
       targetProjectPath: cfg.referenceProjectPath,
+      gatherFilesConfig: cfg.gatherFilesConfigReference,
     });
 
     /**
@@ -448,14 +451,14 @@ class MatchPathsAnalyzer extends Analyzer {
      * Automatically generate a mapping from lion docs import paths to extension layer
      * import paths. To be served to extend-docs
      *
-     * [1] Find path variable.to 'WolfCheckbox'
+     * [B1] Find path variable.to 'WolfCheckbox'
      * Run 'match-subclasses' for target project: we find the 'rootFilePath' of class definition,
      * Result: './packages/wolf-checkbox/WolfCheckbox.js'
-     * [B1] Find export path of 'wolf-checkbox'
-     * Run 'find-customelements' on target project and match rootFile of [A1] with rootFile of
+     * [B2] Find export path of 'wolf-checkbox'
+     * Run 'find-customelements' on target project and match rootFile of [B1] with rootFile of
      * constructor.
      * Result: './wolf-checkbox.js'
-     * [B2] Find export path of 'lion-checkbox'
+     * [B3] Find export path of 'lion-checkbox'
      * Run 'find-customelements' and find-exports (for rootpath) on reference project and match
      * rootFile of constructor with rootFiles of where LionCheckbox is defined.
      * Result: './packages/checkbox/lion-checkbox.js',
@@ -467,6 +470,7 @@ class MatchPathsAnalyzer extends Analyzer {
     /** @type {FindCustomelementsAnalyzerResult} */
     const targetFindCustomelementsResult = await targetFindCustomelementsAnalyzer.execute({
       targetProjectPath: cfg.targetProjectPath,
+      gatherFilesConfig: cfg.gatherFilesConfig,
     });
 
     // [B2]
@@ -474,6 +478,7 @@ class MatchPathsAnalyzer extends Analyzer {
     /** @type {FindCustomelementsAnalyzerResult} */
     const refFindCustomelementsResult = await refFindCustomelementsAnalyzer.execute({
       targetProjectPath: cfg.referenceProjectPath,
+      gatherFilesConfig: cfg.gatherFilesConfigReference,
     });
     // refFindExportsAnalyzer was already created in A3
 
@@ -483,7 +488,6 @@ class MatchPathsAnalyzer extends Analyzer {
     let queryOutput = matchPathsPostprocess(
       targetMatchSubclassesResult,
       targetExportsResult,
-      // refImportsResult,
       targetFindCustomelementsResult,
       refFindCustomelementsResult,
       refFindExportsResult,

--- a/packages/providence-analytics/src/program/utils/async-array-utils.js
+++ b/packages/providence-analytics/src/program/utils/async-array-utils.js
@@ -1,7 +1,7 @@
 /**
  * @desc Readable way to do an async forEach
- * Since predictability mathers, all array items will be handled in a queue;
- * one after anotoher
+ * Since predictability matters, all array items will be handled in a queue,
+ * one after another
  * @param {array} array
  * @param {function} callback
  */
@@ -13,8 +13,8 @@ async function aForEach(array, callback) {
 }
 /**
  * @desc Readable way to do an async forEach
- * Since predictability mathers, all array items will be handled in a queue;
- * one after anotoher
+ * If predictability does not matter, this method will traverse array items concurrently,
+ * leading to a better performance
  * @param {array} array
  * @param {function} callback
  */
@@ -23,7 +23,7 @@ async function aForEachNonSequential(array, callback) {
 }
 /**
  * @desc Readable way to do an async map
- * Since predictability is crucial for a map, all array items will be handled in a queue;
+ * Since predictability is crucial for a map, all array items will be handled in a queue,
  * one after anotoher
  * @param {array} array
  * @param {function} callback

--- a/packages/providence-analytics/test-node/cli/cli.test.js
+++ b/packages/providence-analytics/test-node/cli/cli.test.js
@@ -13,145 +13,332 @@ const {
   suppressNonCriticalLogs,
   restoreSuppressNonCriticalLogs,
 } = require('../../test-helpers/mock-log-service-helpers.js');
-
+const { InputDataService } = require('../../src/program/services/InputDataService.js');
 const { QueryService } = require('../../src/program/services/QueryService.js');
-
 const providenceModule = require('../../src/program/providence.js');
 const extendDocsModule = require('../../src/cli/generate-extend-docs-data.js');
-
-const dummyAnalyzer = require('../../test-helpers/templates/analyzer-template.js');
+const cliHelpersModule = require('../../src/cli/cli-helpers.js');
 const { cli } = require('../../src/cli/cli.js');
-const { pathsArrayFromCs } = require('../../src/cli/cli-helpers.js');
+const promptAnalyzerModule = require('../../src/cli/prompt-analyzer-menu.js');
+
+const {
+  pathsArrayFromCs,
+  pathsArrayFromCollectionName,
+  appendProjectDependencyPaths,
+} = cliHelpersModule;
 
 const queryResults = [];
 const rootDir = pathLib.resolve(__dirname, '../../');
 
+const externalCfgMock = {
+  searchTargetCollections: {
+    'lion-collection': [
+      './providence-input-data/search-targets/example-project-a',
+      './providence-input-data/search-targets/example-project-b',
+      // ...etc
+    ],
+  },
+  referenceCollections: {
+    'lion-based-ui-collection': [
+      './providence-input-data/references/lion-based-ui',
+      './providence-input-data/references/lion-based-ui-labs',
+    ],
+  },
+};
+
+async function runCli(args, cwd) {
+  process.argv = [...process.argv.slice(0, 2), ...args.split(' ')];
+  await cli({ cwd });
+}
+
 describe('Providence CLI', () => {
+  let providenceStub;
+  let promptCfgStub;
+  let iExtConfStub;
+  let promptStub;
+  let qConfStub;
+
   before(() => {
-    suppressNonCriticalLogs();
     mockWriteToJson(queryResults);
+    suppressNonCriticalLogs();
 
     mockProject(
       {
         './src/OriginalComp.js': `export class OriginalComp {}`,
         './src/inbetween.js': `export { OriginalComp as InBetweenComp } from './OriginalComp.js'`,
         './index.js': `export { InBetweenComp as MyComp } from './src/inbetween.js'`,
+        './node_modules/dependency-a/index.js': '',
+        './bower_components/dependency-b/index.js': '',
       },
       {
         projectName: 'example-project',
         projectPath: '/mocked/path/example-project',
       },
     );
+
+    providenceStub = sinon.stub(providenceModule, 'providence').returns(
+      new Promise(resolve => {
+        resolve();
+      }),
+    );
+
+    promptCfgStub = sinon
+      .stub(promptAnalyzerModule, 'promptAnalyzerConfigMenu')
+      .returns({ analyzerConfig: { con: 'fig' } });
+
+    iExtConfStub = sinon.stub(InputDataService, 'getExternalConfig').returns(externalCfgMock);
+
+    promptStub = sinon
+      .stub(promptAnalyzerModule, 'promptAnalyzerMenu')
+      .returns({ analyzerName: 'mock-analyzer' });
+
+    qConfStub = sinon.stub(QueryService, 'getQueryConfigFromAnalyzer').returns({
+      analyzer: {
+        name: 'mock-analyzer',
+        requiresReference: true,
+      },
+    });
   });
 
   after(() => {
     restoreSuppressNonCriticalLogs();
-    restoreWriteToJson();
     restoreMockedProjects();
-  });
+    restoreWriteToJson();
 
-  let providenceStub;
-  let qConfStub;
-  beforeEach(() => {
-    qConfStub = sinon.stub(QueryService, 'getQueryConfigFromAnalyzer').returns({ analyzer: {} });
-    providenceStub = sinon.stub(providenceModule, 'providence').returns(Promise.resolve());
-  });
-
-  afterEach(() => {
     providenceStub.restore();
+    promptCfgStub.restore();
+    iExtConfStub.restore();
+    promptStub.restore();
     qConfStub.restore();
   });
 
-  async function runCli(args, cwd) {
-    process.argv = [...process.argv.slice(0, 2), ...args.split(' ')];
-    await cli({ cwd, addProjectDependencyPaths: false });
-  }
-
-  const analyzCmd = 'analyze find-exports';
-
-  it('creates a QueryConfig', async () => {
-    await runCli('analyze find-exports -t /mocked/path/example-project');
-    expect(qConfStub.called).to.be.true;
-    expect(qConfStub.args[0][0]).to.equal('find-exports');
+  afterEach(() => {
+    providenceStub.resetHistory();
+    promptCfgStub.resetHistory();
+    iExtConfStub.resetHistory();
+    promptStub.resetHistory();
+    qConfStub.resetHistory();
   });
 
+  const analyzeCmd = 'analyze mock-analyzer';
+
   it('calls providence', async () => {
-    await runCli(`${analyzCmd} -t /mocked/path/example-project`);
+    await runCli(`${analyzeCmd} -t /mocked/path/example-project`);
     expect(providenceStub.called).to.be.true;
   });
 
+  it('creates a QueryConfig', async () => {
+    await runCli(`${analyzeCmd} -t /mocked/path/example-project`);
+    expect(qConfStub.called).to.be.true;
+    expect(qConfStub.args[0][0]).to.equal('mock-analyzer');
+  });
+
   describe('Global options', () => {
+    let pathsArrayFromCollectionStub;
+    let pathsArrayFromCsStub;
+    let appendProjectDependencyPathsStub;
+
+    before(() => {
+      pathsArrayFromCsStub = sinon
+        .stub(cliHelpersModule, 'pathsArrayFromCs')
+        .returns(['/mocked/path/example-project']);
+      pathsArrayFromCollectionStub = sinon
+        .stub(cliHelpersModule, 'pathsArrayFromCollectionName')
+        .returns(['/mocked/path/example-project']);
+      appendProjectDependencyPathsStub = sinon
+        .stub(cliHelpersModule, 'appendProjectDependencyPaths')
+        .returns([
+          '/mocked/path/example-project',
+          '/mocked/path/example-project/node_modules/mock-dep-a',
+          '/mocked/path/example-project/bower_components/mock-dep-b',
+        ]);
+    });
+
+    after(() => {
+      pathsArrayFromCsStub.restore();
+      pathsArrayFromCollectionStub.restore();
+      appendProjectDependencyPathsStub.restore();
+    });
+
+    afterEach(() => {
+      pathsArrayFromCsStub.resetHistory();
+      pathsArrayFromCollectionStub.resetHistory();
+      appendProjectDependencyPathsStub.resetHistory();
+    });
+
     it('"-e --extensions"', async () => {
-      await runCli(`${analyzCmd} --extensions bla,blu`);
+      await runCli(`${analyzeCmd} -e bla,blu`);
+      expect(providenceStub.args[0][1].gatherFilesConfig.extensions).to.eql(['.bla', '.blu']);
+
+      providenceStub.resetHistory();
+
+      await runCli(`${analyzeCmd} --extensions bla,blu`);
       expect(providenceStub.args[0][1].gatherFilesConfig.extensions).to.eql(['.bla', '.blu']);
     });
 
-    describe('"-t", "--search-target-paths"', async () => {
-      it('allows absolute paths', async () => {
-        await runCli(`${analyzCmd} -t /mocked/path/example-project`, rootDir);
-        expect(providenceStub.args[0][1].targetProjectPaths).to.eql([
-          '/mocked/path/example-project',
-        ]);
-      });
+    it('"-t --search-target-paths"', async () => {
+      await runCli(`${analyzeCmd} -t /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].targetProjectPaths).to.eql(['/mocked/path/example-project']);
 
-      it('allows relative paths', async () => {
-        await runCli(
-          `${analyzCmd} -t ./test-helpers/project-mocks/importing-target-project`,
-          rootDir,
-        );
-        expect(providenceStub.args[0][1].targetProjectPaths).to.eql([
-          `${rootDir}/test-helpers/project-mocks/importing-target-project`,
-        ]);
+      pathsArrayFromCsStub.resetHistory();
+      providenceStub.resetHistory();
 
-        await runCli(
-          `${analyzCmd} -t test-helpers/project-mocks/importing-target-project`,
-          rootDir,
-        );
-        expect(providenceStub.args[0][1].targetProjectPaths).to.eql([
-          `${rootDir}/test-helpers/project-mocks/importing-target-project`,
-        ]);
-      });
-
-      // TODO: globbing via cli-helpers doesn't work for some reason when run in this test
-      it.skip('allows globs', async () => {
-        await runCli(`${analyzCmd} -t test-helpers/*`, rootDir);
-        expect(providenceStub.args[0][1].targetProjectPaths).to.eql([
-          `${process.cwd()}/needed-for-test/pass-glob`,
-        ]);
-      });
+      await runCli(`${analyzeCmd} --search-target-paths /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].targetProjectPaths).to.eql(['/mocked/path/example-project']);
     });
 
-    it('"-r", "--reference-paths"', async () => {});
-    it('"--search-target-collection"', async () => {});
-    it('"--reference-collection"', async () => {});
+    it('"-r --reference-paths"', async () => {
+      await runCli(`${analyzeCmd} -r /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].referenceProjectPaths).to.eql([
+        '/mocked/path/example-project',
+      ]);
 
-    it.skip('"-R --verbose-report"', async () => {});
-    it.skip('"-D", "--debug"', async () => {});
+      pathsArrayFromCsStub.resetHistory();
+      providenceStub.resetHistory();
+
+      await runCli(`${analyzeCmd} --reference-paths /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].referenceProjectPaths).to.eql([
+        '/mocked/path/example-project',
+      ]);
+    });
+
+    it('"--search-target-collection"', async () => {
+      await runCli(`${analyzeCmd} --search-target-collection lion-collection`, rootDir);
+      expect(pathsArrayFromCollectionStub.args[0][0]).to.equal('lion-collection');
+      expect(providenceStub.args[0][1].targetProjectPaths).to.eql(['/mocked/path/example-project']);
+    });
+
+    it('"--reference-collection"', async () => {
+      await runCli(`${analyzeCmd} --reference-collection lion-based-ui-collection`, rootDir);
+      expect(pathsArrayFromCollectionStub.args[0][0]).to.equal('lion-based-ui-collection');
+      expect(providenceStub.args[0][1].referenceProjectPaths).to.eql([
+        '/mocked/path/example-project',
+      ]);
+    });
+
+    it('"-w --whitelist"', async () => {
+      await runCli(`${analyzeCmd} -w /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].gatherFilesConfig.filter).to.eql([
+        '/mocked/path/example-project',
+      ]);
+
+      pathsArrayFromCsStub.resetHistory();
+      providenceStub.resetHistory();
+
+      await runCli(`${analyzeCmd} --whitelist /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].gatherFilesConfig.filter).to.eql([
+        '/mocked/path/example-project',
+      ]);
+    });
+
+    it('"--whitelist-reference"', async () => {
+      await runCli(`${analyzeCmd} --whitelist-reference /mocked/path/example-project`, rootDir);
+      expect(pathsArrayFromCsStub.args[0][0]).to.equal('/mocked/path/example-project');
+      expect(providenceStub.args[0][1].gatherFilesConfigReference.filter).to.eql([
+        '/mocked/path/example-project',
+      ]);
+    });
+
+    it('"-D --debug"', async () => {
+      await runCli(`${analyzeCmd} -D`, rootDir);
+      expect(providenceStub.args[0][1].debugEnabled).to.equal(true);
+
+      providenceStub.resetHistory();
+
+      await runCli(`${analyzeCmd} --debug`, rootDir);
+      expect(providenceStub.args[0][1].debugEnabled).to.equal(true);
+    });
+
+    it('--write-log-file"', async () => {
+      await runCli(`${analyzeCmd} --write-log-file`, rootDir);
+      expect(providenceStub.args[0][1].writeLogFile).to.equal(true);
+    });
+
+    it('--include-target-deps"', async () => {
+      await runCli(`${analyzeCmd}`, rootDir);
+      expect(appendProjectDependencyPathsStub.called).to.be.false;
+
+      appendProjectDependencyPathsStub.resetHistory();
+      providenceStub.resetHistory();
+
+      await runCli(`${analyzeCmd} --include-target-deps`, rootDir);
+      expect(appendProjectDependencyPathsStub.called).to.be.true;
+      expect(providenceStub.args[0][1].targetProjectPaths).to.eql([
+        '/mocked/path/example-project',
+        '/mocked/path/example-project/node_modules/mock-dep-a',
+        '/mocked/path/example-project/bower_components/mock-dep-b',
+      ]);
+    });
+
+    it('--target-deps-filter"', async () => {
+      await runCli(`${analyzeCmd} --include-target-deps --target-deps-filter ^mock-`, rootDir);
+      expect(appendProjectDependencyPathsStub.args[0][1]).to.equal('^mock-');
+    });
   });
 
   describe('Commands', () => {
     describe('Analyze', () => {
       it('calls providence', async () => {
-        expect(typeof dummyAnalyzer.name).to.equal('string');
+        await runCli(`${analyzeCmd}`, rootDir);
+        expect(providenceStub.called).to.be.true;
       });
+
       describe('Options', () => {
-        it('"-o", "--prompt-optional-config"', async () => {});
-        it('"-c", "--config"', async () => {});
+        it('"-o --prompt-optional-config"', async () => {
+          await runCli(`analyze -o`, rootDir);
+          expect(promptStub.called).to.be.true;
+
+          promptStub.resetHistory();
+
+          await runCli(`analyze --prompt-optional-config`, rootDir);
+          expect(promptStub.called).to.be.true;
+        });
+
+        it('"-c --config"', async () => {
+          await runCli(`analyze mock-analyzer -c {"a":"2"}`, rootDir);
+          expect(qConfStub.args[0][0]).to.equal('mock-analyzer');
+          expect(qConfStub.args[0][1]).to.eql({ a: '2', metaConfig: undefined });
+
+          qConfStub.resetHistory();
+
+          await runCli(`analyze mock-analyzer --config {"a":"2"}`, rootDir);
+          expect(qConfStub.args[0][0]).to.equal('mock-analyzer');
+          expect(qConfStub.args[0][1]).to.eql({ a: '2', metaConfig: undefined });
+        });
+
+        it('calls "promptAnalyzerConfigMenu" without config given', async () => {
+          await runCli(`analyze mock-analyzer`, rootDir);
+          expect(promptCfgStub.called).to.be.true;
+        });
       });
     });
-    describe('Query', () => {});
-    describe('Search', () => {});
+
+    describe.skip('Query', () => {});
+    describe.skip('Search', () => {});
+
     describe('Manage', () => {});
+
     describe('Extend docs', () => {
       let extendDocsStub;
-      beforeEach(() => {
+
+      before(() => {
         extendDocsStub = sinon
           .stub(extendDocsModule, 'launchProvidenceWithExtendDocs')
           .returns(Promise.resolve());
       });
 
-      afterEach(() => {
+      after(() => {
         extendDocsStub.restore();
+      });
+
+      afterEach(() => {
+        extendDocsStub.resetHistory();
       });
 
       it('allows configuration', async () => {
@@ -176,8 +363,8 @@ describe('Providence CLI', () => {
           },
           outputFolder: '/outp',
           extensions: ['.bla'],
-          whitelist: [`${process.cwd()}/wl`],
-          whitelistReference: [`${process.cwd()}/wlr`],
+          whitelist: [`${rootDir}/wl`],
+          whitelistReference: [`${rootDir}/wlr`],
         });
       });
     });
@@ -203,8 +390,102 @@ describe('CLI helpers', () => {
 
     it('allows globs', async () => {
       expect(pathsArrayFromCs('test-helpers/project-mocks*', rootDir)).to.eql([
-        `${process.cwd()}/test-helpers/project-mocks`,
-        `${process.cwd()}/test-helpers/project-mocks-analyzer-outputs`,
+        `${rootDir}/test-helpers/project-mocks`,
+        `${rootDir}/test-helpers/project-mocks-analyzer-outputs`,
+      ]);
+    });
+
+    it('allows multiple comma separated paths', async () => {
+      const paths =
+        'test-helpers/project-mocks*, ./test-helpers/project-mocks/importing-target-project,/mocked/path/example-project';
+      expect(pathsArrayFromCs(paths, rootDir)).to.eql([
+        `${rootDir}/test-helpers/project-mocks`,
+        `${rootDir}/test-helpers/project-mocks-analyzer-outputs`,
+        `${rootDir}/test-helpers/project-mocks/importing-target-project`,
+        '/mocked/path/example-project',
+      ]);
+    });
+  });
+
+  describe('pathsArrayFromCollectionName', () => {
+    it('gets collections from external target config', async () => {
+      expect(
+        pathsArrayFromCollectionName('lion-collection', 'search-target', externalCfgMock, rootDir),
+      ).to.eql(
+        externalCfgMock.searchTargetCollections['lion-collection'].map(p =>
+          pathLib.join(rootDir, p),
+        ),
+      );
+    });
+
+    it('gets collections from external reference config', async () => {
+      expect(
+        pathsArrayFromCollectionName(
+          'lion-based-ui-collection',
+          'reference',
+          externalCfgMock,
+          rootDir,
+        ),
+      ).to.eql(
+        externalCfgMock.referenceCollections['lion-based-ui-collection'].map(p =>
+          pathLib.join(rootDir, p),
+        ),
+      );
+    });
+  });
+
+  describe('appendProjectDependencyPaths', () => {
+    before(() => {
+      mockWriteToJson(queryResults);
+      suppressNonCriticalLogs();
+
+      mockProject(
+        {
+          './src/OriginalComp.js': `export class OriginalComp {}`,
+          './src/inbetween.js': `export { OriginalComp as InBetweenComp } from './OriginalComp.js'`,
+          './index.js': `export { InBetweenComp as MyComp } from './src/inbetween.js'`,
+          './node_modules/dependency-a/index.js': '',
+          './bower_components/dependency-b/index.js': '',
+        },
+        {
+          projectName: 'example-project',
+          projectPath: '/mocked/path/example-project',
+        },
+      );
+    });
+
+    it('adds bower and node dependencies', async () => {
+      const result = await appendProjectDependencyPaths(['/mocked/path/example-project']);
+      expect(result).to.eql([
+        '/mocked/path/example-project/node_modules/dependency-a',
+        '/mocked/path/example-project/bower_components/dependency-b',
+        '/mocked/path/example-project',
+      ]);
+    });
+
+    it('allows a regex filter', async () => {
+      const result = await appendProjectDependencyPaths(['/mocked/path/example-project'], 'b$');
+      expect(result).to.eql([
+        '/mocked/path/example-project/bower_components/dependency-b',
+        '/mocked/path/example-project',
+      ]);
+    });
+
+    it('allows to filter out only npm or bower deps', async () => {
+      const result = await appendProjectDependencyPaths(['/mocked/path/example-project'], null, [
+        'npm',
+      ]);
+      expect(result).to.eql([
+        '/mocked/path/example-project/node_modules/dependency-a',
+        '/mocked/path/example-project',
+      ]);
+
+      const result2 = await appendProjectDependencyPaths(['/mocked/path/example-project'], null, [
+        'bower',
+      ]);
+      expect(result2).to.eql([
+        '/mocked/path/example-project/bower_components/dependency-b',
+        '/mocked/path/example-project',
       ]);
     });
   });

--- a/packages/providence-analytics/test-node/cli/cli.test.js
+++ b/packages/providence-analytics/test-node/cli/cli.test.js
@@ -28,9 +28,6 @@ const {
   appendProjectDependencyPaths,
 } = cliHelpersModule;
 
-// Prevent (node:2860) MaxListenersExceededWarning
-commander.setMaxListeners(100);
-
 const queryResults = [];
 const rootDir = pathLib.resolve(__dirname, '../../');
 
@@ -63,6 +60,9 @@ describe('Providence CLI', () => {
   let qConfStub;
 
   before(() => {
+    // Prevent MaxListenersExceededWarning
+    commander.setMaxListeners(100);
+
     mockWriteToJson(queryResults);
     suppressNonCriticalLogs();
 
@@ -105,6 +105,8 @@ describe('Providence CLI', () => {
   });
 
   after(() => {
+    commander.setMaxListeners(10);
+
     restoreSuppressNonCriticalLogs();
     restoreMockedProjects();
     restoreWriteToJson();

--- a/packages/providence-analytics/test-node/cli/cli.test.js
+++ b/packages/providence-analytics/test-node/cli/cli.test.js
@@ -1,6 +1,7 @@
 const sinon = require('sinon');
 const pathLib = require('path');
 const { expect } = require('chai');
+const commander = require('commander');
 const {
   mockProject,
   restoreMockedProjects,
@@ -26,6 +27,9 @@ const {
   pathsArrayFromCollectionName,
   appendProjectDependencyPaths,
 } = cliHelpersModule;
+
+// Prevent (node:2860) MaxListenersExceededWarning
+commander.setMaxListeners(100);
 
 const queryResults = [];
 const rootDir = pathLib.resolve(__dirname, '../../');
@@ -260,14 +264,14 @@ describe('Providence CLI', () => {
       expect(providenceStub.args[0][1].writeLogFile).to.equal(true);
     });
 
-    it('--include-target-deps"', async () => {
+    it('--target-dependencies"', async () => {
       await runCli(`${analyzeCmd}`, rootDir);
       expect(appendProjectDependencyPathsStub.called).to.be.false;
 
       appendProjectDependencyPathsStub.resetHistory();
       providenceStub.resetHistory();
 
-      await runCli(`${analyzeCmd} --include-target-deps`, rootDir);
+      await runCli(`${analyzeCmd} --target-dependencies`, rootDir);
       expect(appendProjectDependencyPathsStub.called).to.be.true;
       expect(providenceStub.args[0][1].targetProjectPaths).to.eql([
         '/mocked/path/example-project',
@@ -276,9 +280,9 @@ describe('Providence CLI', () => {
       ]);
     });
 
-    it('--target-deps-filter"', async () => {
-      await runCli(`${analyzeCmd} --include-target-deps --target-deps-filter ^mock-`, rootDir);
-      expect(appendProjectDependencyPathsStub.args[0][1]).to.equal('^mock-');
+    it('--target-dependencies /^with-regex/"', async () => {
+      await runCli(`${analyzeCmd} --target-dependencies /^mock-/`, rootDir);
+      expect(appendProjectDependencyPathsStub.args[0][1]).to.equal('/^mock-/');
     });
   });
 
@@ -464,7 +468,7 @@ describe('CLI helpers', () => {
     });
 
     it('allows a regex filter', async () => {
-      const result = await appendProjectDependencyPaths(['/mocked/path/example-project'], 'b$');
+      const result = await appendProjectDependencyPaths(['/mocked/path/example-project'], '/b$/');
       expect(result).to.eql([
         '/mocked/path/example-project/bower_components/dependency-b',
         '/mocked/path/example-project',

--- a/packages/providence-analytics/test-node/program/analyzers/match-imports.test.js
+++ b/packages/providence-analytics/test-node/program/analyzers/match-imports.test.js
@@ -312,17 +312,18 @@ describe('Analyzer "match-imports"', () => {
   describe('Configuration', () => {
     it(`allows to provide results of FindExportsAnalyzer and FindImportsAnalyzer`, async () => {
       mockTargetAndReferenceProject(searchTargetProject, referenceProject);
-      const importsAnalyzerResult = await new FindImportsAnalyzer().execute({
+      const findImportsResult = await new FindImportsAnalyzer().execute({
         targetProjectPath: searchTargetProject.path,
       });
-      const exportsAnalyzerResult = await new FindExportsAnalyzer().execute({
+      const findExportsResult = await new FindExportsAnalyzer().execute({
         targetProjectPath: referenceProject.path,
       });
-      await providence(matchImportsQueryConfig, {
-        ..._providenceCfg,
-        importsAnalyzerResult,
-        exportsAnalyzerResult,
+
+      const matchImportsQueryConfigExt = QueryService.getQueryConfigFromAnalyzer('match-imports', {
+        targetProjectResult: findImportsResult,
+        referenceProjectResult: findExportsResult,
       });
+      await providence(matchImportsQueryConfigExt, _providenceCfg);
       const queryResult = queryResults[0];
 
       expectedExportIdsDirect.forEach(targetId => {
@@ -333,5 +334,8 @@ describe('Analyzer "match-imports"', () => {
         testMatchedEntry(targetId, queryResult, ['./target-src/indirect-imports.js']);
       });
     });
+
+    // TODO: Test this unwind functionality in a generic MatchAnalyzer test
+    it.skip(`allows to provide results of FindExportsAnalyzer and FindImportsAnalyzer from external jsons`, async () => {});
   });
 });

--- a/packages/providence-analytics/test-node/program/services/InputDataService.test.js
+++ b/packages/providence-analytics/test-node/program/services/InputDataService.test.js
@@ -118,7 +118,7 @@ describe('InputDataService', () => {
         ]);
       });
 
-      it('allows passing excludeFolders', async () => {
+      it('allows passing excluded folders', async () => {
         const globOutput = InputDataService.gatherFilesFromDir('/fictional/project', {
           extensions: ['.html', '.js'],
           filter: ['!nested/**'],


### PR DESCRIPTION
adds:
- `--include-target-deps`: For all search targets, will include all its dependencies
    (node_modules and bower_components). When --target-deps-filter is applied, a subset
    will be applied that matches the filter condition
- `--target-deps-filter`: Regex condition to be applied to dependencies of search targets.

- extensive cli tests