### PR TITLE
feat(overlays): open, close and toggle methods on host

### DIFF
--- a/.changeset/weak-papayas-sort.md
+++ b/.changeset/weak-papayas-sort.md
@@ -1,0 +1,5 @@
+---
+"@lion/overlays": patch
+---
+
+Overlays: open, close and toggle methods on host (OverlayMixin)

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -28,6 +28,13 @@ export const OverlayMixinImplementation = superclass =>
       this.__needsSetup = true;
       /** @type {OverlayConfig} */
       this.config = {};
+
+      /** @type {EventListener} */
+      this.toggle = this.toggle.bind(this);
+      /** @type {EventListener} */
+      this.open = this.open.bind(this);
+      /** @type {EventListener} */
+      this.close = this.close.bind(this);
     }
 
     get config() {
@@ -307,6 +314,27 @@ export const OverlayMixinImplementation = superclass =>
         /** @type {OverlayController} */
         (this._overlayCtrl).hide();
       }
+    }
+
+    /**
+     * Toggles the overlay
+     */
+    toggle() {
+      /** @type {OverlayController} */ (this._overlayCtrl).toggle();
+    }
+
+    /**
+     * Shows the overlay
+     */
+    open() {
+      /** @type {OverlayController} */ (this._overlayCtrl).show();
+    }
+
+    /**
+     * Hides the overlay
+     */
+    close() {
+      /** @type {OverlayController} */ (this._overlayCtrl).hide();
     }
   };
 export const OverlayMixin = dedupeMixin(OverlayMixinImplementation);

--- a/packages/overlays/test-suites/OverlayMixin.suite.js
+++ b/packages/overlays/test-suites/OverlayMixin.suite.js
@@ -209,6 +209,32 @@ export function runOverlayMixinSuite({ tagString, tag, suffix = '' }) {
       await nextFrame(); // hide takes at least a frame
       expect(el.opened).to.be.false;
     });
+
+    // See https://github.com/ing-bank/lion/discussions/1095
+    it('exposes open(), close() and toggle() methods', async () => {
+      const el = /** @type {OverlayEl} */ (await fixture(html`
+        <${tag}>
+          <div slot="content">content</div>
+          <button slot="invoker">invoker button</button>
+        </${tag}>
+      `));
+      expect(el.opened).to.be.false;
+      el.open();
+      await nextFrame();
+      expect(el.opened).to.be.true;
+
+      el.close();
+      await nextFrame();
+      expect(el.opened).to.be.false;
+
+      el.toggle();
+      await nextFrame();
+      expect(el.opened).to.be.true;
+
+      el.toggle();
+      await nextFrame();
+      expect(el.opened).to.be.false;
+    });
   });
 
   describe(`OverlayMixin${suffix} nested`, () => {

--- a/packages/overlays/types/OverlayMixinTypes.d.ts
+++ b/packages/overlays/types/OverlayMixinTypes.d.ts
@@ -22,6 +22,10 @@ export declare class OverlayHost {
   public get config(): OverlayConfig;
   public set config(value: OverlayConfig);
 
+  public open(): void;
+  public close(): void;
+  public toggle(): void;
+
   protected _overlayCtrl: OverlayController;
 
   protected get _overlayInvokerNode(): HTMLElement;


### PR DESCRIPTION
## What I did

expose `open()`,  `close()` and `toggle()` methods on host,

### Why?
- requested by consumers: See: https://github.com/ing-bank/lion/discussions/1095. It's a better interface than the opened attribute
- makes it more straightforward to add your own click/hover etc. handlers

So before, for every extension you would have to do:

```js
constructor() {
  super();
  this._myToggleMethod = this._myToggleMethod.bind(this);
}

_myToggleMethod() {
   this._overlayCtrl.toggle();
}

_setupOverlayCtrl() {
  super._setupOverlayCtrl();
  this._invokerNode.addEventListener('click', this._myToggleMethod);
}

_teardownOverlayCtrl() {
  super._teardownOverlayCtrl();
  this._invokerNode.removeEventListener('click', this._myToggleMethod);
}
```

Now it's just :
```js
_setupOverlayCtrl() {
  super._setupOverlayCtrl();
  this._invokerNode.addEventListener('click', this.toggle);
}

_teardownOverlayCtrl() {
  super._teardownOverlayCtrl();
  this._invokerNode.removeEventListener('click', this.toggle);
}
```


