### PR TITLE
fix(icon): single pronounciation in JAWS/FF

### DIFF
--- a/.changeset/large-dodos-notice.md
+++ b/.changeset/large-dodos-notice.md
@@ -1,0 +1,5 @@
+---
+'@lion/icon': minor
+---
+
+fix(icon): single pronounciation in JAWS/FF

--- a/packages/icon/README.md
+++ b/packages/icon/README.md
@@ -73,8 +73,8 @@ export const iconSets = () => html`
           font-size: 10px;
         }
       </style>
-      <div class="demo-icon__container" title="lion:space:${name}">
-        <lion-icon icon-id="lion:space:${name}" aria-label="icon: ${name}"></lion-icon>
+      <div class="demo-icon__container">
+        <lion-icon icon-id="lion:space:${name}" aria-label="${name}"></lion-icon>
         <span class="demo-icon__name">${name}</span>
       </div>
     `,

--- a/packages/icon/src/LionIcon.js
+++ b/packages/icon/src/LionIcon.js
@@ -145,6 +145,9 @@ export class LionIcon extends LitElement {
   _renderSvg(svgObject) {
     validateSvg(svgObject);
     render(svgObject, this);
+    if (this.firstElementChild) {
+      this.firstElementChild.setAttribute('aria-hidden', 'true');
+    }
   }
 
   async _onIconIdChanged(prevIconId) {

--- a/packages/icon/test/lion-icon.test.js
+++ b/packages/icon/test/lion-icon.test.js
@@ -61,6 +61,11 @@ describe('lion-icon', () => {
     await expect(el).to.be.accessible();
   });
 
+  it('expect the svg icon to be aria-hidden', async () => {
+    const icon = await fixture(html`<lion-icon .svg=${heartSvg} aria-label="Love"></lion-icon>`);
+    expect(icon.children[0].getAttribute('aria-hidden')).to.equal('true');
+  });
+
   it('expects svg-icons to have the attribute `focusable="false"` so the icon doesn\'t appear in tab-order in IE/Edge', async () => {
     const icon = await fixture(html`<lion-icon .svg=${heartSvg} aria-label="Love"></lion-icon>`);
     expect(icon.children[0].getAttribute('focusable')).to.equal('false');


### PR DESCRIPTION
## What I did

1. Fixed some minor demo details
2. Added aria-hidden to the SVG in the icon to hide it for FireFox

Fixes https://github.com/ing-bank/lion/issues/172