### PR TITLE
refactor: add package exports entries

### DIFF
--- a/.changeset/red-steaks-brake.md
+++ b/.changeset/red-steaks-brake.md
@@ -1,0 +1,47 @@
+---
+'babel-plugin-extend-docs': minor
+'providence-analytics': minor
+'remark-extend': minor
+'@lion/accordion': minor
+'@lion/ajax': minor
+'@lion/button': minor
+'@lion/calendar': minor
+'@lion/checkbox-group': minor
+'@lion/collapsible': minor
+'@lion/combobox': minor
+'@lion/core': minor
+'@lion/dialog': minor
+'@lion/fieldset': minor
+'@lion/form': minor
+'@lion/form-core': minor
+'@lion/form-integrations': minor
+'@lion/helpers': minor
+'@lion/icon': minor
+'@lion/input': minor
+'@lion/input-amount': minor
+'@lion/input-date': minor
+'@lion/input-datepicker': minor
+'@lion/input-email': minor
+'@lion/input-iban': minor
+'@lion/input-range': minor
+'@lion/input-stepper': minor
+'@lion/listbox': minor
+'@lion/localize': minor
+'@lion/overlays': minor
+'@lion/pagination': minor
+'@lion/progress-indicator': minor
+'@lion/radio-group': minor
+'@lion/select': minor
+'@lion/select-rich': minor
+'singleton-manager': minor
+'@lion/steps': minor
+'@lion/switch': minor
+'@lion/tabs': minor
+'@lion/textarea': minor
+'@lion/tooltip': minor
+'@lion/validate-messages': minor
+---
+
+Add exports field in package.json
+
+Note that some tools can break with this change as long as they respect the exports field. If that is the case, check that you always access the elements included in the exports field, with the same name which they are exported. Any item not exported is considered private to the package and should not be accessed from the outside.

--- a/packages-node/babel-plugin-extend-docs/package.json
+++ b/packages-node/babel-plugin-extend-docs/package.json
@@ -30,5 +30,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "exports": "./index.js"
 }

--- a/packages-node/providence-analytics/package.json
+++ b/packages-node/providence-analytics/package.json
@@ -65,5 +65,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./src/program/providence.js",
+    "./src/cli/index.js": "./src/cli/index.js"
   }
 }

--- a/packages-node/remark-extend/package.json
+++ b/packages-node/remark-extend/package.json
@@ -35,5 +35,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "exports": "./index.js"
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -42,5 +42,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-accordion": "./lion-accordion.js"
   }
 }

--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -39,7 +39,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "exports": {
-    ".": "./index.js"
-  }
+  "exports": "./index.js"
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -42,5 +42,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-button": "./lion-button.js"
   }
 }

--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -6,7 +6,7 @@ import {
   LitElement,
   SlotMixin,
 } from '@lion/core';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
+import '@lion/core/differentKeyEventNamesShimIE';
 
 const isKeyboardClickEvent = (/** @type {KeyboardEvent} */ e) => e.key === ' ' || e.key === 'Enter';
 const isSpaceKeyboardClickEvent = (/** @type {KeyboardEvent} */ e) => e.key === ' ';

