### PR TITLE
chore(combobox): cleanup & enable _handleAutocompletion for highlighting

### DIFF
--- a/packages/combobox/docs/demo-server-side.js
+++ b/packages/combobox/docs/demo-server-side.js
@@ -29,8 +29,8 @@ class DemoServerSide extends LitElement {
     this.loading = true;
     this.myData = await fetchMyData(e.target.value);
     this.loading = false;
-    // await this.updateComplete;
-    // this._combobox._handleAutocompletion();
+    await this.updateComplete;
+    this._combobox._handleAutocompletion();
   }
 
   render() {

--- a/packages/combobox/src/LionCombobox.js
+++ b/packages/combobox/src/LionCombobox.js
@@ -342,7 +342,6 @@ export class LionCombobox extends OverlayMixin(LionListbox) {
    */
   _onListboxContentChanged() {
     super._onListboxContentChanged();
-    console.log('_onListboxContentChanged');
     this.__shouldAutocompleteNextUpdate = true;
   }
 
@@ -449,7 +448,6 @@ export class LionCombobox extends OverlayMixin(LionListbox) {
    * Matches visibility of listbox options against current ._inputNode contents
    */
   _handleAutocompletion() {
-    console.log('_handleAutocompletion');
     if (this.autocomplete === 'none') {
       return;
     }


### PR DESCRIPTION
## What I did

1. remove console.logs
2. re-enable _handleAutocompletion in order to fix initial highlighting
