### PR TITLE
chore: add playwright and a script to test in all evergreen browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "storybook:build:start": "es-dev-server --root-dir storybook-static --open",
     "test": "run-p test:browser test:node",
     "test:browser": "wtr \"packages/**/*/test/**/*.test.js\" --coverage",
+    "test:browser:all": "wtr \"packages/**/*/test/**/*.test.js\" --playwright --browsers webkit chromium firefox --coverage",
     "test:browser:watch": "wtr \"packages/**/*/test/**/*.test.js\" --watch",
     "test:browserstack": "wtr --config ./web-test-runner-browserstack.config.js \"packages/form-core/test/**/*.test.js\"",
     "test:node": "node scripts/workspaces-scripts.mjs run test:node"
@@ -44,8 +45,9 @@
     "@storybook/addon-a11y": "~5.0.0",
     "@types/chai-dom": "^0.0.8",
     "@web/dev-server-legacy": "^0.0.3",
-    "@web/test-runner": "^0.6.46",
+    "@web/test-runner": "^0.6.50",
     "@web/test-runner-browserstack": "^0.0.8",
+    "@web/test-runner-playwright": "^0.4.13",
     "@webcomponents/webcomponentsjs": "^2.4.4",
     "babel-eslint": "^8.2.6",
     "babel-polyfill": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2464,20 +2464,20 @@
     polyfills-loader "^1.6.1"
     valid-url "^1.0.9"
 
-"@web/dev-server-rollup@^0.1.5":
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/@web/dev-server-rollup/-/dev-server-rollup-0.1.5.tgz#cce84bbd4c668fb238f9b96e997edf46fe967710"
-  integrity sha512-2DmnIkg8AvEGkW9yr5Ao0v6CwrRxaRP5CA3HfXY41Qk9rKx9pNvEVZpsdTNN4wmSZuWc2Qx+ldXpJHtWvJ87bA==
+"@web/dev-server-rollup@^0.1.6":
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/@web/dev-server-rollup/-/dev-server-rollup-0.1.6.tgz#711fea9053d059b8ba4498d6cb5db1be24f3f100"
+  integrity sha512-B979K6wFXTBP/vslAvegOMyoNY4UwOKdeECx4Mk/uSwNI4Aysmwr6YDLETyw7mODFyp8I1cdK76j3mSntXVmrA==
   dependencies:
     "@web/dev-server-core" "^0.1.5"
     chalk "^4.1.0"
     rollup "^2.20.0"
     whatwg-url "^8.1.0"
 
-"@web/test-runner-browser-lib@^0.2.9":
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-browser-lib/-/test-runner-browser-lib-0.2.9.tgz#dab39ced79f11a7eddbd0c942ca63011a416c3ad"
-  integrity sha512-8VoJ+wymGPW1C4496aV8NFEHl/0K1kIW6Hf9319Re2eM4Gdh3SMHtwVdldk7e4+NXNVs9hKZZHGXsbEQ2zQTZg==
+"@web/test-runner-browser-lib@^0.2.10":
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-browser-lib/-/test-runner-browser-lib-0.2.10.tgz#d21551a90114c61f6bf7183d762cd9bbe24b98f3"
+  integrity sha512-PiyXi3Mh7GsYs8yE1/qTe1x7cRnGCh2SLc3zlUMJ+WqDbdTkFvRmMBZHDtno6OEsGqp2NkjN3r2adr7o7uTv7w==
 
 "@web/test-runner-browserstack@^0.0.8":
   version "0.0.8"
@@ -2491,27 +2491,27 @@
     selenium-webdriver "^4.0.0-alpha.7"
     uuid "^8.1.0"
 
