### PR TITLE
Feat/ajax concurrent fetch

### DIFF
--- a/.changeset/brave-tools-tie.md
+++ b/.changeset/brave-tools-tie.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+allow caching concurrent requests

--- a/.changeset/lucky-games-poke.md
+++ b/.changeset/lucky-games-poke.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+return cached status and headers

--- a/docs/docs/systems/form/formatting-and-parsing.md
+++ b/docs/docs/systems/form/formatting-and-parsing.md
@@ -157,9 +157,9 @@ In the example below, we do not allow you to write digits.
 
 ```js preview-story
 export const preprocessors = () => {
-  const preprocess = (value) => {
+  const preprocess = value => {
     return value.replace(/[0-9]/g, '');
-  }
+  };
   return html`
     <lion-input
       label="Date Example"

--- a/packages/ajax/test/interceptors-cache.test.js
+++ b/packages/ajax/test/interceptors-cache.test.js
@@ -491,5 +491,31 @@ describe('ajax cache', () => {
       ajaxRequestSpy.restore();
       removeCacheInterceptors(ajax, indexes);
     });
+
+    it('preserves status and headers when returning cached response', async () => {
+      newCacheId();
+      fetchStub.returns(
+        Promise.resolve(
+          new Response('mock response', { status: 206, headers: { 'x-foo': 'x-bar' } }),
+        ),
+      );
+
+      const indexes = addCacheInterceptors(ajax, {
+        useCache: true,
+        timeToLive: 100,
+      });
+      const ajaxRequestSpy = spy(ajax, 'request');
+
+      const response1 = await ajax.request('/test');
+      const response2 = await ajax.request('/test');
+      expect(fetchStub.callCount).to.equal(1);
+      expect(response1.status).to.equal(206);
+      expect(response1.headers.get('x-foo')).to.equal('x-bar');
+      expect(response2.status).to.equal(206);
+      expect(response2.headers.get('x-foo')).to.equal('x-bar');
+
+      ajaxRequestSpy.restore();
+      removeCacheInterceptors(ajax, indexes);
+    });
   });
 });


### PR DESCRIPTION
## What I did

1. Added support for caching when multiple requests are made concurrently. When two requests have caching enabled, the second will wait for the first to finish and then serve the response from cache. This fulfills a major use case for caching where multiple web components on the page need to fetch the same data. They can be implemented independently and rendered on the page at the same time, fetch data from the same endpoint with a short cache time to live (for instance 1 minute) and only result in one actual call to the backend when they are rendered on the page.

2. While implementing I noticed a bug where only the response text was cached. I fixed this by also caching things like status and headers.
