### PR TITLE
feat: introduce transfer component to allow users

### DIFF
--- a/.changeset/twelve-terms-knock.md
+++ b/.changeset/twelve-terms-knock.md
@@ -1,0 +1,5 @@
+---
+'@lion/transfer': patch
+---
+
+introducing transfer component which allows the user to shift/transfer one or more items between lists

--- a/packages/transfer/CHANGELOG.md
+++ b/packages/transfer/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+# 0.0.1 (2021-02-22)
+
+### Features
+
+- introducing transfer component which allows the user to shift/transfer one or more items between lists ([7de1b96](https://github.com/ing-bank/lion/commit/7de1b96))

--- a/packages/transfer/README.md
+++ b/packages/transfer/README.md
@@ -1,0 +1,41 @@
+# Transfer
+
+`lion-transfer` component allows the user to shift/transfer one or more items between lists.
+
+You cannot use interactive elements inside the options. Avoid very long names to
+facilitate the understandability and perceivability for screen reader users. Sets of options
+where each option name starts with the same word or phrase can also significantly degrade
+usability for keyboard and screen reader users.
+
+```js script
+import { html } from 'lit-html';
+import { Required } from '@lion/form-core';
+import '@lion/listbox/lion-option.js';
+
+import './lion-transfer.js';
+
+export default {
+  title: 'Others/Transfer',
+};
+```
+
+```js preview-story
+export const main = () => html`
+  <lion-transfer>
+    <div slot="leftList">
+      <lion-option .choiceValue="Apple">Apple</lion-option>
+      <lion-option .choiceValue="Artichoke">Artichoke</lion-option>
+      <lion-option .choiceValue="Asparagus">Asparagus</lion-option>
+    </div>
+    <button slot="transferToLeftActionSlot">To Left &lt;</button>
+    <button slot="transferToRightActionSlot">To Right &gt;</button>
+    <div slot="rightList">
+      <lion-option .choiceValue="Banana">Banana</lion-option>
+      <lion-option .choiceValue="Beets">Beets</lion-option>
+      <lion-option .choiceValue="Bell pepper">Bell pepper</lion-option>
+      <lion-option .choiceValue="Broccoli">Broccoli</lion-option>
+      <lion-option .choiceValue="Brussels sprout">Brussels sprout</lion-option>
+    </div>
+  </lion-transfer>
+`;
+```

--- a/packages/transfer/index.js
+++ b/packages/transfer/index.js
@@ -1,0 +1,1 @@
+export { LionTransfer } from './src/LionTransfer.js';

--- a/packages/transfer/lion-transfer.js
+++ b/packages/transfer/lion-transfer.js
@@ -1,0 +1,3 @@
+import { LionTransfer } from './src/LionTransfer.js';
+
+customElements.define('lion-transfer', LionTransfer);

--- a/packages/transfer/package.json
+++ b/packages/transfer/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@lion/transfer",
+  "version": "0.0.1",
+  "description": "Allows the user to shift/transfer one or more items between lists.",
+  "license": "MIT",
+  "author": "ing-bank",
+  "homepage": "https://github.com/ing-bank/lion/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ing-bank/lion.git",
+    "directory": "packages/transfer"
+  },
+  "main": "index.js",
+  "module": "index.js",
+  "files": [
+    "*.d.ts",
+    "*.js",
+    "custom-elements.json",
+    "docs",
+    "src",
+    "test",
+    "test-helpers",
+    "translations",
+    "types"
+  ],
+  "scripts": {
+    "custom-elements-manifest": "custom-elements-manifest analyze --litelement --exclude 'docs/**/*'",
+    "debug": "cd ../../ && npm run debug -- --group transfer",
+    "debug:firefox": "cd ../../ && npm run debug:firefox -- --group transfer",
+    "debug:webkit": "cd ../../ && npm run debug:webkit -- --group transfer",
+    "prepublishOnly": "../../scripts/npm-prepublish.js && npm run custom-elements-manifest",
+    "test": "cd ../../ && npm run test:browser -- --group transfer"
+  },
+  "sideEffects": [
+    "lion-transfer.js"
+  ],
+  "dependencies": {
+    "@lion/core": "0.14.0",
+    "@lion/listbox": "0.5.1"
+  },
+  "keywords": [
+    "lion",
+    "transfer",
+    "web-components"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "customElementsManifest": "custom-elements.json",
+  "exports": {
+    ".": "./index.js",
+    "./lion-transfer": "./lion-transfer.js"
+  }
+}

--- a/packages/transfer/src/LionTransfer.js
+++ b/packages/transfer/src/LionTransfer.js
@@ -1,0 +1,175 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable import/no-extraneous-dependencies */
+
+import { LitElement, css, html } from '@lion/core';
+import '@lion/listbox/lion-listbox';
+
+/** @typedef {{choiceValue: string, checked: boolean, active: boolean}} ListOption */
+/**
+ * LionTransfer: provide functionality to shift items between listboxes
+ * which indeed implicitly provide all wai-aria listbox design pattern and integrates it as a Lion
+ * @customElement lion-transfer
+ */
+export class LionTransfer extends LitElement {
+  /**
+   * Instance of the element is created/upgraded. Useful for initializing
+   * state, set up event listeners, create shadow dom.
+
+   * @constructor
+   */
+  constructor() {
+    super();
+    /** @type {Array.<ListOption>} */
+    this.leftList = [];
+    /** @type {Array.<ListOption>} */
+    this.rightList = [];
+    this.shouldTransfer = false;
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: flex;
+      }
+
+      .action-panel {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        margin: auto 16px;
+      }
+    `;
+  }
+
+  render() {
+    return html`
+      <lion-listbox id="leftListBox" multiple-choice></lion-listbox>
+      <div class="action-panel">
+        <slot
+          name="transferToRightActionSlot"
+          @click=${this._handleTransferToRight.bind(this)}
+        ></slot>
+        <slot
+          name="transferToLeftActionSlot"
+          @click=${this._handleTransferToLeft.bind(this)}
+        ></slot>
+      </div>
+      <lion-listbox id="rightListBox" multiple-choice></lion-listbox>
+
+      <slot id="leftListSlot" name="leftList"></slot>
+      <slot id="rightListSlot" name="rightList"></slot>
+    `;
+  }
+
+  /**
+   * click handler on right list box slot
+   * @protected
+   */
+  _handleTransferToRight() {
+    this._transferingOptions('leftList', 'rightList');
+  }
+
+  /**
+   * click handler on left list box slot
+   * @protected
+   */
+  _handleTransferToLeft() {
+    this._transferingOptions('rightList', 'leftList');
+  }
+
+  get modelValue() {
+    return {
+      left: this.leftList?.map(el => el.choiceValue) || [],
+      right: this.rightList?.map(el => el.choiceValue) || [],
+    };
+  }
+
+  firstUpdated() {
+    this.leftListBox = this.shadowRoot?.querySelector('#leftListBox');
+    this.rightListBox = this.shadowRoot?.querySelector('#rightListBox');
+
+    const leftListSlot = /** @type {HTMLSlotElement} */ (
+      /** @type {ShadowRoot} */ this.shadowRoot?.querySelector('#leftListSlot')
+    );
+    const rightListSlot = /** @type {HTMLSlotElement} */ (
+      /** @type {ShadowRoot} */ this.shadowRoot?.querySelector('#rightListSlot')
+    );
+
+    [leftListSlot, rightListSlot].forEach(slot => {
+      slot?.addEventListener('slotchange', () => {
+        const nodes = /** @type {HTMLElement[]} */ (slot?.assignedNodes());
+        const itemCollection = nodes[0]?.children;
+        const slotType = slot?.id.replace('Slot', '');
+
+        this[slotType] = Array.from(itemCollection);
+        this[slotType].forEach(
+          /** @param {ListOption & HTMLElement} option */ option => {
+            option.choiceValue = option.getAttribute('.choicevalue') || ''; // eslint-disable-line no-param-reassign
+            option.removeAttribute('.choicevalue');
+          },
+        );
+        this.shouldTransfer = true;
+        this._renderOptions(slotType);
+      });
+    });
+  }
+
+  /**
+   * render the options into the listboxes
+   * @param {String} listName e.g. leftList|rightList
+   * @protected
+   */
+  _renderOptions(listName) {
+    this._clearOptions(listName);
+
+    this[listName]?.forEach(
+      /** @param {HTMLElement} el */ el => {
+        this[`${listName}Box`]?._inputNode?.appendChild(el);
+      },
+    );
+  }
+
+  /**
+   * transfer options between listboxes left to right or reverse
+   * @param {String} fromListName e.g. leftList|rightList
+   * @param {String} toListName e.g. leftList|rightList
+   * @protected
+   */
+  _transferingOptions(fromListName, toListName) {
+    const selected =
+      this[fromListName]?.filter(/** @param {ListOption} item */ item => item.checked) || [];
+
+    this[fromListName] =
+      this[fromListName]?.filter(/** @param {ListOption} item */ item => !item.checked) || [];
+    this.shouldTransfer = false;
+    selected.forEach(
+      /** @param {ListOption} element */ element => {
+        this.shouldTransfer = true;
+        element.checked = false; // eslint-disable-line no-param-reassign
+        element.active = false; // eslint-disable-line no-param-reassign
+      },
+    );
+
+    this[toListName] = [...this[toListName], ...selected];
+
+    if (this.shouldTransfer) {
+      this._renderOptions('leftList');
+      this._renderOptions('rightList');
+    }
+  }
+
+  /**
+   * remove the list options
+   * @param {String} listName name of the list e.g. leftList|rightList
+   * @protected
+   */
+  _clearOptions(listName) {
+    let lastChild = this[`${listName}Box`]?._inputNode?.lastChild;
+
+    while (lastChild) {
+      lastChild.remove();
+      lastChild = this[`${listName}Box`]?._inputNode?.lastChild;
+    }
+  }
+}

--- a/packages/transfer/test/lion-transfer.test.js
+++ b/packages/transfer/test/lion-transfer.test.js
@@ -1,0 +1,64 @@
+import { expect, fixture, html } from '@open-wc/testing';
+
+/** @typedef {{_inputNode:HTMLElement}} ListBox */
+// import sinon from 'sinon';
+import '../lion-transfer.js';
+// eslint-disable-next-line no-unused-vars
+
+describe('lion-transfer', () => {
+  /** @type {{leftListBox: ListBox, modelValue:{left:Array<string>, right:Array<string>},rightListBox: ListBox, leftList: Array<{checked: boolean}>, rightList: Array<{checked: boolean}>} & Element} element */
+  let element;
+
+  beforeEach(async () => {
+    element = await fixture(
+      html`<lion-transfer>
+        <div slot="leftList">
+          <lion-option .choiceValue="Apple">Apple</lion-option>
+          <lion-option .choiceValue="Artichoke">Artichoke</lion-option>
+          <lion-option .choiceValue="Asparagus">Asparagus</lion-option>
+        </div>
+        <button slot="transferToLeftActionSlot">To Left &lt;</button>
+        <button slot="transferToRightActionSlot">To Right &gt;</button>
+        <div slot="rightList">
+          <lion-option .choiceValue="Banana">Banana</lion-option>
+          <lion-option .choiceValue="Beets">Beets</lion-option>
+          <lion-option .choiceValue="Bell pepper">Bell pepper</lion-option>
+          <lion-option .choiceValue="Broccoli">Broccoli</lion-option>
+          <lion-option .choiceValue="Brussels sprout">Brussels sprout</lion-option>
+        </div>
+      </lion-transfer>`,
+    );
+  });
+
+  it('listBoxes should have provided options', () => {
+    expect(element.leftListBox._inputNode.children.length).to.be.equal(3);
+    expect(element.rightListBox._inputNode.children.length).to.be.equal(5);
+
+    expect(element.leftList.length).to.be.equal(3);
+    expect(element.rightList.length).to.be.equal(5);
+  });
+
+  it('select first option in left listboox and tranfer it to right listbox', () => {
+    element.leftList[0].checked = true; // Apple
+    const transferToRightAction = /** @type {HTMLElement} */ (element.shadowRoot?.querySelector(
+      'slot[name="transferToRightActionSlot"]',
+    ));
+    transferToRightAction?.click();
+
+    expect(element.leftList.length).to.be.equal(2);
+    expect(element.rightList.length).to.be.equal(6);
+    expect(element.modelValue.right[5]).to.equal('Apple');
+  });
+
+  it('select second option in right listboox and tranfer it to left listbox', () => {
+    element.rightList[1].checked = true; // Beets
+    const transferToLeftAction = /** @type {HTMLElement} */ (element.shadowRoot?.querySelector(
+      'slot[name="transferToLeftActionSlot"]',
+    ));
+    transferToLeftAction?.click();
+
+    expect(element.leftList.length).to.be.equal(4);
+    expect(element.rightList.length).to.be.equal(4);
+    expect(element.modelValue.left[3]).to.equal('Beets');
+  });
+});


### PR DESCRIPTION

 ## What I did
* introducing a brand new component which allows users to shift/transfer one or more items between lists
Idea initiated at https://github.com/ing-bank/lion/discussions/1149


## A working screenshot of storybook
<img width="495" alt="Screenshot 2021-02-19 at 4 11 39 PM" src="https://user-images.githubusercontent.com/25560921/108526143-15898f00-72d1-11eb-8448-50e2aadb640c.png">

## Test coverages
<img width="1586" alt="Screenshot 2021-02-19 at 4 11 01 PM" src="https://user-images.githubusercontent.com/25560921/108526174-1c180680-72d1-11eb-9a4d-6a4084695ed5.png">
