### PR TITLE
Fix/overlay unhandled rejection

### DIFF
--- a/packages/overlays/src/OverlayController.js
+++ b/packages/overlays/src/OverlayController.js
@@ -298,7 +298,8 @@ export class OverlayController {
       this._renderTarget.appendChild(this.contentNode);
     } else {
       const isInsideRenderTarget = this._renderTarget === this._contentWrapperNode.parentNode;
-      if (!isInsideRenderTarget) {
+      const nodeContainsTarget = this._contentWrapperNode.contains(this._renderTarget);
+      if (!isInsideRenderTarget && !nodeContainsTarget) {
         // contentWrapperNode becomes the direct (non projected) parent of contentNode
         this._renderTarget.appendChild(this._contentWrapperNode);
       }


### PR DESCRIPTION
Fix of issue - https://github.com/ing-bank/lion/issues/826

OverlayController.js has unhandled rejection -
Unhandled rejection: Error: Failed to execute 'appendChild' on 'Node': The new child element contains the parent.