### PR TITLE
Fix super.styles in the docs

### DIFF
--- a/docs/guides/how-to/get-started.md
+++ b/docs/guides/how-to/get-started.md
@@ -38,7 +38,7 @@ import { LionInput } from '@lion/input';
 class MyInput extends LionInput {
   static get styles() {
     return [
-      super.styles,
+      ...super.styles,
       css`
         /* your styles here */
       `,


### PR DESCRIPTION
## What I did

Fix `super.styles` in the docs

To avoid this kind of TS errors:

<img width="661" alt="Screenshot 2021-03-30 at 16 53 56" src="https://user-images.githubusercontent.com/1007051/113010622-4636d100-9179-11eb-95d7-3f4a09b11d3e.png">
