### PR TITLE
fix(form-core): allow Validators from different form-core versions

### DIFF
--- a/.changeset/clean-guests-invent.md
+++ b/.changeset/clean-guests-invent.md
@@ -1,0 +1,5 @@
+---
+"@lion/form-core": patch
+---
+
+Allow Validators from different form-core versions

--- a/packages/form-core/src/validate/ValidateMixin.js
+++ b/packages/form-core/src/validate/ValidateMixin.js
@@ -8,6 +8,7 @@ import { SyncUpdatableMixin } from '../utils/SyncUpdatableMixin.js';
 import { LionValidationFeedback } from './LionValidationFeedback.js';
 import { ResultValidator } from './ResultValidator.js';
 import { Unparseable } from './Unparseable.js';
+// eslint-disable-next-line no-unused-vars
 import { Validator } from './Validator.js';
 import { Required } from './validators/Required.js';
 import { FormControlMixin } from '../FormControlMixin.js';
@@ -466,10 +467,14 @@ export const ValidateMixinImplementation = superclass =>
           v.onFormControlDisconnect(this);
         });
       }
+
+      const isValidator = (/** @type {Validator} */ v) =>
+        /** @type {typeof Validator} */ (v.constructor).validatorName !== undefined && v.execute;
+
       this._allValidators.forEach(v => {
-        if (!(v instanceof Validator)) {
+        if (!isValidator(v)) {
           // throws in constructor are not visible to end user so we do both
-          const errorType = Array.isArray(v) ? 'array' : typeof v;
+          const errorType = Array.isArray(v) ? 'array' : v.constructor.name;
           const errorMessage = `Validators array only accepts class instances of Validator. Type "${errorType}" found.`;
           // eslint-disable-next-line no-console
           console.error(errorMessage, this);

--- a/packages/form-core/test-suites/ValidateMixin.suite.js
+++ b/packages/form-core/test-suites/ValidateMixin.suite.js
@@ -78,7 +78,7 @@ export function runValidateMixinSuite(customConfig) {
         expect(stub.args[0][0]).to.equal(errorMessage);
 
         const errorMessage2 =
-          'Validators array only accepts class instances of Validator. Type "string" found.';
+          'Validators array only accepts class instances of Validator. Type "String" found.';
         expect(() => {
           // @ts-expect-error because we purposely put a wrong type
           el.validators = ['required'];


### PR DESCRIPTION
closes https://github.com/ing-bank/lion/issues/1079
