### PR TITLE
fix(localization): was not formatting minus values

### DIFF
--- a/.changeset/breezy-emus-rush.md
+++ b/.changeset/breezy-emus-rush.md
@@ -1,0 +1,5 @@
+---
+'@lion/localize': patch
+---
+
+Fix formatting negative values for Turkish locale.

--- a/packages/localize/src/number/forceTryCurrencyCode.js
+++ b/packages/localize/src/number/forceTryCurrencyCode.js
@@ -4,13 +4,17 @@
  * @param {import('../../types/LocalizeMixinTypes').FormatNumberOptions} [options]
  * @returns {FormatNumberPart[]}
  */
+
 export function forceTryCurrencyCode(formattedParts, { currency, currencyDisplay } = {}) {
   const result = formattedParts;
-  // Change the currency code from TRY to TL, for Turkey
   if (currency === 'TRY' && currencyDisplay === 'code') {
-    if (result[0].value === 'TRY') {
-      result[0].value = 'TL';
-    }
+    result.map(part => {
+      const newPart = part;
+      if (part.type === 'currency') {
+        newPart.value = 'TL';
+      }
+      return newPart;
+    });
   }
   return result;
 }

--- a/packages/localize/test/number/formatNumber.test.js
+++ b/packages/localize/test/number/formatNumber.test.js
@@ -329,6 +329,16 @@ describe('formatNumber', () => {
         expect(formatNumber(123456.789, currencySymbol('JPY'))).to.equal('¥123.457');
         expect(formatNumber(123456.789, currencySymbol('TRY'))).to.equal('₺123.456,79');
       });
+
+      it('forces turkish currency code ', () => {
+        localize.locale = 'tr-TR';
+        expect(
+          formatNumber(1234.56, { style: 'currency', currencyDisplay: 'code', currency: 'TRY' }),
+        ).to.equal('1.234,56 TL');
+        expect(
+          formatNumber(-1234.56, { style: 'currency', currencyDisplay: 'code', currency: 'TRY' }),
+        ).to.equal('−1.234,56 TL');
+      });
     });
   });
 });


### PR DESCRIPTION
The old code was taking only the index 0 of formatted parts. This cause a bug in minus amount values. This foreach function changes the specific 'currency' value.