-"@web/test-runner-chrome@^0.5.12":
-  version "0.5.12"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-chrome/-/test-runner-chrome-0.5.12.tgz#0d4d9665276cc5a54dd8774195acf7dda13063d1"
-  integrity sha512-CLvFz31hlt9XJRfeTRXK4p5u706CKgLlb6uIwGV5aALUmf+i0La3Fb8b4sBgCVF4ZtDjvLlg+lS69csrXJ8unw==
+"@web/test-runner-chrome@^0.5.13":
+  version "0.5.13"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-chrome/-/test-runner-chrome-0.5.13.tgz#367f250f2448e56c6cb3ebc987f384b0b24a6a90"
+  integrity sha512-mZfIoX6I1kZ8aNXiyFUpuX8F30dpx46Tv8pdev3OpWiX2JaSXc5IqNO8wviQN7lj7mOLeS3ZQ/Qkp/3hUVeEbg==
   dependencies:
     "@types/puppeteer-core" "^2.0.0"
     "@web/browser-logs" "^0.0.1"
-    "@web/test-runner-coverage-v8" "^0.0.3"
+    "@web/test-runner-coverage-v8" "^0.0.4"
     chrome-launcher "^0.13.3"
     puppeteer-core "^5.0.0"
 
-"@web/test-runner-cli@^0.4.21":
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-cli/-/test-runner-cli-0.4.21.tgz#91f9158c39e3120a7dfe82f84ca4d46ece1cabea"
-  integrity sha512-fJ5m4Qp4EuhtyaPGfMX2vW/k8usv28cP9Thx9HzXwvGLN6oxiD8r9qK5QFi70TxdL6g+UpqV747x0XpD9gvxUA==
+"@web/test-runner-cli@^0.4.23":
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-cli/-/test-runner-cli-0.4.23.tgz#7404f0b855d51474ba9b5e82483222fc436a226a"
+  integrity sha512-/snvRDJhMaqHLk0xTxktuyKQGGz2Cklq97GDfDdXHbsxJ3AR8Xa6F28XmS7Tg2m0Jw6uc5w4Jxg9Rt9eHjXsDQ==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@types/babel__code-frame" "^7.0.1"
     "@web/browser-logs" "^0.0.1"
     "@web/config-loader" "^0.0.3"
-    "@web/test-runner-core" "^0.6.16"
+    "@web/test-runner-core" "^0.6.17"
     camelcase "^6.0.0"
     chalk "^4.1.0"
     cli-cursor "^3.1.0"
@@ -2536,6 +2536,15 @@
     picomatch "^2.2.2"
     uuid "^8.1.0"
 
+"@web/test-runner-core@^0.6.17":
+  version "0.6.17"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-core/-/test-runner-core-0.6.17.tgz#ea4fb93d4e919b083509cdd0db7fb2c2e6df7f8d"
+  integrity sha512-bwwZk/todrTEbYi45ae/zBULXRfWhMygJyhXqtPp38zmLh0Oj5rm7dXQEMIR0cAvbtfd7RYVOALDbkA0MrkNDA==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    picomatch "^2.2.2"
+    uuid "^8.1.0"
+
 "@web/test-runner-core@^0.6.9":
   version "0.6.15"
   resolved "https://registry.yarnpkg.com/@web/test-runner-core/-/test-runner-core-0.6.15.tgz#44b710cf9be7537eff42c96b5c3ee66d3915e45c"
@@ -2545,23 +2554,33 @@
     picomatch "^2.2.2"
     uuid "^8.1.0"
 
-"@web/test-runner-coverage-v8@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.0.3.tgz#094d45f9af8ed8259d017aa6c8305a601f778808"
-  integrity sha512-otpJtVIMB8ZVVXQ0Pyj/AaIbF0UryORawOiDPv8ZqEYHS79MD/3jeIct1cpMDgoyULkrUKSf9PmxXhiXfb2dcQ==
+"@web/test-runner-coverage-v8@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-coverage-v8/-/test-runner-coverage-v8-0.0.4.tgz#c5aff4eb7383a8a06c99d4ed5f13207721ca1e1d"
+  integrity sha512-c77PwhoFYnS6Suy9c/3PSEc4Yw+0AzZbstkO7sfcJ4iP9zbmseU5Jzzwkyzl+ijxeU3b0krIf5gMQGJUHxWf2Q==
   dependencies:
     "@web/test-runner-core" "^0.6.9"
     istanbul-lib-coverage "^3.0.0"
     v8-to-istanbul "^4.1.4"
 