--- a/packages/button/test/lion-button.test.js
+++ b/packages/button/test/lion-button.test.js
@@ -1,7 +1,7 @@
 import { browserDetection } from '@lion/core';
 import { aTimeout, expect, fixture, html, oneEvent, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
+import '@lion/core/differentKeyEventNamesShimIE';
 import '../lion-button.js';
 
 /**

--- a/packages/calendar/index.js
+++ b/packages/calendar/index.js
@@ -1,1 +1,2 @@
+export { isSameDate } from './src/utils/isSameDate.js';
 export { LionCalendar } from './src/LionCalendar.js';

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -43,5 +43,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-calendar": "./lion-calendar.js",
+    "./test-helpers": "./test-helpers.js"
   }
 }

--- a/packages/calendar/src/LionCalendar.js
+++ b/packages/calendar/src/LionCalendar.js
@@ -1,5 +1,4 @@
 import { html, LitElement } from '@lion/core';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
 import {
   getMonthNames,
   getWeekdayNames,
@@ -7,6 +6,8 @@ import {
   LocalizeMixin,
   normalizeDateTime,
 } from '@lion/localize';
+
+import '@lion/core/differentKeyEventNamesShimIE';
 import { calendarStyle } from './calendarStyle.js';
 import { createDay } from './utils/createDay.js';
 import { createMultipleMonth } from './utils/createMultipleMonth.js';

--- a/packages/calendar/test/lion-calendar.test.js
+++ b/packages/calendar/test/lion-calendar.test.js
@@ -1,7 +1,7 @@
 import { html } from '@lion/core';
 import '@lion/core/test-helpers/keyboardEventShimIE.js';
 import { localize } from '@lion/localize';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { expect, fixture as _fixture } from '@open-wc/testing';
 import sinon from 'sinon';
 import '../lion-calendar.js';

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -46,5 +46,11 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-checkbox": "./lion-checkbox.js",
+    "./lion-checkbox-group": "./lion-checkbox-group.js",
+    "./lion-checkbox-indeterminate": "./lion-checkbox-indeterminate.js"
   }
 }

--- a/packages/checkbox-group/test/lion-checkbox-group.test.js
+++ b/packages/checkbox-group/test/lion-checkbox-group.test.js
@@ -1,4 +1,4 @@
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { expect, fixture as _fixture, html } from '@open-wc/testing';
 import '../lion-checkbox-group.js';
 import '../lion-checkbox.js';

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -45,5 +45,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-collapsible": "./lion-collapsible.js"
   }
 }

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -55,5 +55,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-combobox": "./lion-combobox.js"
   }
 }

--- a/packages/combobox/test/lion-combobox.test.js
+++ b/packages/combobox/test/lion-combobox.test.js
@@ -1,8 +1,8 @@
-import '@lion/listbox/lion-option.js';
+import '@lion/listbox/lion-option';
 import { expect, fixture, html, defineCE, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
 import '../lion-combobox.js';
-import { LionOptions } from '@lion/listbox/src/LionOptions.js';
+import { LionOptions } from '@lion/listbox';
 import { browserDetection, LitElement } from '@lion/core';
 import { Required } from '@lion/form-core';
 import { LionCombobox } from '../src/LionCombobox.js';

--- a/packages/core/closestPolyfill.js
+++ b/packages/core/closestPolyfill.js
@@ -1,0 +1,1 @@
+import './src/closestPolyfill.js';

--- a/packages/core/differentKeyEventNamesShimIE.js
+++ b/packages/core/differentKeyEventNamesShimIE.js
@@ -1,0 +1,1 @@
+import './src/differentKeyEventNamesShimIE.js';

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,7 +29,10 @@
     "prepublishOnly": "../../scripts/npm-prepublish.js",
     "test": "cd ../../ && npm run test:browser -- --group core"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "./closestPolyfill.js",
+    "./differentKeyEventNamesShimIE.js"
+  ],
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.2.18",
     "@open-wc/scoped-elements": "^1.3.3",
@@ -42,5 +45,11 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./test-helpers/*": "./test-helpers/*",
+    "./closestPolyfill": "./src/closestPolyfill.js",
+    "./differentKeyEventNamesShimIE": "./src/differentKeyEventNamesShimIE.js"
   }
 }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -44,5 +44,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-dialog": "./lion-dialog.js"
   }
 }

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -44,5 +44,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-fieldset": "./lion-fieldset.js"
   }
 }

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -44,5 +44,12 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./test-helpers/*": "./test-helpers/*",
+    "./test-suites/*": "./test-suites/*",
+    "./lion-field": "./lion-field.js",
+    "./lion-validation-feedback": "./lion-validation-feedback.js"
   }
 }

--- a/packages/form-core/src/FormControlMixin.js
+++ b/packages/form-core/src/FormControlMixin.js
@@ -1,5 +1,4 @@
-import { css, dedupeMixin, html, nothing, SlotMixin } from '@lion/core';
-import { DisabledMixin } from '@lion/core/src/DisabledMixin.js';
+import { css, dedupeMixin, html, nothing, SlotMixin, DisabledMixin } from '@lion/core';
 import { FormRegisteringMixin } from './registration/FormRegisteringMixin.js';
 import { getAriaElementsInRightDomOrder } from './utils/getAriaElementsInRightDomOrder.js';
 import { Unparseable } from './validate/Unparseable.js';

--- a/packages/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -1,6 +1,6 @@
 import { LitElement } from '@lion/core';
 import { localize } from '@lion/localize';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { defineCE, expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
 import { DefaultSuccess, MinLength, Required, ValidateMixin, Validator } from '../index.js';

--- a/packages/form-core/test-suites/choice-group/ChoiceGroupMixin.suite.js
+++ b/packages/form-core/test-suites/choice-group/ChoiceGroupMixin.suite.js
@@ -1,6 +1,6 @@
 import { LitElement } from '@lion/core';
 import { LionInput } from '@lion/input';
-import '@lion/fieldset/lion-fieldset.js';
+import '@lion/fieldset/lion-fieldset';
 import { FormGroupMixin, Required } from '@lion/form-core';
 import { expect, html, fixture, unsafeStatic } from '@open-wc/testing';
 import { ChoiceGroupMixin } from '../../src/choice-group/ChoiceGroupMixin.js';

--- a/packages/form-core/test-suites/form-group/FormGroupMixin-input.suite.js
+++ b/packages/form-core/test-suites/form-group/FormGroupMixin-input.suite.js
@@ -1,8 +1,8 @@
 import { LitElement } from '@lion/core';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { defineCE, expect, html, unsafeStatic, fixture } from '@open-wc/testing';
 import { LionInput } from '@lion/input';
-import '@lion/form-core/lion-field.js';
+import '@lion/form-core/lion-field';
 import { FormGroupMixin } from '../../src/form-group/FormGroupMixin.js';
 
 /**

--- a/packages/form-core/test-suites/form-group/FormGroupMixin.suite.js
+++ b/packages/form-core/test-suites/form-group/FormGroupMixin.suite.js
@@ -1,5 +1,5 @@
 import { LitElement } from '@lion/core';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import {
   defineCE,
   expect,
@@ -11,7 +11,7 @@ import {
 } from '@open-wc/testing';
 import sinon from 'sinon';
 import { IsNumber, Validator, LionField } from '@lion/form-core';
-import '@lion/form-core/lion-field.js';
+import '@lion/form-core/lion-field';
 import { FormGroupMixin } from '../../src/form-group/FormGroupMixin.js';
 
 /**

--- a/packages/form-core/test/lion-field.test.js
+++ b/packages/form-core/test/lion-field.test.js
@@ -1,6 +1,6 @@
 import { unsafeHTML } from '@lion/core';
 import { localize } from '@lion/localize';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { Required, Validator } from '@lion/form-core';
 import {
   expect,

--- a/packages/form-integrations/package.json
+++ b/packages/form-integrations/package.json
@@ -64,5 +64,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "exports": "./index.js"
 }

--- a/packages/form-integrations/test/helpers/umbrella-form.js
+++ b/packages/form-integrations/test/helpers/umbrella-form.js
@@ -1,24 +1,24 @@
 import { LitElement, html } from '@lion/core';
 import { Required, MinLength } from '@lion/form-core';
-import '@lion/form/lion-form.js';
-import '@lion/fieldset/lion-fieldset.js';
-import '@lion/input/lion-input.js';
-import '@lion/input-date/lion-input-date.js';
-import '@lion/input-datepicker/lion-input-datepicker.js';
-import '@lion/input-amount/lion-input-amount.js';
-import '@lion/input-iban/lion-input-iban.js';
-import '@lion/input-email/lion-input-email.js';
-import '@lion/checkbox-group/lion-checkbox-group.js';
-import '@lion/checkbox-group/lion-checkbox.js';
-import '@lion/radio-group/lion-radio-group.js';
-import '@lion/radio-group/lion-radio.js';
-import '@lion/select/lion-select.js';
-import '@lion/select-rich/lion-select-rich.js';
-import '@lion/select-rich/lion-options.js';
-import '@lion/select-rich/lion-option.js';
-import '@lion/input-range/lion-input-range.js';
-import '@lion/textarea/lion-textarea.js';
-import '@lion/button/lion-button.js';
+import '@lion/form/lion-form';
+import '@lion/fieldset/lion-fieldset';
+import '@lion/input/lion-input';
+import '@lion/input-date/lion-input-date';
+import '@lion/input-datepicker/lion-input-datepicker';
+import '@lion/input-amount/lion-input-amount';
+import '@lion/input-iban/lion-input-iban';
+import '@lion/input-email/lion-input-email';
+import '@lion/checkbox-group/lion-checkbox-group';
+import '@lion/checkbox-group/lion-checkbox';
+import '@lion/radio-group/lion-radio-group';
+import '@lion/radio-group/lion-radio';
+import '@lion/select/lion-select';
+import '@lion/select-rich/lion-select-rich';
+import '@lion/select-rich/lion-options';
+import '@lion/select-rich/lion-option';
+import '@lion/input-range/lion-input-range';
+import '@lion/textarea/lion-textarea';
+import '@lion/button/lion-button';
 
 export class UmbrellaForm extends LitElement {
   get _lionFormNode() {

--- a/packages/form-integrations/test/model-value-consistency.test.js
+++ b/packages/form-integrations/test/model-value-consistency.test.js
@@ -3,31 +3,31 @@ import { expect, html, unsafeStatic, fixture } from '@open-wc/testing';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import sinon from 'sinon';
 
-import '@lion/input/lion-input.js';
-import '@lion/input-amount/lion-input-amount.js';
-import '@lion/input-date/lion-input-date.js';
-import '@lion/input-datepicker/lion-input-datepicker.js';
-import '@lion/input-email/lion-input-email.js';
-import '@lion/input-iban/lion-input-iban.js';
-import '@lion/input-range/lion-input-range.js';
-import '@lion/textarea/lion-textarea.js';
+import '@lion/input/lion-input';
+import '@lion/input-amount/lion-input-amount';
+import '@lion/input-date/lion-input-date';
+import '@lion/input-datepicker/lion-input-datepicker';
+import '@lion/input-email/lion-input-email';
+import '@lion/input-iban/lion-input-iban';
+import '@lion/input-range/lion-input-range';
+import '@lion/textarea/lion-textarea';
 
-import '@lion/checkbox-group/lion-checkbox-group.js';
-import '@lion/checkbox-group/lion-checkbox.js';
+import '@lion/checkbox-group/lion-checkbox-group';
+import '@lion/checkbox-group/lion-checkbox';
 
-import '@lion/radio-group/lion-radio-group.js';
-import '@lion/radio-group/lion-radio.js';
+import '@lion/radio-group/lion-radio-group';
+import '@lion/radio-group/lion-radio';
 
-import '@lion/select/lion-select.js';
+import '@lion/select/lion-select';
 
-import '@lion/combobox/lion-combobox.js';
-import '@lion/listbox/lion-listbox.js';
-import '@lion/listbox/lion-option.js';
-import '@lion/select-rich/lion-select-rich.js';
+import '@lion/combobox/lion-combobox';
+import '@lion/listbox/lion-listbox';
+import '@lion/listbox/lion-option';
+import '@lion/select-rich/lion-select-rich';
 
-import '@lion/fieldset/lion-fieldset.js';
-import '@lion/form/lion-form.js';
-import '@lion/form-core/lion-field.js';
+import '@lion/fieldset/lion-fieldset';
+import '@lion/form/lion-form';
+import '@lion/form-core/lion-field';
 
 /**
  * @typedef {import('@lion/core').LitElement} LitElement

--- a/packages/form-integrations/test/model-value-event.test.js
+++ b/packages/form-integrations/test/model-value-event.test.js
@@ -1,5 +1,5 @@
-import '@lion/fieldset/lion-fieldset.js';
-import '@lion/input/lion-input.js';
+import '@lion/fieldset/lion-fieldset';
+import '@lion/input/lion-input';
 import { expect, html, fixture } from '@open-wc/testing';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import sinon from 'sinon';

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -42,5 +42,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-form": "./lion-form.js"
   }
 }

--- a/packages/form/test/lion-form.test.js
+++ b/packages/form/test/lion-form.test.js
@@ -10,8 +10,8 @@ import {
 import { spy } from 'sinon';
 import { LionField } from '@lion/form-core';
 import { LionFieldset } from '@lion/fieldset';
-import '@lion/form-core/lion-field.js';
-import '@lion/fieldset/lion-fieldset.js';
+import '@lion/form-core/lion-field';
+import '@lion/fieldset/lion-fieldset';
 
 import '../lion-form.js';
 

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -42,5 +42,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./sb-action-logger": "./sb-action-logger.js",
+    "./sb-locale-switcher": "./sb-locale-switcher.js"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -44,5 +44,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-icon": "./lion-icon.js"
   }
 }

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -46,5 +46,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input-amount": "./lion-input-amount.js"
   }
 }

--- a/packages/input-amount/test/formatters.test.js
+++ b/packages/input-amount/test/formatters.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@open-wc/testing';
 import { localize } from '@lion/localize';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 
 import { formatAmount } from '../src/formatters.js';
 

--- a/packages/input-amount/test/lion-input-amount.test.js
+++ b/packages/input-amount/test/lion-input-amount.test.js
@@ -1,6 +1,6 @@
 import { html } from '@lion/core';
 import { localize } from '@lion/localize';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { aTimeout, expect, fixture } from '@open-wc/testing';
 import '../lion-input-amount.js';
 import { formatAmount } from '../src/formatters.js';

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -46,5 +46,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input-date": "./lion-input-date.js"
   }
 }

--- a/packages/input-date/test/lion-input-date.test.js
+++ b/packages/input-date/test/lion-input-date.test.js
@@ -1,6 +1,6 @@
 import { html } from '@lion/core';
 import { localize } from '@lion/localize';
-import { localizeTearDown } from '@lion/localize/test-helpers.js';
+import { localizeTearDown } from '@lion/localize/test-helpers';
 import { MaxDate } from '@lion/form-core';
 import { expect, fixture as _fixture } from '@open-wc/testing';
 import '../lion-input-date.js';

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -51,5 +51,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./test-helpers/*": "./test-helpers/*",
+    "./lion-input-datepicker": "./lion-input-datepicker.js"
   }
 }

--- a/packages/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/input-datepicker/src/LionInputDatepicker.js
@@ -1,4 +1,4 @@
-import { LionCalendar } from '@lion/calendar/src/LionCalendar';
+import { LionCalendar } from '@lion/calendar';
 import { html, ifDefined, ScopedElementsMixin } from '@lion/core';
 import { LionInputDate } from '@lion/input-date';
 import {

--- a/packages/input-datepicker/test-helpers/DatepickerInputObject.js
+++ b/packages/input-datepicker/test-helpers/DatepickerInputObject.js
@@ -1,4 +1,4 @@
-import { CalendarObject } from '@lion/calendar/test-helpers.js';
+import { CalendarObject } from '@lion/calendar/test-helpers';
 
 export class DatepickerInputObject {
   /** @param {import('../src/LionInputDatepicker').LionInputDatepicker} el */

--- a/packages/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/input-datepicker/test/lion-input-datepicker.test.js
@@ -1,5 +1,4 @@
-import { LionCalendar } from '@lion/calendar';
-import { isSameDate } from '@lion/calendar/src/utils/isSameDate.js';
+import { LionCalendar, isSameDate } from '@lion/calendar';
 import { html, LitElement } from '@lion/core';
 import { IsDateDisabled, MaxDate, MinDate, MinMaxDate } from '@lion/form-core';
 import { aTimeout, defineCE, expect, fixture as _fixture, nextFrame } from '@open-wc/testing';

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -46,5 +46,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input-email": "./lion-input-email.js"
   }
 }

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -47,5 +47,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input-iban": "./lion-input-iban.js"
   }
 }

