### PR TITLE
[draft] feat(form-core): default fieldNames and articles

### DIFF
--- a/packages/form-core/src/FormControlMixin.js
+++ b/packages/form-core/src/FormControlMixin.js
@@ -93,12 +93,12 @@ export const FormControlMixin = dedupeMixin(
         this.requestUpdate('helpText', oldValue);
       }
 
-      set fieldName(value) {
-        this.__fieldName = value;
-      }
+      // set fieldName(value) {
+      //   this.__fieldName = value;
+      // }
 
       get fieldName() {
-        return this.__fieldName || this.label || this.name;
+        return super.fieldName || this.label || this.name;
       }
 
       get slots() {

--- a/packages/form-core/src/validate/ValidateMixin.js
+++ b/packages/form-core/src/validate/ValidateMixin.js
@@ -100,15 +100,6 @@ export const ValidateMixin = dedupeMixin(
            * error messages. For instance: `Please fill in a(n) {fieldName}`
            */
           fieldName: String,
-
-          /**
-           * @type {Promise<string>|string} will be passed as an argument to the `.getMessage`
-           * method of a Validator. When filled in, this field name can be used to enhance
-           * error messages. For instance: `Please fill in {article} {fieldName}`
-           * The article has a direct relationship with fieldName and should thus only be
-           * provided together with a fieldName
-           */
-          article: String,
         };
       }
 
@@ -164,14 +155,6 @@ export const ValidateMixin = dedupeMixin(
 
       set fieldName(f) {
         this.__fieldName = f;
-      }
-
-      get article() {
-        return this.__article || this.constructor.article;
-      }
-
-      set article(a) {
-        this.__article = a;
       }
 
       constructor() {
@@ -539,21 +522,16 @@ export const ValidateMixin = dedupeMixin(
        */
       async __getFeedbackMessages(validators) {
         let fieldName = await this.fieldName;
-        let article = await this.article;
 
         return Promise.all(
           validators.map(async validator => {
             if (validator.config.fieldName) {
               fieldName = await validator.config.fieldName;
             }
-            if (validator.config.article) {
-              article = await validator.config.article;
-            }
             const message = await validator._getMessage({
               modelValue: this.modelValue,
               formControl: this,
               fieldName,
-              article,
             });
             return { message, type: validator.type, validator };
           }),

--- a/packages/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -490,66 +490,6 @@ export function runValidateMixinFeedbackPart() {
           name: 'MinLength',
         });
       });
-
-      it('".getMessage()" gets .article defined on instance', async () => {
-        const constructorValidator = new MinLength(4);
-        const spy = sinon.spy(constructorValidator.constructor, 'getMessage');
-
-        const el = await fixture(html`
-          <${tag}
-            .submitted=${true}
-            .validators=${[constructorValidator]}
-            .modelValue=${'cat'}
-            .fieldName=${new Promise(resolve => resolve('myField'))}
-            .article=${new Promise(resolve => resolve('a'))}
-          >${lightDom}</${tag}>
-        `);
-        await el.updateComplete;
-        await el.feedbackComplete;
-        expect(spy.args[0][0]).to.eql({
-          config: {},
-          params: 4,
-          modelValue: 'cat',
-          formControl: el,
-          fieldName: 'myField',
-          article: 'a',
-          type: 'error',
-          name: 'MinLength',
-        });
-      });
-
-      it('".getMessage()" gets .article defined on Validator config', async () => {
-        const constructorValidator = new MinLength(4, {
-          fieldName: new Promise(resolve => resolve('myFieldViaCfg')),
-        });
-        const spy = sinon.spy(constructorValidator.constructor, 'getMessage');
-
-        const el = await fixture(html`
-          <${tag}
-            .submitted=${true}
-            .validators=${[constructorValidator]}
-            .modelValue=${'cat'}
-            .fieldName=${new Promise(resolve => resolve('myField'))}
-            .article=${new Promise(resolve => resolve('a'))}
-          >${lightDom}</${tag}>
-        `);
-        await el.updateComplete;
-        await el.feedbackComplete;
-
-        // ignore fieldName Promise as it will always be unique
-        const compare = spy.args[0][0];
-        delete compare.config.fieldName;
-        expect(compare).to.eql({
-          config: {},
-          params: 4,
-          modelValue: 'cat',
-          formControl: el,
-          fieldName: 'myFieldViaCfg',
-          article: 'a',
-          type: 'error',
-          name: 'MinLength',
-        });
-      });
     });
 
     it('handles _updateFeedbackComponent with sync and async combinations', async () => {
@@ -591,17 +531,16 @@ export function runValidateMixinFeedbackPart() {
         expect(el._feedbackNode.feedbackData[0].message).to.equal('Fill in something');
       });
 
-      it('can set global validator messages', async () => {
-        Required.getMessage = ({ article, fieldName }) => `Please enter ${article} ${fieldName}`;
+      it('can set global fieldNames', async () => {
+        Required.getMessage = ({ fieldName }) => `Please enter a(n) ${fieldName}`;
         ValidateMixin.fieldName = 'value';
-        ValidateMixin.article = 'a';
 
         const el = await fixture(html`<${tag}
           .validators=${[new Required()]}
         >${lightDom}</${tag}>`);
         await el.feedbackComplete;
 
-        expect(el._feedbackNode.feedbackData[0].message).to.equal('Please enter a value');
+        expect(el._feedbackNode.feedbackData[0].message).to.equal('Please enter a(n) value');
       });
     });
   });