-"@web/test-runner-mocha@^0.2.9":
-  version "0.2.9"
-  resolved "https://registry.yarnpkg.com/@web/test-runner-mocha/-/test-runner-mocha-0.2.9.tgz#2d6f7163ccffad813a9031658880972539966a7c"
-  integrity sha512-aUtWrymiwqxCvhLcjobAnxJSf43OtzDHPRlO71ZOiiep4OiG/0hDBJ4U6ctkjsA1HSJ++ft7xNoWSO2mnZFIxw==
+"@web/test-runner-mocha@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-mocha/-/test-runner-mocha-0.2.11.tgz#5fbc7a58803f60e6dc9e5242209dd741c9b0a2ea"
+  integrity sha512-sTCRzGQxqsemSYbdF3wWMsaXIqQyGWGyFtMXbRMxvg9/nr9p01B+tSCoxGZj0SDBSV253svt92bPFgrbPj2SNQ==
   dependencies:
     "@types/mocha" "^7.0.2"
-    "@web/test-runner-browser-lib" "^0.2.9"
+    "@web/test-runner-browser-lib" "^0.2.10"
     mocha "^7.2.0"
+
+"@web/test-runner-playwright@^0.4.13":
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/@web/test-runner-playwright/-/test-runner-playwright-0.4.13.tgz#066c6aeb144dbf8de4d3e40c7bd5f3382bd03680"
+  integrity sha512-NcZGkAMH6f5PcXwT5Km1ogm9mm8NykjXWDN9uQsp4YUVRetZ9DG3MBFZNnKch761aeQivtptNz3M51GIyfZdMw==
+  dependencies:
+    "@web/browser-logs" "^0.0.1"
+    "@web/test-runner-core" "^0.6.16"
+    "@web/test-runner-coverage-v8" "^0.0.4"
+    playwright "^1.2.1"
 
 "@web/test-runner-selenium@^0.1.4":
   version "0.1.4"
@@ -2584,17 +2603,17 @@
     dependency-graph "^0.9.0"
     picomatch "^2.2.2"
 
-"@web/test-runner@^0.6.46":
-  version "0.6.46"
-  resolved "https://registry.yarnpkg.com/@web/test-runner/-/test-runner-0.6.46.tgz#f738917e397d49d8eb726fee39bfde371e86c7fc"
-  integrity sha512-RUaF2Kv5tip4dXhfG3IjRTh3l91rObTVs/qet3ywM+sFh1VZoEsPgOy+SIFQJwTYl4zJs3JhgebOH1YNYx4dwg==
+"@web/test-runner@^0.6.50":
+  version "0.6.50"
+  resolved "https://registry.yarnpkg.com/@web/test-runner/-/test-runner-0.6.50.tgz#c15121a58e65e487c5ee7f280ead48bce48ecb93"
+  integrity sha512-90T0jpYMPUxXunSlcWbAXpUC3r1NCu4KkMfIaTSb4YgB9IxcDxIOZbTnkvybLHuX3jgfiQiRcrO+bL+rcKxJkA==
   dependencies:
     "@rollup/plugin-node-resolve" "^8.1.0"
-    "@web/dev-server-rollup" "^0.1.5"
-    "@web/test-runner-chrome" "^0.5.12"
-    "@web/test-runner-cli" "^0.4.21"
-    "@web/test-runner-core" "^0.6.16"
-    "@web/test-runner-mocha" "^0.2.9"
+    "@web/dev-server-rollup" "^0.1.6"
+    "@web/test-runner-chrome" "^0.5.13"
+    "@web/test-runner-cli" "^0.4.23"
+    "@web/test-runner-core" "^0.6.17"
+    "@web/test-runner-mocha" "^0.2.11"
     "@web/test-runner-server" "^0.5.12"
     command-line-args "^5.1.1"
     deepmerge "^4.2.2"