--- a/packages/input-range/package.json
+++ b/packages/input-range/package.json
@@ -45,5 +45,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input-range": "./lion-input-range.js"
   }
 }

--- a/packages/input-stepper/package.json
+++ b/packages/input-stepper/package.json
@@ -45,5 +45,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input-stepper": "./lion-input-stepper.js"
   }
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -42,5 +42,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-input": "./lion-input.js"
   }
 }

--- a/packages/input/src/LionInput.js
+++ b/packages/input/src/LionInput.js
@@ -1,5 +1,4 @@
-import { LionField } from '@lion/form-core';
-import { NativeTextFieldMixin } from '@lion/form-core/src/NativeTextFieldMixin';
+import { LionField, NativeTextFieldMixin } from '@lion/form-core';
 
 /**
  * LionInput: extension of lion-field with native input element in place and user friendly API.

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -46,5 +46,12 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./test-suites/*": "./test-suites/*",
+    "./lion-listbox": "./lion-listbox.js",
+    "./lion-option": "./lion-option.js",
+    "./lion-options": "./lion-options.js"
   }
 }

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -1,6 +1,6 @@
 import { css, dedupeMixin, html, ScopedElementsMixin, SlotMixin } from '@lion/core';
-import '@lion/core/src/closestPolyfill.js';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
+import '@lion/core/closestPolyfill';
+import '@lion/core/differentKeyEventNamesShimIE';
 import { ChoiceGroupMixin, FormControlMixin, FormRegistrarMixin } from '@lion/form-core';
 import { LionOptions } from './LionOptions.js';
 

--- a/packages/listbox/test-suites/ListboxMixin.suite.js
+++ b/packages/listbox/test-suites/ListboxMixin.suite.js
@@ -1,8 +1,8 @@
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
+import '@lion/core/differentKeyEventNamesShimIE';
 import { Required } from '@lion/form-core';
 import { LionOptions } from '@lion/listbox';
-import '@lion/listbox/lion-option.js';
-import '@lion/listbox/lion-options.js';
+import '@lion/listbox/lion-option';
+import '@lion/listbox/lion-options';
 import { expect, fixture as _fixture, html, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
 import '../lion-listbox.js';

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -42,5 +42,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./test-helpers": "./test-helpers.js"
   }
 }

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -46,5 +46,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./translations/*": "./translations/*",
+    "./test-suites/*": "./test-suites/*"
   }
 }

--- a/packages/overlays/src/OverlayController.js
+++ b/packages/overlays/src/OverlayController.js
@@ -1,4 +1,4 @@
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
+import '@lion/core/differentKeyEventNamesShimIE';
 import { EventTargetShim } from '@lion/core';
 // eslint-disable-next-line import/no-cycle
 import { overlays } from './overlays.js';

--- a/packages/overlays/test/OverlayController.test.js
+++ b/packages/overlays/test/OverlayController.test.js
@@ -1,8 +1,9 @@
 /* eslint-disable no-new */
