### PR TITLE
fix(combobox): form-control class to correct node

### DIFF
--- a/.changeset/eleven-bears-repair.md
+++ b/.changeset/eleven-bears-repair.md
@@ -1,0 +1,5 @@
+---
+"@lion/combobox": patch
+---
+
+fix(combobox): form-control class to correct node

--- a/packages/combobox/src/LionCombobox.js
+++ b/packages/combobox/src/LionCombobox.js
@@ -69,6 +69,15 @@ export class LionCombobox extends OverlayMixin(LionListbox) {
   }
 
   /**
+   * @enhance FormControlMixin - add form-control to [slot=input] instead of _inputNode
+   */
+  _enhanceLightDomClasses() {
+    if (this.querySelector('[slot=input]')) {
+      this.querySelector('[slot=input]').classList.add('form-control');
+    }
+  }
+
+  /**
    * @enhance FormControlMixin - add slot[name=selection-display]
    */
   // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
## What I did

1. define enhancer for `formControlMixin` to add `form-control` class to slot element instead of child element of slot so as to style slot from component
