### PR TITLE
feat(listbox): add click on enter for options with href

### DIFF
--- a/.changeset/eight-lions-provide.md
+++ b/.changeset/eight-lions-provide.md
@@ -1,0 +1,5 @@
+---
+'@lion/listbox': minor
+---
+
+Add click on enter for options with href, to ensure that anchors are navigated towards, for example when applying LinkMixin to LionOption as part of a listbox.

--- a/packages/combobox/docs/LinkMixin.js
+++ b/packages/combobox/docs/LinkMixin.js
@@ -51,6 +51,9 @@ const LinkMixinImplementation = superclass =>
       if (changedProperties.has('target')) {
         this._nativeAnchor.target = this.target;
       }
+      if (changedProperties.has('rel')) {
+        this._nativeAnchor.rel = this.rel;
+      }
     }
 
     __navigate() {

--- a/packages/combobox/docs/Subclassers.md
+++ b/packages/combobox/docs/Subclassers.md
@@ -5,6 +5,7 @@ import { html } from 'lit-html';
 import './md-combobox/md-combobox.js';
 import './gh-combobox/gh-combobox.js';
 import './wa-combobox/wa-combobox.js';
+import './lm-option/lm-option.js';
 
 export default {
   title: 'Forms/Combobox/Extensions',
@@ -77,5 +78,47 @@ export const Whatsapp = () => html`
       .choiceValue=${'Bill Clinton'}
     ></wa-option>
   </wa-combobox>
+`;
+```
+
+```js preview-story
+export const LinkMixinBox = () => html`
+  <lion-combobox name="combo" label="Default">
+    <lm-option
+      href="https://www.google.com/search?query=apple"
+      target="_blank"
+      rel="noopener noreferrer"
+      .choiceValue=${'Apple'}
+      >Apple</lm-option
+    >
+    <lm-option
+      href="https://www.google.com/search?query=Artichoke"
+      target="_blank"
+      rel="noopener noreferrer"
+      .choiceValue=${'Artichoke'}
+      >Artichoke</lm-option
+    >
+    <lm-option
+      href="https://www.google.com/search?query=Asparagus"
+      target="_blank"
+      rel="noopener noreferrer"
+      .choiceValue=${'Asparagus'}
+      >Asparagus</lm-option
+    >
+    <lm-option
+      href="https://www.google.com/search?query=Banana"
+      target="_blank"
+      rel="noopener noreferrer"
+      .choiceValue=${'Banana'}
+      >Banana</lm-option
+    >
+    <lm-option
+      href="https://www.google.com/search?query=Beets"
+      target="_blank"
+      rel="noopener noreferrer"
+      .choiceValue=${'Beets'}
+      >Beets</lm-option
+    >
+  </lion-combobox>
 `;
 ```

--- a/packages/combobox/docs/lm-option/lm-option.js
+++ b/packages/combobox/docs/lm-option/lm-option.js
@@ -1,0 +1,6 @@
+import { LionOption } from '@lion/listbox';
+import { LinkMixin } from '../LinkMixin.js';
+
+export class LmOption extends LinkMixin(LionOption) {}
+
+customElements.define('lm-option', LmOption);

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -493,6 +493,11 @@ const ListboxMixinImplementation = superclass =>
           if (this.formElements[this.activeIndex].disabled) {
             return;
           }
+
+          if (this.formElements[this.activeIndex].href) {
+            this.formElements[this.activeIndex].click();
+          }
+
           this.setCheckedIndex(this.activeIndex);
           break;
         }

--- a/packages/listbox/test-suites/ListboxMixin.suite.js
+++ b/packages/listbox/test-suites/ListboxMixin.suite.js
@@ -1184,5 +1184,48 @@ export function runListboxMixinSuite(customConfig = {}) {
         expect(listbox.children[0].tagName).to.equal(cfg.optionTagString.toUpperCase());
       });
     });
+
+    describe('Href Options', () => {
+      it('allows anchors to be clicked when a [href] attribute is present', async () => {
+        const el = await fixture(html`
+          <${tag}>
+            <${optionTag}>Google</${optionTag}>
+            <${optionTag} .href=${'https://duckduckgo.com'}>DuckDuck Go</${optionTag}>
+          </${tag}>
+        `);
+
+        const { listbox } = getProtectedMembers(el);
+
+        el.activeIndex = 1;
+
+        // Allow options that behave like anchors (think of Google Search) to trigger the anchor behavior
+        const activeOption = el.formElements[1];
+        const clickSpy = sinon.spy(activeOption, 'click');
+
+        listbox.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+        expect(clickSpy).to.have.been.calledOnce;
+      });
+
+      it('does not allow anchors to be clicked when a [href] attribute is not present', async () => {
+        const el = await fixture(html`
+          <${tag}>
+            <${optionTag}>Google</${optionTag}>
+            <${optionTag} .href=${'https://duckduckgo.com'}>DuckDuck Go</${optionTag}>
+          </${tag}>
+        `);
+
+        const { listbox } = getProtectedMembers(el);
+
+        el.activeIndex = 0;
+
+        const activeOption = el.formElements[0];
+        const clickSpy = sinon.spy(activeOption, 'click');
+
+        listbox.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+
+        expect(clickSpy).to.not.have.been.called;
+      });
+    });
   });
 }


### PR DESCRIPTION
## What I did

1. Current implementation with LinkMixin allows to add links to the options of a combox, however link is only triggered on a 'click' and not on 'enter' as the listboxmixin blocks this. 
In order to get the same behaviour an extra check is implemented to click on 'enter' of an option with a 'href' attribute.
2. Added example doc.
3. added Rel option to LinkMixin in order to allow passing in 'noopener noreferrer' when required.

Test to follow (let me know if you have a suggestion on how to test this properly)
