### PR TITLE
feat(providence-analytics): add option skipCheckMatchCompatibility

### DIFF
--- a/.changeset/tasty-rabbits-fry.md
+++ b/.changeset/tasty-rabbits-fry.md
@@ -1,0 +1,5 @@
+---
+"providence-analytics": feat
+---
+
+add option skipCheckMatchCompatibility and enable for monorepos in extend-docs

--- a/packages/providence-analytics/src/program/analyzers/helpers/Analyzer.js
+++ b/packages/providence-analytics/src/program/analyzers/helpers/Analyzer.js
@@ -205,7 +205,7 @@ class Analyzer {
 
     // If we have a provided result cfg.referenceProjectResult, we assume the providing
     // party provides compatible results for now...
-    if (cfg.referenceProjectPath) {
+    if (cfg.referenceProjectPath && !cfg.skipCheckMatchCompatibility) {
       const { compatible, reason } = checkForMatchCompatibility(
         cfg.referenceProjectPath,
         cfg.targetProjectPath,

--- a/packages/providence-analytics/src/program/analyzers/match-imports.js
+++ b/packages/providence-analytics/src/program/analyzers/match-imports.js
@@ -249,6 +249,7 @@ class MatchImportsAnalyzer extends Analyzer {
       referenceProjectResult = await findExportsAnalyzer.execute({
         metaConfig: cfg.metaConfig,
         targetProjectPath: cfg.referenceProjectPath,
+        skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
       });
     }
 
@@ -258,6 +259,7 @@ class MatchImportsAnalyzer extends Analyzer {
       targetProjectResult = await findImportsAnalyzer.execute({
         metaConfig: cfg.metaConfig,
         targetProjectPath: cfg.targetProjectPath,
+        skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
       });
     }
 

--- a/packages/providence-analytics/src/program/analyzers/match-paths.js
+++ b/packages/providence-analytics/src/program/analyzers/match-paths.js
@@ -216,8 +216,7 @@ function getTagPaths(
   let targetResult;
   targetFindCustomelementsResult.queryOutput.some(({ file, result }) => {
     const targetPathMatch = result.find(entry => {
-      const sameRoot =
-        entry.rootFile.file === targetMatchedFile || entry.rootFile.file === '[current]';
+      const sameRoot = entry.rootFile.file === targetMatchedFile;
       const sameIdentifier = entry.rootFile.specifier === toClass;
       return sameRoot && sameIdentifier;
     });
@@ -429,6 +428,7 @@ class MatchPathsAnalyzer extends Analyzer {
       referenceProjectPath: cfg.referenceProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfig,
       gatherFilesConfigReference: cfg.gatherFilesConfigReference,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
 
     // [A2]
@@ -437,6 +437,7 @@ class MatchPathsAnalyzer extends Analyzer {
     const targetExportsResult = await targetFindExportsAnalyzer.execute({
       targetProjectPath: cfg.targetProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfig,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
 
     // [A3]
@@ -445,6 +446,7 @@ class MatchPathsAnalyzer extends Analyzer {
     const refFindExportsResult = await refFindExportsAnalyzer.execute({
       targetProjectPath: cfg.referenceProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfigReference,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
 
     /**
@@ -472,6 +474,7 @@ class MatchPathsAnalyzer extends Analyzer {
     const targetFindCustomelementsResult = await targetFindCustomelementsAnalyzer.execute({
       targetProjectPath: cfg.targetProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfig,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
 
     // [B2]
@@ -480,6 +483,7 @@ class MatchPathsAnalyzer extends Analyzer {
     const refFindCustomelementsResult = await refFindCustomelementsAnalyzer.execute({
       targetProjectPath: cfg.referenceProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfigReference,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
     // refFindExportsAnalyzer was already created in A3
 

--- a/packages/providence-analytics/src/program/analyzers/match-subclasses.js
+++ b/packages/providence-analytics/src/program/analyzers/match-subclasses.js
@@ -297,17 +297,20 @@ class MatchSubclassesAnalyzer extends Analyzer {
     const exportsAnalyzerResult = await findExportsAnalyzer.execute({
       targetProjectPath: cfg.referenceProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfigReference,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
     const findClassesAnalyzer = new FindClassesAnalyzer();
     /** @type {FindClassesAnalyzerResult} */
     const targetClassesAnalyzerResult = await findClassesAnalyzer.execute({
       targetProjectPath: cfg.targetProjectPath,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
     const findRefClassesAnalyzer = new FindClassesAnalyzer();
     /** @type {FindClassesAnalyzerResult} */
     const refClassesAnalyzerResult = await findRefClassesAnalyzer.execute({
       targetProjectPath: cfg.referenceProjectPath,
       gatherFilesConfig: cfg.gatherFilesConfigReference,
+      skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     });
 
     const queryOutput = matchSubclassesPostprocess(

--- a/packages/providence-analytics/src/program/providence.js
+++ b/packages/providence-analytics/src/program/providence.js
@@ -63,6 +63,7 @@ async function handleAnalyzerForProjectCombo(slicedQConfig, cfg) {
   const queryResult = await QueryService.astSearch(slicedQConfig, {
     gatherFilesConfig: cfg.gatherFilesConfig,
     gatherFilesConfigReference: cfg.gatherFilesConfigReference,
+    skipCheckMatchCompatibility: cfg.skipCheckMatchCompatibility,
     ...slicedQConfig.analyzerConfig,
   });
   if (queryResult) {
@@ -179,6 +180,7 @@ async function providenceMain(queryConfig, customConfig) {
       report: true,
       debugEnabled: false,
       writeLogFile: false,
+      skipCheckMatchCompatibility: false,
     },
     customConfig,
   );


### PR DESCRIPTION
## What I did

1. add `skipCheckMatchCompatibility` for mono repo support (which have their deps not in main package.json)

See: https://github.com/ing-bank/lion/issues/858

