### PR TITLE
fix(dialog): prevent opened-changed to be sent when it is not changing

### DIFF
--- a/.changeset/silver-horses-return.md
+++ b/.changeset/silver-horses-return.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+Prevent `opened-changed` event to be sent twice

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -62,7 +62,7 @@ export const OverlayMixinImplementation = superclass =>
      */
     requestUpdateInternal(name, oldValue) {
       super.requestUpdateInternal(name, oldValue);
-      if (name === 'opened') {
+      if (name === 'opened' && this.opened !== oldValue) {
         this.dispatchEvent(new Event('opened-changed'));
       }
     }

--- a/packages/overlays/test-suites/OverlayMixin.suite.js
+++ b/packages/overlays/test-suites/OverlayMixin.suite.js
@@ -132,6 +132,9 @@ export function runOverlayMixinSuite({ tagString, tag, suffix = '' }) {
       await el.updateComplete;
       expect(spy.callCount).to.equal(1);
       expect(el.opened).to.be.true;
+      el.opened = true;
+      await el.updateComplete;
+      expect(spy.callCount).to.equal(1);
       await el._overlayCtrl.hide();
       await el.updateComplete;
       expect(spy.callCount).to.equal(2);


### PR DESCRIPTION
## What I did

1. Prevent opened-changed to be sent twice.

If you add an event listener on a `<lion-dialog>`, you have 2 events sent when you open it.