@@ -2649,6 +2668,13 @@ agent-base@5:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
   integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
+agent-base@6:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
+  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  dependencies:
+    debug "4"
 
 aggregate-error@^3.0.0:
   version "3.0.1"
@@ -2953,6 +2979,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+async-limiter@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
+  integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
 async@^2.6.2:
   version "2.6.3"
@@ -6210,6 +6241,14 @@ https-proxy-agent@^4.0.0:
     agent-base "5"
     debug "4"
 
+https-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
+  integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-id@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/human-id/-/human-id-1.0.2.tgz#e654d4b2b0d8b07e45da9f6020d8af17ec0a5df3"
@@ -6832,6 +6871,11 @@ jest-worker@^24.9.0:
   dependencies:
     merge-stream "^2.0.0"
     supports-color "^6.1.0"
+
+jpeg-js@^0.3.7:
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.3.7.tgz#471a89d06011640592d314158608690172b1028d"
+  integrity sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ==
 
 js-beautify@^1.8.9:
   version "1.11.0"
@@ -7768,7 +7812,7 @@ mime-types@^2.1.18, mime-types@^2.1.27, mime-types@~2.1.24:
   dependencies:
     mime-db "1.44.0"
 
-mime@^2.0.3:
+mime@^2.0.3, mime@^2.4.4:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.6.tgz#e5b407c90db442f2beb5b162373d07b69affa4d1"
   integrity sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==
@@ -8740,6 +8784,23 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
+playwright@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.2.1.tgz#9c6758668ff9776b162f8174a2d972265540cd5b"
+  integrity sha512-wD5WZ3rNvmXq+W4qhwykrm8J7VGYsjMjdC2WjZb4B4r7j/IFzq6EhliD+ZBIl+HOymFNsTwPZYhXy7IqeC2+YQ==
+  dependencies:
+    commander "^5.1.0"
+    debug "^4.1.1"
+    extract-zip "^2.0.0"
+    https-proxy-agent "^5.0.0"
+    jpeg-js "^0.3.7"
+    mime "^2.4.4"
+    pngjs "^5.0.0"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    rimraf "^3.0.2"
+    ws "^6.1.0"
+
 please-upgrade-node@^3.1.1, please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -8767,6 +8828,11 @@ plugin-error@^1.0.1:
     arr-diff "^4.0.0"
     arr-union "^3.1.0"
     extend-shallow "^3.0.2"
+
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
 
 polished@^2.3.3:
   version "2.3.3"
@@ -8913,7 +8979,7 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-progress@^2.0.0, progress@^2.0.1:
+progress@^2.0.0, progress@^2.0.1, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -8946,7 +9012,7 @@ proto-list@~1.2.1:
   resolved "https://registry.yarnpkg.com/proto-list/-/proto-list-1.2.4.tgz#212d5bfe1318306a420f6402b8e26ff39647a849"
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
-proxy-from-env@^1.0.0:
+proxy-from-env@^1.0.0, proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
@@ -11666,6 +11732,13 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+ws@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  dependencies:
+    async-limiter "~1.0.0"
 
 ws@^7.2.3:
   version "7.3.1"


### PR DESCRIPTION
Currently results in this output
```
Chromium: |██████████████████████████████| 117/117 test files | 1502 passed, 0 failed
Firefox:  |██████████████████████████████| 117/117 test files | 1478 passed, 24 failed
Webkit:   |██████████████████████████████| 117/117 test files | 1488 passed, 14 failed
```

before we can enable it in the CI this needs to be green for everything.

Errors are most likely in the tests but needs to be clean up. (Firefox fails on all focus tests - potentially a playwright config issue)