### PR TITLE
fix(overlays): reinsert missing tab detect el, don't error on disconnect

### DIFF
--- a/.changeset/long-fans-flash.md
+++ b/.changeset/long-fans-flash.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+Use MutationObserver to watch child changes of the contentNode, and re-insert tab detection element when necessary.

--- a/packages/overlays/test/utils-tests/contain-focus.test.js
+++ b/packages/overlays/test/utils-tests/contain-focus.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, nextFrame } from '@open-wc/testing';
 import { renderLitAsNode } from '@lion/helpers';
 import { getDeepActiveElement } from '../../src/utils/get-deep-active-element.js';
 import { getFocusableElements } from '../../src/utils/get-focusable-elements.js';
@@ -164,6 +164,17 @@ describe('containFocus()', () => {
   });
 
   describe('Tabbing into window', () => {
+    it('reinserts tab detection element when contentNode changes inner content', async () => {
+      await fixture(lightDomTemplate);
+      const root = /** @type {HTMLElement} */ (document.getElementById('rootElement'));
+      const { disconnect } = containFocus(root);
+      expect(root.querySelector('[data-is-tab-detection-element]')).to.exist;
+      root.innerHTML = `my content`;
+      await nextFrame();
+      expect(root.querySelector('[data-is-tab-detection-element]')).to.exist;
+      disconnect();
+    });
+
     it('restores focus within root element', async () => {
       await fixture(lightDomTemplate);
       const root = /** @type {HTMLElement} */ (document.getElementById('rootElement'));


### PR DESCRIPTION
## What I did

1. Observe content node children, reinsert tab detection element if children have changed but tab detection element is missing 
2. Guard disconnect tab detection el to check if the el is a child of the root element. This happens only if content node children change is observed and the tab detection element is identified as missing. It will disconnect and reconnect a containFocus, essentially re-inserting the tab detection element
