### PR TITLE
feat: use global storage for singleton instances

### DIFF
--- a/packages/singleton-manager/src/SingletonManagerClass.js
+++ b/packages/singleton-manager/src/SingletonManagerClass.js
@@ -1,6 +1,8 @@
+const sym = Symbol.for('lion::SingletonManagerClassStorage');
+
 export class SingletonManagerClass {
   constructor() {
-    this._map = new Map();
+    this._map = window[sym] ? window[sym] : window[sym] = new Map();
   }
 
   /**


### PR DESCRIPTION
## What I did

1. Use a map stored in "window" of a map scoped to the module to store instances registered in the Singleton Manager to enable coexistence of several singleton manager instances
