### PR TITLE
fix(form-core): dedupe click event label choice inputs

### DIFF
--- a/.changeset/eleven-pans-shave.md
+++ b/.changeset/eleven-pans-shave.md
@@ -1,0 +1,5 @@
+---
+'@lion/form-core': patch
+---
+
+Stop propagation of label click event in choice inputs to deduplicate the click event on the choice input.

--- a/packages/form-core/test-suites/choice-group/ChoiceInputMixin.suite.js
+++ b/packages/form-core/test-suites/choice-group/ChoiceInputMixin.suite.js
@@ -95,6 +95,26 @@ export function runChoiceInputMixinSuite({ tagString } = {}) {
       expect(counter).to.equal(1);
     });
 
+    it('fires one "click" event when clicking label or input, using the right target', async () => {
+      const spy = sinon.spy();
+      const el = /** @type {ChoiceInput} */ (await fixture(html`
+        <${tag}
+          @click="${spy}"
+        >
+          <input slot="input" />
+        </${tag}>
+      `));
+      el.click();
+      expect(spy.args[0][0].target).to.equal(el);
+      expect(spy.callCount).to.equal(1);
+      el._labelNode.click();
+      expect(spy.args[1][0].target).to.equal(el._labelNode);
+      expect(spy.callCount).to.equal(2);
+      el._inputNode.click();
+      expect(spy.args[2][0].target).to.equal(el._inputNode);
+      expect(spy.callCount).to.equal(3);
+    });
+
     it('adds "isTriggerByUser" flag on model-value-changed', async () => {
       let isTriggeredByUser;
       const el = /** @type {ChoiceInput} */ (await fixture(html`

--- a/packages/form-core/types/choice-group/ChoiceInputMixinTypes.d.ts
+++ b/packages/form-core/types/choice-group/ChoiceInputMixinTypes.d.ts
@@ -41,6 +41,8 @@ export declare class ChoiceInputHost {
   connectedCallback(): void;
   disconnectedCallback(): void;
 
+  _preventDuplicateLabelClick(ev: Event): void;
+
   __toggleChecked(): void;
 
   __syncModelCheckedToChecked(checked: boolean): void;


### PR DESCRIPTION
Not sure if this is the right place to fix it, but doing

```html
<lion-checkbox 
  @click=${() => console.log('clicked')} 
  label="Francis Bacon" 
  .choiceValue=${'Francis Bacon'}
></lion-checkbox>
```

and then clicking the label creates 2 click events.

Clicking the graphic container only creates 1 click event. 

Therefore, I figured we just prevent the label click from propagating on the CE (lion-choice-input), so that you only get 1 click event on the CE.