### PR TITLE
fix(select-rich): change scrollTargetNode to listboxNode

### DIFF
--- a/.changeset/stupid-ads-guess.md
+++ b/.changeset/stupid-ads-guess.md
@@ -1,0 +1,5 @@
+---
+'@lion/select-rich': patch
+---
+
+Change scrollTargetNode to listboxNode, same as parent and extention layer. The extention layer has a different overlayContentNode and had to set it back to listboxNode.

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -63,7 +63,7 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
   }
 
   get _scrollTargetNode() {
-    return this._overlayContentNode._scrollTargetNode || this._overlayContentNode;
+    return this._listboxNode._scrollTargetNode || this._listboxNode;
   }
 
   get checkedIndex() {


### PR DESCRIPTION
## What I did

1. Change scrollTargetNode to listboxNode, same as parent and extention layer. The extention layer has a different overlayContentNode and had to set it back to listboxNode.
