### PR TITLE
Export reparentNodes and removeNodes

### DIFF
--- a/.changeset/rotten-foxes-tan.md
+++ b/.changeset/rotten-foxes-tan.md
@@ -1,0 +1,5 @@
+---
+"@lion/core": patch
+---
+
+Export reparentNodes and removeNodes

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -49,4 +49,6 @@ export {
   svg,
   SVGTemplateResult,
   TemplateResult,
+  removeNodes,
+  reparentNodes,
 } from 'lit-html';

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -34,6 +34,8 @@ export {
   svg,
   SVGTemplateResult,
   TemplateResult,
+  reparentNodes,
+  removeNodes,
 } from 'lit-html';
 export { asyncAppend } from 'lit-html/directives/async-append.js';
 export { asyncReplace } from 'lit-html/directives/async-replace.js';


### PR DESCRIPTION
## What I did

Export removeNodes and reparentNodes functions from lit-html. This is needed to write directives.
