### PR TITLE
feat(icon): allow custom iconManager

### DIFF
--- a/.changeset/forty-buttons-occur.md
+++ b/.changeset/forty-buttons-occur.md
@@ -1,0 +1,5 @@
+---
+'@lion/icon': minor
+---
+
+Allow setting a custom icon manager, which is important if you as a subclasser are managing your singletons.

--- a/packages/icon/src/LionIcon.js
+++ b/packages/icon/src/LionIcon.js
@@ -161,6 +161,11 @@ export class LionIcon extends LitElement {
     }
   }
 
+  // eslint-disable-next-line class-methods-use-this
+  get _iconManager() {
+    return icons;
+  }
+
   /**
    * @param {string} prevIconId
    */
@@ -172,7 +177,7 @@ export class LionIcon extends LitElement {
       }
     } else {
       const iconIdBeforeResolve = this.iconId;
-      const svg = await icons.resolveIconForId(iconIdBeforeResolve);
+      const svg = await this._iconManager.resolveIconForId(iconIdBeforeResolve);
 
       // update SVG if it did not change in the meantime to avoid race conditions
       if (this.iconId === iconIdBeforeResolve) {


### PR DESCRIPTION
## What I did

Add a _iconManager function at LionIcon to allow components extending LionIcon to use their own IconManager, or at least, set a project specific key for the singletonManager
