### PR TITLE
chore: explicitly put super.properties in properties() of child class

### DIFF
--- a/packages/accordion/src/LionAccordion.js
+++ b/packages/accordion/src/LionAccordion.js
@@ -126,10 +126,10 @@ const collapseContent = element => {
 export class LionAccordion extends LitElement {
   static get properties() {
     return {
+      ...super.properties,
       /**
        * index number of the focused accordion
-       */
-      focusedIndex: {
+       */ focusedIndex: {
         type: Number,
       },
       /**

--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -14,6 +14,7 @@ const isSpaceKeyboardClickEvent = (/** @type {KeyboardEvent} */ e) => e.key === 
 export class LionButton extends DisabledWithTabIndexMixin(SlotMixin(LitElement)) {
   static get properties() {
     return {
+      ...super.properties,
       role: {
         type: String,
         reflect: true,

--- a/packages/calendar/src/LionCalendar.js
+++ b/packages/calendar/src/LionCalendar.js
@@ -79,10 +79,10 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
 
   static get properties() {
     return {
+      ...super.properties,
       /**
        * Minimum date. All dates before will be disabled
-       */
-      minDate: { attribute: false },
+       */ minDate: { attribute: false },
 
       /**
        * Maximum date. All dates after will be disabled

--- a/packages/collapsible/src/LionCollapsible.js
+++ b/packages/collapsible/src/LionCollapsible.js
@@ -24,6 +24,7 @@ export class LionCollapsible extends LitElement {
 
   static get properties() {
     return {
+      ...super.properties,
       opened: {
         type: Boolean,
         reflect: true,

--- a/packages/combobox/src/LionCombobox.js
+++ b/packages/combobox/src/LionCombobox.js
@@ -23,6 +23,7 @@ import { LionListbox } from '@lion/listbox';
 export class LionCombobox extends OverlayMixin(LionListbox) {
   static get properties() {
     return {
+      ...super.properties,
       autocomplete: { type: String, reflect: true },
       matchMode: {
         type: String,

--- a/packages/form-core/src/LionField.js
+++ b/packages/form-core/src/LionField.js
@@ -28,6 +28,7 @@ export class LionField extends FormControlMixin(
 ) {
   static get properties() {
     return {
+      ...super.properties,
       autocomplete: {
         type: String,
         reflect: true,

--- a/packages/form-core/src/validate/LionValidationFeedback.js
+++ b/packages/form-core/src/validate/LionValidationFeedback.js
@@ -15,9 +15,7 @@ import { html, LitElement } from '@lion/core';
  */
 export class LionValidationFeedback extends LitElement {
   static get properties() {
-    return {
-      feedbackData: { attribute: false },
-    };
+    return { ...super.properties, feedbackData: { attribute: false } };
   }
 
   /**

--- a/packages/helpers/sb-action-logger/src/SbActionLogger.js
+++ b/packages/helpers/sb-action-logger/src/SbActionLogger.js
@@ -5,6 +5,7 @@ import { css, html, LitElement, render } from '@lion/core';
 export class SbActionLogger extends LitElement {
   static get properties() {
     return {
+      ...super.properties,
       title: { type: String, reflect: true },
       simple: { type: Boolean, reflect: true },
       __logCounter: { type: Number },

--- a/packages/helpers/sb-locale-switcher/src/SbLocaleSwitcher.js
+++ b/packages/helpers/sb-locale-switcher/src/SbLocaleSwitcher.js
@@ -2,9 +2,7 @@ import { LitElement, html } from '@lion/core';
 
 export class SbLocaleSwitcher extends LitElement {
   static get properties() {
-    return {
-      showLocales: { type: Array, attribute: 'show-locales' },
-    };
+    return { ...super.properties, showLocales: { type: Array, attribute: 'show-locales' } };
   }
 
   constructor() {

--- a/packages/icon/src/LionIcon.js
+++ b/packages/icon/src/LionIcon.js
@@ -21,6 +21,7 @@ function validateSvg(svg) {
 export class LionIcon extends LitElement {
   static get properties() {
     return {
+      ...super.properties,
       /**
        * @desc When icons are not loaded as part of an iconset defined on iconManager,
        * it's possible to directly load an svg.

--- a/packages/input-amount/src/LionInputAmount.js
+++ b/packages/input-amount/src/LionInputAmount.js
@@ -15,12 +15,12 @@ import { parseAmount } from './parsers.js';
 export class LionInputAmount extends LocalizeMixin(LionInput) {
   static get properties() {
     return {
+      ...super.properties,
       /**
        * @desc an iso code like 'EUR' or 'USD' that will be displayed next to the input
        * and from which an accessible label (like 'euros') is computed for screen
        * reader users
-       */
-      currency: String,
+       */ currency: String,
       /**
        * @desc the modelValue of the input-amount has the 'Number' type. This allows
        * Application Developers to easily read from and write to this input or write custom

--- a/packages/input-date/src/LionInputDate.js
+++ b/packages/input-date/src/LionInputDate.js
@@ -21,9 +21,7 @@ function isValidDate(date) {
 // @ts-expect-error https://github.com/microsoft/TypeScript/issues/40110
 export class LionInputDate extends LocalizeMixin(LionInput) {
   static get properties() {
-    return {
-      modelValue: Date,
-    };
+    return { ...super.properties, modelValue: Date };
   }
 
   constructor() {

--- a/packages/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/input-datepicker/src/LionInputDatepicker.js
@@ -19,12 +19,12 @@ export class LionInputDatepicker extends ScopedElementsMixin(OverlayMixin(LionIn
 
   static get properties() {
     return {
+      ...super.properties,
       /**
        * The heading to be added on top of the calendar overlay.
        * Naming chosen from an Application Developer perspective.
        * For a Subclasser 'calendarOverlayHeading' would be more appropriate.
-       */
-      calendarHeading: {
+       */ calendarHeading: {
         type: String,
         attribute: 'calendar-heading',
       },

--- a/packages/input-range/src/LionInputRange.js
+++ b/packages/input-range/src/LionInputRange.js
@@ -16,6 +16,7 @@ import { formatNumber, LocalizeMixin } from '@lion/localize';
 export class LionInputRange extends LocalizeMixin(LionInput) {
   static get properties() {
     return {
+      ...super.properties,
       min: {
         type: Number,
         reflect: true,

--- a/packages/input-stepper/src/LionInputStepper.js
+++ b/packages/input-stepper/src/LionInputStepper.js
@@ -22,6 +22,7 @@ export class LionInputStepper extends LionInput {
 
   static get properties() {
     return {
+      ...super.properties,
       min: {
         type: Number,
         reflect: true,

--- a/packages/input/src/LionInput.js
+++ b/packages/input/src/LionInput.js
@@ -10,6 +10,7 @@ import { NativeTextFieldMixin } from '@lion/form-core/src/NativeTextFieldMixin';
 export class LionInput extends NativeTextFieldMixin(LionField) {
   static get properties() {
     return {
+      ...super.properties,
       /**
        * A Boolean attribute which, if present, indicates that the user should not be able to edit
        * the value of the input. The difference between disabled and readonly is that read-only
@@ -17,8 +18,7 @@ export class LionInput extends NativeTextFieldMixin(LionField) {
        * controls until they are enabled.
        *
        * (From: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-readonly)
-       */
-      readOnly: {
+       */ readOnly: {
         type: Boolean,
         attribute: 'readonly',
         reflect: true,

--- a/packages/listbox/src/LionOption.js
+++ b/packages/listbox/src/LionOption.js
@@ -17,6 +17,7 @@ import { css, DisabledMixin, html, LitElement } from '@lion/core';
 export class LionOption extends DisabledMixin(ChoiceInputMixin(FormRegisteringMixin(LitElement))) {
   static get properties() {
     return {
+      ...super.properties,
       active: {
         type: Boolean,
         reflect: true,

--- a/packages/listbox/src/LionOptions.js
+++ b/packages/listbox/src/LionOptions.js
@@ -7,6 +7,7 @@ import { FormRegistrarPortalMixin } from '@lion/form-core';
 export class LionOptions extends FormRegistrarPortalMixin(LitElement) {
   static get properties() {
     return {
+      ...super.properties,
       role: {
         type: String,
         reflect: true,

--- a/packages/pagination/src/LionPagination.js
+++ b/packages/pagination/src/LionPagination.js
@@ -86,6 +86,7 @@ export class LionPagination extends LocalizeMixin(LitElement) {
 
   static get properties() {
     return {
+      ...super.properties,
       current: {
         type: Number,
         reflect: true,

--- a/packages/providence-analytics/dashboard/src/app/components/p-table/PTable.js
+++ b/packages/providence-analytics/dashboard/src/app/components/p-table/PTable.js
@@ -5,6 +5,7 @@ import { DecorateMixin } from '../../utils/DecorateMixin.js';
 export class PTable extends DecorateMixin(LitElement) {
   static get properties() {
     return {
+      ...super.properties,
       mobile: {
         reflect: true,
         type: Boolean,

--- a/packages/providence-analytics/dashboard/src/app/p-board.js
+++ b/packages/providence-analytics/dashboard/src/app/p-board.js
@@ -26,7 +26,7 @@ function checkedValues(checkboxOrNodeList) {
 class PBoard extends DecorateMixin(LitElement) {
   static get properties() {
     return {
-      // Transformed data from fetch
+      ...super.properties, // Transformed data from fetch
       tableData: Object,
       __resultFiles: Array,
       __menuData: Object,

--- a/packages/select-rich/src/LionSelectInvoker.js
+++ b/packages/select-rich/src/LionSelectInvoker.js
@@ -25,6 +25,7 @@ export class LionSelectInvoker extends LionButton {
   static get properties() {
     return {
       ...super.properties,
+      ...super.properties,
       selectedElement: {
         type: Object,
       },

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -34,6 +34,7 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
 
   static get properties() {
     return {
+      ...super.properties,
       navigateWithinInvoker: {
         type: Boolean,
         attribute: 'navigate-within-invoker',

--- a/packages/steps/src/LionStep.js
+++ b/packages/steps/src/LionStep.js
@@ -13,10 +13,10 @@ import { css, html, LitElement } from '@lion/core';
 export class LionStep extends LitElement {
   static get properties() {
     return {
+      ...super.properties,
       /**
        * Step status, one of: "untouched", "entered", "left", "skipped".
-       */
-      status: {
+       */ status: {
         type: String,
         reflect: true,
       },

--- a/packages/switch/src/LionSwitchButton.js
+++ b/packages/switch/src/LionSwitchButton.js
@@ -3,6 +3,7 @@ import { html, css, LitElement, DisabledWithTabIndexMixin } from '@lion/core';
 export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
   static get properties() {
     return {
+      ...super.properties,
       role: {
         type: String,
         reflect: true,

--- a/packages/tabs/src/LionTabs.js
+++ b/packages/tabs/src/LionTabs.js
@@ -105,6 +105,7 @@ function handleButtonKeydown(ev) {
 export class LionTabs extends LitElement {
   static get properties() {
     return {
+      ...super.properties,
       selectedIndex: {
         type: Number,
         attribute: 'selected-index',

--- a/packages/textarea/src/LionTextarea.js
+++ b/packages/textarea/src/LionTextarea.js
@@ -25,6 +25,7 @@ class LionFieldWithTextArea extends LionField {
 export class LionTextarea extends NativeTextFieldMixin(LionFieldWithTextArea) {
   static get properties() {
     return {
+      ...super.properties,
       maxRows: {
         type: Number,
         attribute: 'max-rows',

--- a/packages/tooltip/src/LionTooltip.js
+++ b/packages/tooltip/src/LionTooltip.js
@@ -13,6 +13,7 @@ import { ArrowMixin, OverlayMixin } from '@lion/overlays';
 export class LionTooltip extends ArrowMixin(OverlayMixin(LitElement)) {
   static get properties() {
     return {
+      ...super.properties,
       invokerRelation: {
         type: String,
         attribute: 'invoker-relation',


### PR DESCRIPTION
## What I did

1. Explicitly put super.properties in properties() of child classes

> And when we run yarn test, 95 of the browser tests fail as listed below.

packages/combobox/test/lion-combobox-integrations.test.js:

 ❌ ListboxMixin > FormControl (Field / ChoiceGroup) functionality > requests update for modelValue when checkedIndex changes for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  2
      +]

      expected [] to deeply equal [ 2 ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:209:36


 ❌ ListboxMixin > FormControl (Field / ChoiceGroup) functionality > requests update for modelValue after click for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  2
      +]

      expected [] to deeply equal [ 2 ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:231:36


 ❌ ListboxMixin > Selection > supports changing the selection through serializedValue setter
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      --1
      +1

      expected -1 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:323:36


 ❌ ListboxMixin > Values > should reset selected value to initial values when multiple-choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  "20"
      +  "30"
      +]

      expected [] to deeply equal [ '20', '30' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:495:39


 ❌ ListboxMixin > Complex Data > works for complex array data
      at: node_modules/chai/chai.js:9449:13
      expected undefined to deeply equal { Object (type, label, ...) }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:1183:39


packages/combobox/test/lion-combobox.test.js:

 ❌ lion-combobox > Values > sets modelValue to empty array if no option is selected for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  "Artichoke"
      +]

      expected [] to deeply equal [ 'Artichoke' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:240:32


 ❌ lion-combobox > Autocompletion > filters options when autocomplete is "both"
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       [
      -  ""
      +  "Artichoke"
         "Chard"
      -  ""
      +  "Chicory"
       ]

      expected [ '', 'Chard', '' ] to deeply equal [ 'Artichoke', 'Chard', 'Chicory' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:641:46


 ❌ lion-combobox > Autocompletion > filters options when autocomplete is "list"
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       [
      -  ""
      -  ""
      -  ""
      +  "Artichoke"
      +  "Chard"
      +  "Chicory"
       ]

      expected [ '', '', '' ] to deeply equal [ 'Artichoke', 'Chard', 'Chicory' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:676:46


 ❌ lion-combobox > Autocompletion > does not filter options when autocomplete is "none"
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       [
      -  ""
      -  ""
      -  ""
      -  ""
      +  "Artichoke"
      +  "Chard"
      +  "Chicory"
      +  "Victoria Plum"
       ]

      expected [ '', '', '', '' ] to deeply equal [ Array(4) ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:691:46


 ❌ lion-combobox > Autocompletion > does not filter options when autocomplete is "inline"
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       [
      -  ""
      +  "Artichoke"
         "Chard"
      -  ""
      -  ""
      +  "Chicory"
      +  "Victoria Plum"
       ]

      expected [ '', 'Chard', '', '' ] to deeply equal [ Array(4) ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:710:46


 ❌ lion-combobox > Match Mode > will suggest partial matches (in the middle of the word) when set to "all"
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       [
      -  ""
      +  "Artichoke"
         "Chard"
      -  ""
      -  ""
      +  "Chicory"
      +  "Victoria Plum"
       ]

      expected [ '', 'Chard', '', '' ] to deeply equal [ Array(4) ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:1188:76


 ❌ lion-combobox > Match Mode > will only suggest beginning matches when set to "begin"
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       [
         "Chard"
      -  ""
      +  "Chicory"
       ]

      expected [ 'Chard', '' ] to deeply equal [ 'Chard', 'Chicory' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:1200:76


 ❌ lion-combobox > Match Mode > Subclassers > allows for custom matching functions
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  "Chicory"
      +]

      expected [] to deeply equal [ 'Chicory' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/combobox/test/lion-combobox.test.js:1219:78


packages/fieldset/test/lion-fieldset.test.js:

 ❌ FormGroupMixin with LionInput > serializes undefined values as "" (nb radios/checkboxes are always serialized)
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       {
         "custom[]": [
           "custom 1"
      -    [undefined]
      +    ""
         ]
       }

      expected { Object (custom[]) } to deeply equal { 'custom[]': [ 'custom 1', '' ] }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormGroupMixinInputSuite/</< @ packages/form-core/test-suites/form-group/FormGroupMixin-input.suite.js:52:48


packages/form-integrations/test/form-integrations.test.js:

 ❌ Form Integrations > ".serializedValue" returns all non disabled fields based on form structure
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       {
      -  "bio": [undefined]
      +  "bio": ""
         "checkers": [
           "foo"
           "bar"
         ]
      -  "comments": [undefined]
      +  "comments": ""
         "date": "2000-12-12"
         "datepicker": "2020-12-12"
         "dinosaurs": "brontosaurus"
      -  "email": [undefined]
      +  "email": ""
         "favoriteColor": "hotpink"
         "full_name": {
      -    "first_name": [undefined]
      -    "last_name": [undefined]
      +    "first_name": ""
      +    "last_name": ""
         }
      -  "iban": [undefined]
      +  "iban": ""
         "lyrics": "1"
      -  "money": [undefined]
      +  "money": ""
         "range": 2.3
         "terms": []
       }

      expected { Object (full_name, date, ...) } to deeply equal { Object (bio, checkers, ...) }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/form-integrations/test/form-integrations.test.js:10:39


 ❌ Form Integrations > ".formattedValue" returns all non disabled fields based on form structure
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       {
      -  "bio": [undefined]
      +  "bio": ""
         "checkers": [
           "foo"
           "bar"
         ]
      -  "comments": [undefined]
      +  "comments": ""
         "date": "12/12/2000"
         "datepicker": "12/12/2020"
         "dinosaurs": "brontosaurus"
      -  "email": [undefined]
      -  "favoriteColor": {
      -    "checked": true
      -    "value": [undefined]
      -  }
      +  "email": ""
      +  "favoriteColor": "hotpink"
         "full_name": {
      -    "first_name": [undefined]
      -    "last_name": [undefined]
      +    "first_name": ""
      +    "last_name": ""
         }
      -  "iban": [undefined]
      +  "iban": ""
         "lyrics": "1"
      -  "money": [undefined]
      +  "money": ""
         "range": 2.3
         "terms": []
       }

      expected { Object (full_name, date, ...) } to deeply equal { Object (bio, checkers, ...) }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        @http:/localhost:9628/packages/form-integrations/test/form-integrations.test.js:35:38


packages/form-integrations/test/form-reset.test.js:

 🚧 Browser logs on Webkit:
      [OverlayController] Could not find a render target, since the provided contentNode is not connected to the DOM. Make sure that it is connected, e.g. by doing "document.body.appendChild(contentNode)", before passing it on.
        OverlayController@http:/localhost:9628/packages/overlays/src/OverlayController.js:154:24
        _defineOverlay@http:/localhost:9628/packages/overlays/src/OverlayMixin.js:66:35
        _setupOverlayCtrl@http:/localhost:9628/packages/overlays/src/OverlayMixin.js:199:46
        packages/overlays/src/OverlayMixin.js:153:33
        promiseReactionJob@[native code]
      [OverlayController] Could not find a render target, since the provided contentNode is not connected to the DOM. Make sure that it is connected, e.g. by doing "document.body.appendChild(contentNode)", before passing it on.
        OverlayController@http:/localhost:9628/packages/overlays/src/OverlayController.js:154:24
        _defineOverlay@http:/localhost:9628/packages/overlays/src/OverlayMixin.js:66:35
        _setupOverlayCtrl@http:/localhost:9628/packages/overlays/src/OverlayMixin.js:199:46
        packages/overlays/src/OverlayMixin.js:153:33
        promiseReactionJob@[native code]

packages/form-integrations/test/model-value-consistency.test.js:

 ❌ lion-input > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-input-amount > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-input-date > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-input-datepicker > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-input-email > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-input-iban > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-input-range > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


 ❌ lion-textarea > model value > should dispatch 1 time(s) on first paint
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        fieldDispatchesCountOnFirstPaint/< @ packages/form-integrations/test/model-value-consistency.test.js:43:30


packages/input/test/input-integrations.test.js:

 ❌ <lion-input> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: foo

      expected '' to equal 'foo: foo'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input/test/lion-input-integrations.test.js:

 ❌ <lion-input> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: foo

      expected '' to equal 'foo: foo'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input/test/lion-input.test.js:

 ❌ <lion-input> > delegates value property
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +one

      expected '' to equal 'one'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/input/test/lion-input.test.js:77:10


 ❌ <lion-input> > Delegation > delegates property value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +one

      expected '' to equal 'one'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/input/test/lion-input.test.js:168:38


 ❌ <lion-input> > Delegation > delegates property selectionStart and selectionEnd
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +5

      expected 0 to equal 5
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/input/test/lion-input.test.js:180:47


packages/input-amount/test/lion-input-amount-integrations.test.js:

 ❌ <lion-input-amount> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input-amount> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input-amount> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input-amount> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: 123

      expected '' to equal 'foo: 123'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input-amount> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input-amount> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input-date/test/lion-input-date-integrations.test.js:

 ❌ <lion-input-date> integrations > FormatMixin > fires `model-value-changed` for every change on the input
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:137:26


 ❌ <lion-input-date> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input-date> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input-date> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input-date> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: Thu May 05 2005 02:00:00 GMT+0200 (Central European Summer Time)

      expected '' to equal 'foo: Thu May 05 2005 02:00:00 GMT+0200 (Central European Summer Time)'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input-date> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input-date> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input-datepicker/test/lion-input-datepicker-integrations.test.js:

 ❌ <lion-input-datepicker> integrations > FormatMixin > fires `model-value-changed` for every change on the input
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:137:26


 ❌ <lion-input-datepicker> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input-datepicker> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input-datepicker> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input-datepicker> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: Thu May 05 2005 02:00:00 GMT+0200 (Central European Summer Time)

      expected '' to equal 'foo: Thu May 05 2005 02:00:00 GMT+0200 (Central European Summer Time)'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input-datepicker> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input-datepicker> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input-email/test/lion-input-email-integrations.test.js:

 ❌ <lion-input-email> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input-email> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input-email> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input-email> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: some-user@ing.com

      expected '' to equal 'foo: some-user@ing.com'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input-email> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input-email> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input-iban/test/lion-input-iban-integrations.test.js:

 ❌ <lion-input-iban> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-input-iban> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-input-iban> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-input-iban> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: SE3550000000054910000003

      expected '' to equal 'foo: SE3550000000054910000003'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-input-iban> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-input-iban> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/input-range/test/lion-input-range.test.js:

 ❌ <lion-input-range> > parser method should return a value parsed into a number format
      at: node_modules/chai/chai.js:9449:13
      expected undefined to equal 130
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/input-range/test/lion-input-range.test.js:98:30


packages/listbox/test/lion-listbox.test.js:

 ❌ ListboxMixin > FormControl (Field / ChoiceGroup) functionality > requests update for modelValue when checkedIndex changes for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  2
      +]

      expected [] to deeply equal [ 2 ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:209:36


 ❌ ListboxMixin > FormControl (Field / ChoiceGroup) functionality > requests update for modelValue after click for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  2
      +]

      expected [] to deeply equal [ 2 ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:231:36


 ❌ ListboxMixin > Selection > supports changing the selection through serializedValue setter
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      --1
      +1

      expected -1 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:323:36


 ❌ ListboxMixin > Values > should reset selected value to initial values when multiple-choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  "20"
      +  "30"
      +]

      expected [] to deeply equal [ '20', '30' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:495:39


 ❌ ListboxMixin > Complex Data > works for complex array data
      at: node_modules/chai/chai.js:9449:13
      expected undefined to deeply equal { Object (type, label, ...) }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:1183:39


packages/listbox/test/lion-option.test.js:

 ❌ lion-option > Values > has a modelValue
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       {
         "checked": false
      -  "value": ""
      +  "value": 10
       }

      expected { value: '', checked: false } to deeply equal { value: 10, checked: false }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/listbox/test/lion-option.test.js:13:37


 ❌ lion-option > Values > can be checked
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

       {
         "checked": true
      -  "value": [undefined]
      +  "value": 10
       }

      expected { value: undefined, checked: true } to deeply equal { value: 10, checked: true }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/listbox/test/lion-option.test.js:20:37


packages/select-rich/test/lion-select-listbox-suite-integration.test.js:

 ❌ <lion-select-rich> integration with ListboxMixin > ListboxMixin > FormControl (Field / ChoiceGroup) functionality > requests update for modelValue when checkedIndex changes for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  2
      +]

      expected [] to deeply equal [ 2 ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:209:36


 ❌ <lion-select-rich> integration with ListboxMixin > ListboxMixin > FormControl (Field / ChoiceGroup) functionality > requests update for modelValue after click for multiple choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  2
      +]

      expected [] to deeply equal [ 2 ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:231:36


 ❌ <lion-select-rich> integration with ListboxMixin > ListboxMixin > Selection > supports changing the selection through serializedValue setter
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      --1
      +1

      expected -1 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:323:36


 ❌ <lion-select-rich> integration with ListboxMixin > ListboxMixin > Values > should reset selected value to initial values when multiple-choice
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -[]
      +[
      +  "20"
      +  "30"
      +]

      expected [] to deeply equal [ '20', '30' ]
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:495:39


 ❌ <lion-select-rich> integration with ListboxMixin > ListboxMixin > Complex Data > works for complex array data
      at: node_modules/chai/chai.js:9449:13
      expected undefined to deeply equal { Object (type, label, ...) }
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEql@http:/localhost:9628/node_modules/chai/chai.js:1445:10
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1384:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runListboxMixinSuite/</</< @ packages/listbox/test-suites/ListboxMixin.suite.js:1183:39


packages/select-rich/test/lion-select-rich-interaction.test.js:

 ❌ lion-select-rich interactions > Accessibility > sets [aria-invalid="true"] to "._invokerNode" when there is an error
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -false
      +true

      expected 'false' to equal 'true'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/select-rich/test/lion-select-rich-interaction.test.js:202:55


packages/select-rich/test/lion-select-rich.test.js:

 ❌ lion-select-rich > Invoker > updates the invoker when the selected element is the same but the modelValue was updated asynchronously
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +10

      expected '' to equal '10'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/select-rich/test/lion-select-rich.test.js:184:75


 ❌ lion-select-rich > Use cases > keeps showing the selected item after a new item has been added in the selectedIndex position
      at: node_modules/chai/chai.js:9449:13
      expected undefined to equal 'hotpink'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/select-rich/test/lion-select-rich.test.js:607:40


packages/textarea/test/lion-textarea-integrations.test.js:

 ❌ <lion-textarea> integrations > FormatMixin > has modelValue, formattedValue and serializedValue which are computed synchronously
      at: node_modules/chai/chai.js:9449:13
      modelValue initially: expected undefined to equal ''
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:174:39


 ❌ <lion-textarea> integrations > FormatMixin > has an input node (like <input>/<textarea>) which holds the formatted (view) value
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: string

      expected '' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:188:45


 ❌ <lion-textarea> integrations > FormatMixin > synchronizes _inputNode.value as a fallback mechanism
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -string
      +foo: string

      expected 'string' to equal 'foo: string'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:229:46


 ❌ <lion-textarea> integrations > FormatMixin > reflects back formatted value to user on leave
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: foo

      expected '' to equal 'foo: foo'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:250:44


 ❌ <lion-textarea> integrations > FormatMixin > reflects back .formattedValue immediately when .modelValue changed imperatively
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +foo: test2

      expected '' to equal 'foo: test2'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</< @ packages/form-core/test-suites/FormatMixin.suite.js:269:38


 ❌ <lion-textarea> integrations > FormatMixin > parsers/formatters/serializers > will only call the parser for defined values
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -0
      +1

      expected 0 to equal 1
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        runFormatMixinSuite/</</< @ packages/form-core/test-suites/FormatMixin.suite.js:327:40


packages/textarea/test/lion-textarea.test.js:

 ❌ <lion-textarea> > supports initial modelValue
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      +From value attribute

      expected '' to equal 'From value attribute'
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/textarea/test/lion-textarea.test.js:70:52


 ❌ <lion-textarea> > adjusts height based on content
      at: node_modules/chai/chai.js:9449:13
      + expected - actual

      -false
      +true

      expected false to equal true
        AssertionError@http:/localhost:9628/node_modules/chai/chai.js:9449:13
        [3]</module.exports/Assertion.prototype.assert @ node_modules/chai/chai.js:239:13
        assertEqual@http:/localhost:9628/node_modules/chai/chai.js:1387:12
        methodWrapper@http:/localhost:9628/node_modules/chai/chai.js:7824:25
        handleDom@http:/localhost:9628/node_modules/@open-wc/semantic-dom-diff/chai-dom-diff.js:102:16
        overwritingMethodWrapper@http:/localhost:9628/node_modules/chai/chai.js:9039:33
        @http:/localhost:9628/packages/textarea/test/lion-textarea.test.js:79:52


Firefox:  |██████████████████████████████| 124/124 test files | 1745 passed, 95 failed, 44 skipped
Chromium: |██████████████████████████████| 124/124 test files | 1745 passed, 95 failed, 44 skipped
Webkit:   |██████████████████████████████| 124/124 test files | 1741 passed, 95 failed, 44 skipped

Code coverage: 92.37 %
View full coverage report at coverage/lcov-report/index.html

Finished running tests in 87.8s with 285 failed tests.

error Command failed with exit code 1.
