### PR TITLE
Fix @open-wc scoped elements link

### DIFF
--- a/packages/core/docs/guidelines/30-guidelines-scoped-elements.md
+++ b/packages/core/docs/guidelines/30-guidelines-scoped-elements.md
@@ -106,4 +106,4 @@ __getLightDomNode() {
 }
 ```
 
-We encourage you to have a look at [OpenWC's Scoped elements](https://open-wc.org/scoped-elements).
+We encourage you to have a look at [OpenWC's Scoped elements](https://open-wc.org/docs/development/scoped-elements).


### PR DESCRIPTION
## What I did

1. Fixed the link to @open-wc scoped elements documentation page