-import '@lion/core/test-helpers/keyboardEventShimIE.js';
 import { aTimeout, defineCE, expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import { fixtureSync } from '@open-wc/testing-helpers';
 import sinon from 'sinon';
+
+import '@lion/core/differentKeyEventNamesShimIE';
 import { OverlayController } from '../src/OverlayController.js';
 import { overlays } from '../src/overlays.js';
 import { keyCodes } from '../src/utils/key-codes.js';

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -43,5 +43,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-pagination": "./lion-pagination.js"
   }
 }

--- a/packages/progress-indicator/package.json
+++ b/packages/progress-indicator/package.json
@@ -43,5 +43,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-progress-indicator": "./lion-progress-indicator.js"
   }
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -45,5 +45,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-radio": "./lion-radio.js",
+    "./lion-radio-group": "./lion-radio-group.js"
   }
 }

--- a/packages/select-rich/lion-option.js
+++ b/packages/select-rich/lion-option.js
@@ -2,4 +2,4 @@
  * @deprecated
  * Import here for backwards compatibility
  */
-import '@lion/listbox/lion-option.js';
+import '@lion/listbox/lion-option';

--- a/packages/select-rich/lion-options.js
+++ b/packages/select-rich/lion-options.js
@@ -2,4 +2,4 @@
  * @deprecated
  * Import here for backwards compatibility
  */
