### PR TITLE
fix(listbox): on fire model-value-changed when update from children

### DIFF
--- a/.changeset/silver-forks-learn.md
+++ b/.changeset/silver-forks-learn.md
@@ -1,0 +1,5 @@
+---
+'@lion/listbox': patch
+---
+
+Only send model-value-changed if the event is caused by one of its children

--- a/packages/form-integrations/test/model-value-consistency.test.js
+++ b/packages/form-integrations/test/model-value-consistency.test.js
@@ -20,9 +20,10 @@ import '@lion/radio-group/lion-radio.js';
 
 import '@lion/select/lion-select.js';
 
+import '@lion/combobox/lion-combobox.js';
+import '@lion/listbox/lion-listbox.js';
+import '@lion/listbox/lion-option.js';
 import '@lion/select-rich/lion-select-rich.js';
-import '@lion/select-rich/lion-options.js';
-import '@lion/select-rich/lion-option.js';
 
 import '@lion/fieldset/lion-fieldset.js';
 
@@ -206,45 +207,45 @@ describe('lion-select', () => {
   });
 });
 
-describe('lion-select-rich', () => {
-  describe(featureName, () => {
-    it(getFirstPaintTitle(firstStampCount), async () => {
-      const spy = sinon.spy();
-      await fixture(html`
-        <lion-select-rich @model-value-changed="${spy}">
-          <lion-options slot="input">
+['combobox', 'listbox', 'select-rich'].forEach(chunk => {
+  const tagname = `lion-${chunk}`;
+  const tag = unsafeStatic(tagname);
+  describe(`${tagname}`, () => {
+    describe(featureName, () => {
+      it(getFirstPaintTitle(firstStampCount), async () => {
+        const spy = sinon.spy();
+        await fixture(html`
+          <${tag} @model-value-changed="${spy}">
             <lion-option .choiceValue="${'option1'}"></lion-option>
             <lion-option .choiceValue="${'option2'}"></lion-option>
             <lion-option .choiceValue="${'option3'}"></lion-option>
-          </lion-options>
-        </lion-select-rich>
-      `);
+          </${tag}>
+        `);
 
-      expect(spy.callCount).to.equal(firstStampCount);
-    });
+        expect(spy.callCount).to.equal(firstStampCount);
+      });
 
-    it(getInteractionTitle(interactionCount), async () => {
-      const spy = sinon.spy();
-      const el = await fixture(html`
-        <lion-select-rich>
-          <lion-options slot="input">
-            <lion-option .choiceValue="${'option1'}"></lion-option>
-            <lion-option .choiceValue="${'option2'}"></lion-option>
-            <lion-option .choiceValue="${'option3'}"></lion-option>
-          </lion-options>
-        </lion-select-rich>
-      `);
+      it(getInteractionTitle(interactionCount), async () => {
+        const spy = sinon.spy();
+        const el = await fixture(html`
+          <${tag}>
+            <lion-option .choiceValue="${'option1'}">Option 1</lion-option>
+            <lion-option .choiceValue="${'option2'}">Option 2</lion-option>
+            <lion-option .choiceValue="${'option3'}">Option 3</lion-option>
+          </${tag}>
+        `);
 
-      el.addEventListener('model-value-changed', spy);
-      const option2 = el.querySelector('lion-option:nth-child(2)');
-      option2.checked = true;
-      expect(spy.callCount).to.equal(interactionCount);
+        el.addEventListener('model-value-changed', spy);
+        const option2 = el.querySelector('lion-option:nth-child(2)');
+        option2.checked = true;
+        expect(spy.callCount).to.equal(interactionCount);
 
-      spy.resetHistory();
+        spy.resetHistory();
 
-      const option3 = el.querySelector('lion-option:nth-child(3)');
-      option3.checked = true;
-      expect(spy.callCount).to.equal(interactionCount);
+        const option3 = el.querySelector('lion-option:nth-child(3)');
+        option3.checked = true;
+        expect(spy.callCount).to.equal(interactionCount);
+      });
     });
   });
 });

--- a/packages/listbox/test-suites/ListboxMixin.suite.js
+++ b/packages/listbox/test-suites/ListboxMixin.suite.js
@@ -1,11 +1,11 @@
+import '@lion/core/src/differentKeyEventNamesShimIE.js';
 import { Required } from '@lion/form-core';
-import sinon from 'sinon';
-import { expect, html, fixture as _fixture, unsafeStatic } from '@open-wc/testing';
 import { LionOptions } from '@lion/listbox';
 import '@lion/listbox/lion-option.js';
 import '@lion/listbox/lion-options.js';
+import { expect, fixture as _fixture, html, unsafeStatic } from '@open-wc/testing';
+import sinon from 'sinon';
 import '../lion-listbox.js';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
 
 /**
  * @typedef {import('../src/LionListbox').LionListbox} LionListbox
@@ -58,6 +58,56 @@ export function runListboxMixinSuite(customConfig = {}) {
       `);
 
         expect(el.modelValue).to.equal('10');
+      });
+
+      it('should dispatch model-value-changed 1 time on first paint', async () => {
+        const spy = sinon.spy();
+        await fixture(html`
+          <${tag} @model-value-changed="${spy}">
+            <${optionTag} .choiceValue="${'10'}">Item 1</${optionTag}>
+            <${optionTag} .choiceValue="${'20'}">Item 2</${optionTag}>
+            <${optionTag} .choiceValue="${'30'}">Item 3</${optionTag}>
+          </${tag}>
+        `);
+        expect(spy.callCount).to.equal(1);
+      });
+
+      it('should dispatch model-value-changed 1 time on interaction', async () => {
+        const spy = sinon.spy();
+        const el = await fixture(html`
+          <${tag}>
+            <${optionTag} .choiceValue="${'10'}">Item 1</${optionTag}>
+            <${optionTag} .choiceValue="${'20'}">Item 2</${optionTag}>
+            <${optionTag} .choiceValue="${'30'}">Item 3</${optionTag}>
+          </${tag}>
+        `);
+
+        el.addEventListener('model-value-changed', spy);
+        el.formElements[1].checked = true;
+        expect(spy.callCount).to.equal(1);
+
+        spy.resetHistory();
+
+        el.formElements[2].checked = true;
+        expect(spy.callCount).to.equal(1);
+      });
+
+      it('should not dispatch model-value-changed on reappend checked child', async () => {
+        const spy = sinon.spy();
+        const el = await fixture(html`
+          <${tag}>
+            <${optionTag} .choiceValue="${'10'}">Item 1</${optionTag}>
+            <${optionTag} .choiceValue="${'20'}">Item 2</${optionTag}>
+            <${optionTag} .choiceValue="${'30'}">Item 3</${optionTag}>
+          </${tag}>
+        `);
+
+        el.addEventListener('model-value-changed', spy);
+        el.formElements[1].checked = true;
+        expect(spy.callCount).to.equal(1);
+
+        el.appendChild(el.formElements[1]);
+        expect(spy.callCount).to.equal(1);
       });
 
       it('automatically sets the name attribute of child checkboxes to its own name', async () => {


### PR DESCRIPTION
## What I did

1. Does not dispatch model-value-changed on reappend checked child
2. Add combobox and listbox to the `model-value-change` integration test