### PR TITLE
fix(localize): do not parse non-existing dates

### DIFF
--- a/.changeset/swift-windows-train.md
+++ b/.changeset/swift-windows-train.md
@@ -1,0 +1,5 @@
+---
+'@lion/localize': patch
+---
+
+`parseDate('31.02.2020')` returned `'Mon Mar 02 2020 00:00:00 GMT+0100....'`. But not anymore, now it returns `undefined`.

--- a/packages/localize/src/date/parseDate.js
+++ b/packages/localize/src/date/parseDate.js
@@ -56,8 +56,17 @@ export function parseDate(dateString) {
   }
 
   const [year, month, day] = parsedString.split('/').map(Number);
-  if (year > 0 && month > 0 && day > 0) {
-    return new Date(Date.UTC(year, month - 1, day));
+  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+
+  // Check if parsedDate is not `Invalid Date` or that the date has changed (e.g. the not existing 31.02.2020)
+  if (
+    year > 0 &&
+    month > 0 &&
+    day > 0 &&
+    parsedDate.getDate() === day &&
+    parsedDate.getMonth() === month - 1
+  ) {
+    return parsedDate;
   }
   return undefined;
 }

--- a/packages/localize/test/date/parseDate.test.js
+++ b/packages/localize/test/date/parseDate.test.js
@@ -1,7 +1,7 @@
 import { expect } from '@open-wc/testing';
-import { localizeTearDown } from '../../test-helpers.js';
-
 import { parseDate } from '../../src/date/parseDate.js';
+import { localizeTearDown } from '../../test-helpers.js';
+import { localize } from '../../src/localize.js';
 
 /**
  *
@@ -27,13 +27,16 @@ describe('parseDate()', () => {
     expect(equalsDate(parseDate('1-1-1979'), new Date('1979/01/01'))).to.equal(true);
     expect(equalsDate(parseDate('1-11-1979'), new Date('1979/11/01'))).to.equal(true);
   });
+
   it('creates a date object', () => {
     expect(parseDate('10/10/2000') instanceof Date).to.equal(true);
   });
+
   it('returns a date object', () => {
     expect(equalsDate(parseDate('1-1-1979'), new Date('1979/01/01'))).to.equal(true);
     expect(equalsDate(parseDate('31.12.1970'), new Date('1970/12/31'))).to.equal(true);
   });
+
   it('handles all kind of delimiters', () => {
     expect(equalsDate(parseDate('12-12-1976'), new Date('1976/12/12'))).to.equal(true);
     expect(equalsDate(parseDate('13 12 1976'), new Date('1976/12/13'))).to.equal(true);
@@ -41,7 +44,24 @@ describe('parseDate()', () => {
     expect(equalsDate(parseDate('14. 12. 1976.'), new Date('1976/12/14'))).to.equal(true);
     expect(equalsDate(parseDate('14.12.1976 r.'), new Date('1976/12/14'))).to.equal(true);
   });
+
+  it('handles different locales', () => {
+    localize.locale = 'en-GB';
+    expect(equalsDate(parseDate('31-12-1976'), new Date('1976/12/31'))).to.equal(true);
+    localize.locale = 'en-US';
+    expect(equalsDate(parseDate('12-31-1976'), new Date('1976/12/31'))).to.equal(true);
+  });
+
   it('return undefined when no valid date provided', () => {
-    expect(parseDate('12.12.1976.,')).to.equal(undefined);
+    expect(parseDate('12.12.1976.,')).to.equal(undefined); // wrong delimiter
+    expect(parseDate('foo')).to.equal(undefined); // no date
+
+    localize.locale = 'en-GB';
+    expect(parseDate('31.02.2020')).to.equal(undefined); // non existing date
+    expect(parseDate('12.31.2020')).to.equal(undefined); // day & month switched places
+
+    localize.locale = 'en-US';
+    expect(parseDate('02.31.2020')).to.equal(undefined); // non existing date
+    expect(parseDate('31.12.2020')).to.equal(undefined); // day & month switched places
   });
 });


### PR DESCRIPTION
`parseDate('31.02.2020') returned 'Mon Mar 02 2020 00:00:00 GMT+0100....'`

But not anymore, now it returns `undefined`.