### PR TITLE
chore: add generic docs to core

### DIFF
--- a/.changeset/wet-rules-help.md
+++ b/.changeset/wet-rules-help.md
@@ -1,0 +1,5 @@
+---
+'@lion/core': patch
+---
+
+Added some default documentation pages that needs to be exported

--- a/packages/core/docs/components/index.md
+++ b/packages/core/docs/components/index.md
@@ -1,0 +1,3 @@
+# Components
+
+[=> See Source <=](../../../../docs/components/index.md)

--- a/packages/core/docs/docs/index.md
+++ b/packages/core/docs/docs/index.md
@@ -1,0 +1,3 @@
+# Documents
+
+[=> See Source <=](../../../../docs/docs/index.md)

--- a/packages/core/docs/docs/rationales/side-effects.md
+++ b/packages/core/docs/docs/rationales/side-effects.md
@@ -1,0 +1,3 @@
+# Side Effects
+
+[=> See Source <=](../../../../../docs/docs/rationales/side-effects.md)

--- a/packages/core/docs/rationales/side-effects.md
+++ b/packages/core/docs/rationales/side-effects.md
@@ -1,3 +1,0 @@
-# Side Effects
-
-[=> See Source <=](../../../../docs/docs/rationales/side-effects.md)


### PR DESCRIPTION
## What I did

1. Added `/docs/components/index.md` to `@lion/core`
2. Added `/docs/docs/index.md` to `@lion/core`
