### PR TITLE
fix(input-stepper): make use of prefix and suffix slots

### DIFF
--- a/.changeset/silent-steaks-marry.md
+++ b/.changeset/silent-steaks-marry.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-stepper': patch
+---
+
+fix(input-stepper): make use of prefix and suffix slots

--- a/packages/input-stepper/src/LionInputStepper.js
+++ b/packages/input-stepper/src/LionInputStepper.js
@@ -251,15 +251,6 @@ export class LionInputStepper extends LionInput {
   }
 
   /**
-   * Override before template to none
-   * @override
-   */
-  // eslint-disable-next-line class-methods-use-this
-  _inputGroupBeforeTemplate() {
-    return html``;
-  }
-
-  /**
    * Get the decrementor button sign template
    * @returns {String|import('lit-element').TemplateResult}
    */

--- a/packages/input-stepper/src/LionInputStepper.js
+++ b/packages/input-stepper/src/LionInputStepper.js
@@ -103,8 +103,8 @@ export class LionInputStepper extends LionInput {
   get slots() {
     return {
       ...super.slots,
-      prefix: () => this.__getButtonNode(),
-      suffix: () => this.__getButtonNode(true),
+      prefix: () => this.__getDecrementButtonNode(),
+      suffix: () => this.__getIncrementButtonNode(),
     };
   }
 
@@ -208,14 +208,30 @@ export class LionInputStepper extends LionInput {
   }
 
   /**
-   * Get the button node
-   * @param {Boolean} isIncrement flag to differentiate the template
+   * Get the increment button node
    * @returns {Element|null}
    */
-  __getButtonNode(isIncrement = false) {
+  __getIncrementButtonNode() {
     const renderParent = document.createElement('div');
     /** @type {typeof LionInputStepper} */ (this.constructor).render(
-      isIncrement ? this._incrementorTemplate() : this._decrementorTemplate(),
+      this._incrementorTemplate(),
+      renderParent,
+      {
+        scopeName: this.localName,
+        eventContext: this,
+      },
+    );
+    return renderParent.firstElementChild;
+  }
+
+  /**
+   * Get the decrement button node
+   * @returns {Element|null}
+   */
+  __getDecrementButtonNode() {
+    const renderParent = document.createElement('div');
+    /** @type {typeof LionInputStepper} */ (this.constructor).render(
+      this._decrementorTemplate(),
       renderParent,
       {
         scopeName: this.localName,
@@ -271,7 +287,6 @@ export class LionInputStepper extends LionInput {
         ?disabled=${this.disabled || this.readOnly}
         @click=${this.__decrement}
         tabindex="-1"
-        name="decrement"
         type="button"
         aria-label="decrement"
       >
@@ -290,7 +305,6 @@ export class LionInputStepper extends LionInput {
         ?disabled=${this.disabled || this.readOnly}
         @click=${this.__increment}
         tabindex="-1"
-        name="increment"
         type="button"
         aria-label="increment"
       >

--- a/packages/input-stepper/test/lion-input-stepper.test.js
+++ b/packages/input-stepper/test/lion-input-stepper.test.js
@@ -24,7 +24,7 @@ describe('<lion-input-stepper>', () => {
     it('should increment the value to 1 on + button click', async () => {
       const el = await fixture(defaultInputStepper);
       expect(el.value).to.equal('');
-      const incrementButton = el.shadowRoot?.querySelector('[name=increment]');
+      const incrementButton = el.querySelector('[slot=suffix]');
       incrementButton?.dispatchEvent(new Event('click'));
       expect(el.value).to.equal('1');
     });
@@ -32,8 +32,8 @@ describe('<lion-input-stepper>', () => {
     it('should decrement the value to -1 on - button click', async () => {
       const el = await fixture(defaultInputStepper);
       expect(el.value).to.equal('');
-      const incrementButton = el.shadowRoot?.querySelector('[name=decrement]');
-      incrementButton?.dispatchEvent(new Event('click'));
+      const decrementButton = el.querySelector('[slot=prefix]');
+      decrementButton?.dispatchEvent(new Event('click'));
       expect(el.value).to.equal('-1');
     });
 
@@ -66,7 +66,7 @@ describe('<lion-input-stepper>', () => {
 
     it('updates aria-valuenow when stepper is changed', async () => {
       const el = await fixture(inputStepperWithAttrs);
-      const incrementButton = el.shadowRoot?.querySelector('[name=increment]');
+      const incrementButton = el.querySelector('[slot=suffix]');
       incrementButton?.dispatchEvent(new Event('click'));
       expect(el).to.have.attribute('aria-valuenow', '1');
     });


### PR DESCRIPTION
## What I did

1. Use prefix and suffix existing slots for the increment and decrement buttons
2. Add methods that can be overridden for increment and decrement icons
