### PR TITLE
fix: fix backdrop teardown/init bugs and align APIs

### DIFF
--- a/.changeset/cool-panthers-design.md
+++ b/.changeset/cool-panthers-design.md
@@ -1,0 +1,12 @@
+---
+'@lion/overlays': minor
+---
+
+⚠️ BREAKING CHANGE:
+
+Fixed a few problems with the backdropNode and contentNode where they were not torn down properly.
+Simplified the handleBackdrop code to work for both local and global.
+Local overlay backdrop can now be animated.
+Added more demos and docs for backdrop.
+
+The breaking changes lie in the fact that the backdrop style classes are now prefixed 'local'/'global' respectively, instead of always 'global' and the class name suffixes for the `backdropNode` have changed from `fade-in`/`fade-out` to `animation-in`/`animation-out`, as not all animations are fades.

--- a/.changeset/shiny-cameras-sparkle.md
+++ b/.changeset/shiny-cameras-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+If a content slot cannot be found, OverlayMixin should check if there is a contentNode imperatively passed through the config.

--- a/packages/overlays/docs/40-system-configuration.md
+++ b/packages/overlays/docs/40-system-configuration.md
@@ -203,8 +203,8 @@ Boolean property. When true, will add a backdrop when the overlay is opened.
 The backdrop styling can be configured by targeting the `.global-overlays .global-overlays__backdrop` css selector.
 
 The backdrop animation can be configured by targeting the
-`.global-overlays .global-overlays__backdrop--fade-in` and
-`.global-overlays .global-overlays__backdrop--fade-out` css selector.
+`.global-overlays .global-overlays__backdrop--animation-in` and
+`.global-overlays .global-overlays__backdrop--animation-out` css selector.
 This currently only supports CSS Animations, because it relies on the `animationend` event to add/remove classes.
 
 ```js preview-story
@@ -235,8 +235,8 @@ Boolean property. When true, will add a backdrop when the overlay is opened.
 The backdrop styling can be configured by targeting the `.global-overlays .global-overlays__backdrop` css selector.
 
 The backdrop animation can be configured by targeting the
-`.global-overlays .global-overlays__backdrop--fade-in` and
-`.global-overlays .global-overlays__backdrop--fade-out` css selector.
+`.global-overlays .global-overlays__backdrop--animation-in` and
+`.global-overlays .global-overlays__backdrop--animation-out` css selector.
 This currently only supports CSS Animations, because it relies on the `animationend` event to add/remove classes.
 
 ```js preview-story

--- a/packages/overlays/docs/demo-overlay-backdrop.js
+++ b/packages/overlays/docs/demo-overlay-backdrop.js
@@ -1,0 +1,48 @@
+import { css, LitElement } from '@lion/core';
+
+/**
+ * @typedef {import('../types/OverlayConfig').OverlayConfig} OverlayConfig
+ */
+class DemoOverlayBackdrop extends LitElement {
+  static get styles() {
+    return css`
+      :host {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 1;
+        background-color: red;
+        opacity: 0.3;
+        display: none;
+      }
+
+      :host(.local-overlays__backdrop--visible) {
+        display: block;
+      }
+
+      :host(.local-overlays__backdrop--animation-in) {
+        animation: local-overlays-backdrop-fade-in 300ms;
+      }
+
+      :host(.local-overlays__backdrop--animation-out) {
+        animation: local-overlays-backdrop-fade-out 300ms;
+        opacity: 0;
+      }
+
+      @keyframes local-overlays-backdrop-fade-in {
+        from {
+          opacity: 0;
+        }
+      }
+
+      @keyframes local-overlays-backdrop-fade-out {
+        from {
+          opacity: 0.3;
+        }
+      }
+    `;
+  }
+}
+customElements.define('demo-overlay-backdrop', DemoOverlayBackdrop);

--- a/packages/overlays/docs/demo-overlay-system.js
+++ b/packages/overlays/docs/demo-overlay-system.js
@@ -40,7 +40,7 @@ class DemoOverlaySystem extends OverlayMixin(LitElement) {
   render() {
     return html`
       <slot name="invoker"></slot>
-      <slot name="_overlay-shadow-outlet"></slot>
+      <slot name="backdrop"></slot>
       <div id="overlay-content-node-wrapper">
         <slot name="content"></slot>
       </div>

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -183,9 +183,9 @@ export const OverlayMixinImplementation = superclass =>
 
     get _overlayContentNode() {
       if (!this._cachedOverlayContentNode) {
-        this._cachedOverlayContentNode = Array.from(this.children).find(
-          child => child.slot === 'content',
-        );
+        this._cachedOverlayContentNode =
+          Array.from(this.children).find(child => child.slot === 'content') ||
+          this.config.contentNode;
       }
       return this._cachedOverlayContentNode;
     }

--- a/packages/overlays/src/globalOverlaysStyle.js
+++ b/packages/overlays/src/globalOverlaysStyle.js
@@ -85,11 +85,11 @@ export const globalOverlaysStyle = css`
     display: block;
   }
 
-  .global-overlays .global-overlays__backdrop--fade-in {
+  .global-overlays .global-overlays__backdrop--animation-in {
     animation: global-overlays-backdrop-fade-in 300ms;
   }
 
-  .global-overlays .global-overlays__backdrop--fade-out {
+  .global-overlays .global-overlays__backdrop--animation-out {
     animation: global-overlays-backdrop-fade-out 300ms;
     opacity: 0;
   }


### PR DESCRIPTION
## What I did

1. Fix a bug where teardown did not properly teardown the right backdropNode for animation = true
2. Fix a bug where content node was not torn down properly when updateConfig is called every time we show (when for example the config is updated on before-show based on viewport)
3. Simplify the code for backdrop feature
4. Added demos for backdrop
5. Align API for backdrop (can pass `hasBackdrop: true` which spawns a default backdropNode, can pass `backdropNode` or declaratively `<div slot="backdrop"></div>` to pass your own, and can pass `hasBackdropAnimation: true` which turns on animation, assumes you have CSS animations applied to your backdropNode)
6. Small fix for overlayContentNode in OverlayMixin, to support imperatively passed contentNode

The two bugs were quite difficult to create an automated test for, visual regression would really help for these two 😅 