--- a/packages/validate-messages/test/loadDefaultFeedbackMessages.test.js
+++ b/packages/validate-messages/test/loadDefaultFeedbackMessages.test.js
@@ -15,14 +15,14 @@ describe('loadDefaultFeedbackMessages', () => {
     expect(await el._getMessage({ fieldName: 'password' })).to.equal('Please enter a(n) password.');
   });
 
-  it('will set default fieldName and article', async () => {
+  it('will set default fieldName', async () => {
     const el = new Required();
-    expect(await el._getMessage()).to.equals(
+    expect(await el._getMessage()).to.equal(
       'Please configure an error message for "Required" by overriding "static async getMessage()"',
     );
 
     loadDefaultFeedbackMessages();
-    expect(await el._getMessage()).to.equal('Please enter a value.');
+    expect(await el._getMessage()).to.equal('Please enter a(n) value.');
     expect(await el._getMessage({ fieldName: 'password' })).to.equal('Please enter a(n) password.');
   });
 

--- a/packages/validate-messages/test/loadDefaultFeedbackMessages.test.js
+++ b/packages/validate-messages/test/loadDefaultFeedbackMessages.test.js
@@ -15,6 +15,17 @@ describe('loadDefaultFeedbackMessages', () => {
     expect(await el._getMessage({ fieldName: 'password' })).to.equal('Please enter a(n) password.');
   });
 
+  it('will set default fieldName and article', async () => {
+    const el = new Required();
+    expect(await el._getMessage()).to.equals(
+      'Please configure an error message for "Required" by overriding "static async getMessage()"',
+    );
+
+    loadDefaultFeedbackMessages();
+    expect(await el._getMessage()).to.equal('Please enter a value.');
+    expect(await el._getMessage({ fieldName: 'password' })).to.equal('Please enter a(n) password.');
+  });
+
   it('will await loading of translations when switching locale', async () => {
     const el = new Required();
     loadDefaultFeedbackMessages();

--- a/packages/validate-messages/translations/en.js
+++ b/packages/validate-messages/translations/en.js
@@ -49,4 +49,9 @@ export default {
     Changed: 'Changed!',
     OkCorrect: 'Ok, correct.',
   },
+  defaultSubject: {
+    fieldName: 'value',
+    article: 'a',
+  },
+  defaultNeutralArticle: 'a(n)',
 };

--- a/packages/validate-messages/translations/en.js
+++ b/packages/validate-messages/translations/en.js
@@ -49,9 +49,5 @@ export default {
     Changed: 'Changed!',
     OkCorrect: 'Ok, correct.',
   },
-  defaultSubject: {
-    fieldName: 'value',
-    article: 'a',
-  },
-  defaultNeutralArticle: 'a(n)',
+  fieldName: 'value',
 };


### PR DESCRIPTION
Proposal for default fieldNames in validation (instead of label name).

Additionally, we could consider:

- adding default fieldNames `'a date'|'an email'|'an iban'|'an amount'` for lion-input-(date|email|iban|amount)