### PR TITLE
Fix/overlays focus

### DIFF
--- a/.changeset/cyan-onions-juggle.md
+++ b/.changeset/cyan-onions-juggle.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+Only set inert when placementMode is global, otherwise events are broken inside local overlay content

--- a/.changeset/itchy-tools-run.md
+++ b/.changeset/itchy-tools-run.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+Fix deep contains util to properly check multiple nested shadow roots, and do not set containsTarget to false when children deepContains returns false. This would undo a found target in another child somewhere that was found in an earlier recursion.

--- a/packages/overlays/src/OverlayController.js
+++ b/packages/overlays/src/OverlayController.js
@@ -1013,7 +1013,7 @@ export class OverlayController extends EventTargetShim {
     this._containFocusHandler = containFocus(this.contentNode);
     this.__hasActiveTrapsKeyboardFocus = true;
     if (this.manager) {
-      this.manager.informTrapsKeyboardFocusGotEnabled();
+      this.manager.informTrapsKeyboardFocusGotEnabled(this.placementMode);
     }
   }
 

--- a/packages/overlays/src/OverlaysManager.js
+++ b/packages/overlays/src/OverlaysManager.js
@@ -153,8 +153,11 @@ export class OverlaysManager {
     });
   }
 
-  informTrapsKeyboardFocusGotEnabled() {
-    if (this.siblingsInert === false) {
+  /**
+   * @param {'local' | 'global' | undefined} placementMode
+   */
+  informTrapsKeyboardFocusGotEnabled(placementMode) {
+    if (this.siblingsInert === false && placementMode === 'global') {
       if (OverlaysManager.__globalRootNode) {
         setSiblingsInert(this.globalRootNode);
       }

--- a/packages/overlays/src/utils/deep-contains.js
+++ b/packages/overlays/src/utils/deep-contains.js
@@ -10,15 +10,13 @@ export function deepContains(el, targetEl) {
     return true;
   }
 
-  /** @param {HTMLElement} elem */
+  /** @param {HTMLElement|ShadowRoot} elem */
   function checkChildren(elem) {
     for (let i = 0; i < elem.children.length; i += 1) {
       const child = /** @type {HTMLElement}  */ (elem.children[i]);
-      if (child.shadowRoot) {
-        containsTarget = deepContains(child.shadowRoot, targetEl);
-        if (containsTarget) {
-          break;
-        }
+      if (child.shadowRoot && deepContains(child.shadowRoot, targetEl)) {
+        containsTarget = true;
+        break;
       }
       if (child.children.length > 0) {
         checkChildren(child);
@@ -27,14 +25,12 @@ export function deepContains(el, targetEl) {
   }
 
   // If element is not shadowRoot itself
-  if (el instanceof HTMLElement) {
-    if (el.shadowRoot) {
-      containsTarget = deepContains(el.shadowRoot, targetEl);
-      if (containsTarget) {
-        return true;
-      }
+  if (el instanceof HTMLElement && el.shadowRoot) {
+    containsTarget = deepContains(el.shadowRoot, targetEl);
+    if (containsTarget) {
+      return true;
     }
-    checkChildren(el);
   }
+  checkChildren(el);
   return containsTarget;
 }


### PR DESCRIPTION
## What I did

1. Fix an issue with events no longer working inside the contentNode of local overlays due to body inert
2. Fix an issue with deepContains not properly handling multiple nested shadow roots, and fix a recursion problem where earlier loops would find a target, but later loops would not, and then containsTarget bool would end up as "false" even though we did find a target
