### PR TITLE
fix: overlay closed on mouseup

### DIFF
--- a/.changeset/forty-taxis-lay.md
+++ b/.changeset/forty-taxis-lay.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+fix: only close an overlay if both mousedown and mousep events are outside (for hidesOnOutsideClick)

--- a/docs/docs/systems/overlays/configuration.md
+++ b/docs/docs/systems/overlays/configuration.md
@@ -167,7 +167,8 @@ export const hidesOnOutsideClick = () => {
     <demo-overlay-system .config=${hidesOnOutsideClickConfig}>
       <button slot="invoker">Click me to open the overlay!</button>
       <div slot="content" class="demo-overlay">
-        Hello! You can close this notification here:
+        <label for="myInput">Clicking this label should not trigger close</label>
+        <input id="myInput" />
         <button
           class="close-button"
           @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}

--- a/packages/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/input-datepicker/test/lion-input-datepicker.test.js
@@ -2,6 +2,7 @@ import { LionCalendar, isSameDate } from '@lion/calendar';
 import { html, LitElement } from '@lion/core';
 import { IsDateDisabled, MaxDate, MinDate, MinMaxDate } from '@lion/form-core';
 import { aTimeout, defineCE, expect, fixture as _fixture, nextFrame } from '@open-wc/testing';
+import { mimicClick } from '@lion/overlays/test-helpers';
 import sinon from 'sinon';
 import { setViewport } from '@web/test-runner-commands';
 import '@lion/input-datepicker/define';
@@ -98,13 +99,13 @@ describe('<lion-input-datepicker>', () => {
       expect(elObj.overlayController.isShown).to.equal(false);
     });
 
-    it('closes the calendar via outside click', async () => {
+    it('closes the calendar via outside click event', async () => {
       const el = await fixture(html`<lion-input-datepicker></lion-input-datepicker>`);
       const elObj = new DatepickerInputObject(el);
       await elObj.openCalendar();
       expect(elObj.overlayController.isShown).to.equal(true);
 
-      document.body.click();
+      mimicClick(document.body);
       await aTimeout(0);
       expect(elObj.overlayController.isShown).to.be.false;
     });

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -53,6 +53,7 @@
     ".": "./index.js",
     "./test-suites": "./test-suites/index.js",
     "./translations/*": "./translations/*",
+    "./test-helpers": "./test-helpers.js",
     "./docs/": "./docs/"
   }
 }

--- a/packages/overlays/test-helpers.js
+++ b/packages/overlays/test-helpers.js
@@ -1,0 +1,1 @@
+export { mimicClick } from './test-helpers/mimicClick.js';

--- a/packages/overlays/test-helpers/mimicClick.js
+++ b/packages/overlays/test-helpers/mimicClick.js
@@ -1,0 +1,21 @@
+async function sleep(t = 0) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve(true);
+    }, t);
+  });
+}
+
+/**
+ * @param {HTMLElement} el
+ * @param {{isAsync?:boolean, releaseElement?: HTMLElement}} [config]
+ */
+export async function mimicClick(el, { isAsync, releaseElement } = { isAsync: false }) {
+  const releaseEl = releaseElement || el;
+  el.dispatchEvent(new MouseEvent('mousedown'));
+  if (isAsync) {
+    await sleep();
+  }
+  releaseEl.dispatchEvent(new MouseEvent('click'));
+  releaseEl.dispatchEvent(new MouseEvent('mouseup'));
+}

--- a/packages/select-rich/test/lion-select-rich.test.js
+++ b/packages/select-rich/test/lion-select-rich.test.js
@@ -2,6 +2,7 @@ import { LitElement } from '@lion/core';
 import { renderLitAsNode } from '@lion/helpers';
 import { OverlayController } from '@lion/overlays';
 import { LionOption } from '@lion/listbox';
+import { mimicClick } from '@lion/overlays/test-helpers';
 import {
   aTimeout,
   defineCE,
@@ -253,9 +254,8 @@ describe('lion-select-rich', () => {
       ));
 
       expect(el.opened).to.be.true;
-      // a click on the button will trigger hide on outside click
-      // which we then need to sync back to "opened"
-      outerEl.click();
+
+      mimicClick(outerEl);
       await aTimeout(0);
       expect(el.opened).to.be.false;
     });


### PR DESCRIPTION
## What I did

1. Updated Overlaycontroller to add/remove mousedown events instead of click for "outside clicks"
2. Added & updated relevant tests

fixes https://github.com/ing-bank/lion/issues/920