### PR TITLE
fix(button): set width/height clickarea 100%

### DIFF
--- a/.changeset/curly-oranges-promise.md
+++ b/.changeset/curly-oranges-promise.md
@@ -1,0 +1,5 @@
+---
+'@lion/button': patch
+---
+
+On top of the 40x40px min height and width, set width/height to 100% so that the clickarea covers the entire width or height of the button.

--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -76,6 +76,8 @@ export class LionButton extends DisabledWithTabIndexMixin(SlotMixin(LitElement))
           /* src = https://www.smashingmagazine.com/2012/02/finger-friendly-design-ideal-mobile-touchscreen-target-sizes/ */
           min-height: 40px;
           min-width: 40px;
+          width: 100%;
+          height: 100%;
         }
 
         .button-content {


### PR DESCRIPTION
As it may be a bit unclear without a visual:

![Screenshot 2020-10-19 at 13 11 46](https://user-images.githubusercontent.com/36734656/96443304-b32e5e00-120c-11eb-9316-383508715ba7.png)

Red being the click-area and black being the button "real" visual area.