-import '@lion/listbox/lion-options.js';
+import '@lion/listbox/lion-options';

--- a/packages/select-rich/package.json
+++ b/packages/select-rich/package.json
@@ -51,5 +51,12 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-option": "./lion-option.js",
+    "./lion-options": "./lion-options.js",
+    "./lion-select-invoker": "./lion-select-invoker.js",
+    "./lion-select-rich": "./lion-select-rich.js"
   }
 }

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -1,7 +1,8 @@
 import { LionListbox } from '@lion/listbox';
 import { html, ScopedElementsMixin, SlotMixin, browserDetection } from '@lion/core';
 import { OverlayMixin, withDropdownConfig } from '@lion/overlays';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
+
+import '@lion/core/differentKeyEventNamesShimIE';
 import { LionSelectInvoker } from './LionSelectInvoker.js';
 
 /**

--- a/packages/select-rich/test/lion-select-rich-dialog-integration.test.js
+++ b/packages/select-rich/test/lion-select-rich-dialog-integration.test.js
@@ -1,8 +1,8 @@
 import { OverlayMixin } from '@lion/overlays';
 import { LitElement } from '@lion/core';
 import { defineCE, fixture, html, expect, unsafeStatic } from '@open-wc/testing';
-import '@lion/listbox/lion-option.js';
-import '@lion/listbox/lion-options.js';
+import '@lion/listbox/lion-option';
+import '@lion/listbox/lion-options';
 import '../lion-select-rich.js';
 
 /**

--- a/packages/select-rich/test/lion-select-rich-interaction.test.js
+++ b/packages/select-rich/test/lion-select-rich-interaction.test.js
@@ -1,9 +1,9 @@
 import { Required } from '@lion/form-core';
 import { expect, html, triggerBlurFor, triggerFocusFor, fixture } from '@open-wc/testing';
 import { browserDetection } from '@lion/core';
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
-import '@lion/listbox/lion-option.js';
-import '@lion/listbox/lion-options.js';
+import '@lion/core/differentKeyEventNamesShimIE';
+import '@lion/listbox/lion-option';
+import '@lion/listbox/lion-options';
 import '../lion-select-rich.js';
 
 /**

--- a/packages/select-rich/test/lion-select-rich.test.js
+++ b/packages/select-rich/test/lion-select-rich.test.js
@@ -13,9 +13,9 @@ import {
 } from '@open-wc/testing';
 import { LionSelectInvoker, LionSelectRich } from '../index.js';
 
-import '@lion/core/src/differentKeyEventNamesShimIE.js';
-import '@lion/listbox/lion-option.js';
-import '@lion/listbox/lion-options.js';
+import '@lion/core/differentKeyEventNamesShimIE';
+import '@lion/listbox/lion-option';
+import '@lion/listbox/lion-options';
 import '../lion-select-rich.js';
 
 /**

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -43,5 +43,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-select": "./lion-select.js"
   }
 }

--- a/packages/singleton-manager/package.json
+++ b/packages/singleton-manager/package.json
@@ -39,5 +39,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "exports": "./index.js"
 }

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -43,5 +43,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-step": "./lion-step.js",
+    "./lion-steps": "./lion-steps.js"
   }
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -45,5 +45,10 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-switch": "./lion-switch.js",
+    "./lion-switch-button": "./lion-switch-button.js"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -42,5 +42,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-tabs": "./lion-tabs.js"
   }
 }

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -45,5 +45,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-textarea": "./lion-textarea.js"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -44,5 +44,9 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "exports": {
+    ".": "./index.js",
+    "./lion-tooltip": "./lion-tooltip.js"
   }
 }

--- a/packages/validate-messages/package.json
+++ b/packages/validate-messages/package.json
@@ -43,5 +43,6 @@
   ],
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "exports": "./index.js"
 }


### PR DESCRIPTION
## What I did

1. Add the `exports` entry in each `package.json`, exposing the public parts of each package and hiding the private ones.
2. Adapt broken code that accessed private elements of other packages.
3. Unify the way of publishing and access to side-effects.

This commit does not change the behavior of the components but could cause some access issues in those consumers who are accessing internal implementation details.

This change also allows better bundle optimizations by library clients.
