### PR TITLE
fix(listbox): prevent modelValue change by child components addition

### DIFF
--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -670,7 +670,7 @@ const ListboxMixinImplementation = superclass =>
         ev.stopPropagation();
       }
       this.__onChildCheckedChanged(ev);
-      this.requestUpdate('modelValue');
+      this.requestUpdate('modelValue', this.modelValue);
       this.dispatchEvent(
         new CustomEvent('model-value-changed', { detail: { element: ev.target } }),
       );


### PR DESCRIPTION
## What I did

1. This change fixes [this](https://github.com/ing-bank/lion/issues/993) issue. As modelValue is not getting changed when new child components are added, passed `this.modelValue` to be mapped to `oldValue` for comparison
