### PR TITLE
Proposal: Use global cache for storing objects for singletons

### DIFF
--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -33,7 +33,6 @@
   ],
   "dependencies": {
     "@lion/core": "0.12.0",
-    "singleton-manager": "1.1.2"
   },
   "keywords": [
     "icon",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -32,7 +32,7 @@
     "./docs/icon-resolvers.js"
   ],
   "dependencies": {
-    "@lion/core": "0.12.0",
+    "@lion/core": "0.12.0"
   },
   "keywords": [
     "icon",

--- a/packages/icon/src/IconManager.js
+++ b/packages/icon/src/IconManager.js
@@ -1,8 +1,9 @@
-export class IconManager {
-  constructor() {
-    this.__iconResolvers = new Map();
-  }
+const sym = Symbol.for('@lion/icon@0');
+if (!document[sym]) {
+  document[sym] = new Map();
+}
 
+export class IconManager {
   /**
    * Adds an icon resolver for the given namespace. An icon resolver is a
    * function which takes an icon set and an icon name and returns an svg
@@ -12,10 +13,10 @@ export class IconManager {
    * @param {(iconset: string, icon: string) => TemplateResult | Promise<TemplateResult>} iconResolver
    */
   addIconResolver(namespace, iconResolver) {
-    if (this.__iconResolvers.has(namespace)) {
+    if (document[sym].has(namespace)) {
       throw new Error(`An icon resolver has already been registered for namespace: ${namespace}`);
     }
-    this.__iconResolvers.set(namespace, iconResolver);
+    document[sym].set(namespace, iconResolver);
   }
 
   /**
@@ -23,7 +24,7 @@ export class IconManager {
    * @param {string} namespace
    */
   removeIconResolver(namespace) {
-    this.__iconResolvers.delete(namespace);
+    document[sym].delete(namespace);
   }
 
   /**
@@ -35,7 +36,7 @@ export class IconManager {
    * @returns {Promise<TemplateResult>}
    */
   resolveIcon(namespace, iconset, icon) {
-    const resolver = this.__iconResolvers.get(namespace);
+    const resolver = document[sym].get(namespace);
     if (resolver) {
       return resolver(iconset, icon);
     }

--- a/packages/icon/src/IconManager.js
+++ b/packages/icon/src/IconManager.js
@@ -1,4 +1,4 @@
-const sym = Symbol.for('@lion/icon@0');
+const sym = Symbol.for('@lion/icon::icons::0.5.x');
 if (!document[sym]) {
   document[sym] = new Map();
 }

--- a/packages/icon/src/IconManager.js
+++ b/packages/icon/src/IconManager.js
@@ -12,6 +12,7 @@ export class IconManager {
    * @param {string} namespace
    * @param {(iconset: string, icon: string) => TemplateResult | Promise<TemplateResult>} iconResolver
    */
+  // eslint-disable-next-line class-methods-use-this
   addIconResolver(namespace, iconResolver) {
     if (document[sym].has(namespace)) {
       throw new Error(`An icon resolver has already been registered for namespace: ${namespace}`);
@@ -23,6 +24,7 @@ export class IconManager {
    * Removes an icon resolver for a namespace.
    * @param {string} namespace
    */
+  // eslint-disable-next-line class-methods-use-this
   removeIconResolver(namespace) {
     document[sym].delete(namespace);
   }
@@ -35,6 +37,7 @@ export class IconManager {
    * @param {string} icon
    * @returns {Promise<TemplateResult>}
    */
+  // eslint-disable-next-line class-methods-use-this
   resolveIcon(namespace, iconset, icon) {
     const resolver = document[sym].get(namespace);
     if (resolver) {

--- a/packages/icon/src/IconManager.js
+++ b/packages/icon/src/IconManager.js
@@ -4,6 +4,9 @@ if (!document[sym]) {
 }
 
 export class IconManager {
+  get __iconResolvers() {
+    return document[sym];
+  }
   /**
    * Adds an icon resolver for the given namespace. An icon resolver is a
    * function which takes an icon set and an icon name and returns an svg
@@ -12,21 +15,19 @@ export class IconManager {
    * @param {string} namespace
    * @param {(iconset: string, icon: string) => TemplateResult | Promise<TemplateResult>} iconResolver
    */
-  // eslint-disable-next-line class-methods-use-this
   addIconResolver(namespace, iconResolver) {
     if (document[sym].has(namespace)) {
       throw new Error(`An icon resolver has already been registered for namespace: ${namespace}`);
     }
-    document[sym].set(namespace, iconResolver);
+    this.__iconResolvers.set(namespace, iconResolver);
   }
 
   /**
    * Removes an icon resolver for a namespace.
    * @param {string} namespace
    */
-  // eslint-disable-next-line class-methods-use-this
   removeIconResolver(namespace) {
-    document[sym].delete(namespace);
+    this.__iconResolvers.delete(namespace);
   }
 
   /**
@@ -37,9 +38,8 @@ export class IconManager {
    * @param {string} icon
    * @returns {Promise<TemplateResult>}
    */
-  // eslint-disable-next-line class-methods-use-this
   resolveIcon(namespace, iconset, icon) {
-    const resolver = document[sym].get(namespace);
+    const resolver = this.__iconResolvers.get(namespace);
     if (resolver) {
       return resolver(iconset, icon);
     }

--- a/packages/icon/src/IconManager.js
+++ b/packages/icon/src/IconManager.js
@@ -4,9 +4,11 @@ if (!document[sym]) {
 }
 
 export class IconManager {
+  // eslint-disable-next-line class-methods-use-this
   get __iconResolvers() {
     return document[sym];
   }
+  
   /**
    * Adds an icon resolver for the given namespace. An icon resolver is a
    * function which takes an icon set and an icon name and returns an svg

--- a/packages/icon/src/icons.js
+++ b/packages/icon/src/icons.js
@@ -1,8 +1,7 @@
-import { singletonManager } from 'singleton-manager';
 import { IconManager } from './IconManager.js';
 
 // eslint-disable-next-line import/no-mutable-exports
-export let icons = singletonManager.get('@lion/icon::icons::0.5.x') || new IconManager();
+export let icons = new IconManager();
 
 export function setIcons(newIcons) {
   icons = newIcons;


### PR DESCRIPTION
Currently data stored in singletons is scoped to it's module, so it cannot be accessed by coexisting compatible versions of the singleton being consumed.

By using globally registered symbols we can store the singleton data safely in a global scope, so compatible instances can make use of the same objects set safely.

This way, the "singleton" would be the objects stored in the global symbol, and compatible instances could make use of it, not having to worry about dependency trees in large projects, removing the need of artifacts like the singleton manager. 

This PR show an implementation of this pattern in LocalizeManager to open the discussion.