### PR TITLE
fix(tabs): allow nested tabs

### DIFF
--- a/.changeset/five-tips-camp.md
+++ b/.changeset/five-tips-camp.md
@@ -1,0 +1,5 @@
+---
+'@lion/tabs': patch
+---
+
+Only look for tabs and panels as direct children, this allows to have nested tabs.

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -84,6 +84,35 @@ export const slotsOrder = () => html`
 `;
 ```
 
+### Nesting tabs
+
+You can include tabs within tabs
+
+```js preview-story
+export const nestedTabs = () => html`
+  <lion-tabs>
+    <button slot="tab">Movies</button>
+    <button slot="tab">Work</button>
+    <div slot="panel">
+      <p>Find some more info about our favorite movies:</p>
+      <lion-tabs>
+        <button slot="tab">Info about Cars</button>
+        <button slot="tab">Info about Toy Story</button>
+        <p slot="panel">
+          Cars is a 2006 American computer-animated comedy film produced by Pixar Animation Studios
+          and released by Walt Disney Pictures.
+        </p>
+        <p slot="panel">
+          The feature film directorial debut of John Lasseter, it was the first entirely
+          computer-animated feature film, as well as the first feature film from Pixar.
+        </p>
+      </lion-tabs>
+    </div>
+    <p slot="panel">Work page that showcases our work.</p>
+  </lion-tabs>
+`;
+```
+
 ### Distribute New Elements
 
 Below, we demonstrate on how you could dynamically add new tab + panels.

--- a/packages/tabs/src/LionTabs.js
+++ b/packages/tabs/src/LionTabs.js
@@ -184,12 +184,12 @@ export class LionTabs extends LitElement {
   __setupStore() {
     /** @type {StoreEntry[]} */
     this.__store = [];
-    const buttons = /** @type {HTMLElement[]} */ (Array.from(
-      this.querySelectorAll('[slot="tab"]'),
-    ));
-    const panels = /** @type {HTMLElement[]} */ (Array.from(
-      this.querySelectorAll('[slot="panel"]'),
-    ));
+    const buttons = /** @type {HTMLElement[]} */ (Array.from(this.children)).filter(
+      child => child.slot === 'tab',
+    );
+    const panels = /** @type {HTMLElement[]} */ (Array.from(this.children)).filter(
+      child => child.slot === 'panel',
+    );
     if (buttons.length !== panels.length) {
       // eslint-disable-next-line no-console
       console.warn(

--- a/packages/tabs/test/lion-tabs.test.js
+++ b/packages/tabs/test/lion-tabs.test.js
@@ -80,6 +80,25 @@ describe('<lion-tabs>', () => {
       );
       stub.restore();
     });
+
+    it('only takes direct children into account', async () => {
+      const el = /** @type {LionTabs} */ (await fixture(html`
+        <lion-tabs>
+          <button slot="tab">tab 1</button>
+          <div slot="panel">
+            <button slot="tab">nested tab</button>
+            <div slot="panel">nested panel</div>
+          </div>
+          <button slot="tab">tab 2</button>
+          <div slot="panel">panel 2</div>
+        </lion-tabs>
+      `));
+      el.selectedIndex = 1;
+      const selectedTab = /** @type {Element} */ (Array.from(el.children).find(
+        child => child.slot === 'tab' && child.hasAttribute('selected'),
+      ));
+      expect(selectedTab.textContent).to.equal('tab 2');
+    });
   });
 
   describe('Tabs ([slot=tab])', () => {


### PR DESCRIPTION
## What I did

fixed: https://github.com/ing-bank/lion/issues/960

By only looking for tabs and panels as direct children.
