### PR TITLE
Apply all a11y improvements on new branch

### DIFF
--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -1,7 +1,9 @@
 body[layout='layout-home'] .markdown-body .call-to-action:nth-of-type(2) {
-  --primary-color: #222;
-  --primary-color-lighter: #555;
-  --primary-color-darker: #000;
+  background: linear-gradient(to right, #555, #222);
+}
+
+body[layout='layout-home'] .markdown-body .call-to-action:nth-of-type(2):hover {
+  background: #000;
 }
 
 body[layout='layout-home'] .markdown-body .call-to-action-listitem:nth-of-type(1) {

--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -6,16 +6,6 @@ body[layout='layout-home'] .markdown-body .call-to-action:nth-of-type(2):hover {
   background: #000;
 }
 
-body[layout='layout-home'] .markdown-body .call-to-action-listitem:nth-of-type(1) {
-  --primary-color: #8f7325;
-  --primary-color-darker: #725c1e;
-}
-
-#layout-index-open-navigation {
-  --primary-color: #8f7325;
-  --primary-color-darker: #725c1e;
-}
-
 .markdown-body img {
   width: 100%;
 }

--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -1,23 +1,53 @@
 body[layout='layout-home'] .markdown-body .call-to-action:nth-of-type(2) {
   --primary-color: #222;
-  --primary-color-lighter: #333;
+  --primary-color-lighter: #555;
   --primary-color-darker: #000;
+}
+
+body[layout='layout-home'] .markdown-body .call-to-action-listitem:nth-of-type(1) {
+  --primary-color: #8f7325;
+  --primary-color-darker: #725c1e;
+}
+
+#layout-index-open-navigation {
+  --primary-color: #8f7325;
+  --primary-color-darker: #725c1e;
 }
 
 .markdown-body img {
   width: 100%;
 }
 
+.markdown-body a {
+  text-decoration: underline;
+}
+
 mdjs-preview {
   margin-bottom: 20px;
 }
 
-#main-header a[href="/blog/"] {
+#main-header a {
+  font-weight: normal;
+}
+
+#main-header a.active {
+  font-weight: bold;
+}
+
+#main-header .active {
+  display: block;
+}
+
+#sidebar-nav {
+  padding: 2px;
+}
+
+#main-header a[href='/blog/'] {
   display: none;
 }
 
 @media screen and (min-width: 1024px) {
-  #main-header a[href="/blog/"] {
+  #main-header a[href='/blog/'] {
     display: block;
   }
 }

--- a/docs/_assets/variables.css
+++ b/docs/_assets/variables.css
@@ -1,7 +1,7 @@
 html {
   --primary-color: #8f7325;
   --primary-color-lighter: #8f7325;
-  --primary-color-darker: #705918;
+  --primary-color-darker: #725c1e;
   --primary-color-accent: #cee5f6;
   --primary-text-color: #2c3e50;
   --primary-lines-color: #ccc;

--- a/docs/_assets/variables.css
+++ b/docs/_assets/variables.css
@@ -1,6 +1,6 @@
 html {
   --primary-color: #8f7325;
-  --primary-color-lighter: #d1a62f;
+  --primary-color-lighter: #8f7325;
   --primary-color-darker: #705918;
   --primary-color-accent: #cee5f6;
   --primary-text-color: #2c3e50;
@@ -15,27 +15,7 @@ html {
   --footer-background: rgba(0, 0, 0, 0.1);
 
   --text-color: black;
-}
 
-html.dark {
-  --primary-color: #e63946;
-  --primary-color-lighter: #e25761;
-  --primary-color-darker: #a22831;
-  --primary-color-accent: #cee5f6;
-  --primary-text-color: #eee;
-
-  /* Contrast colors */
-  --contrast-color-light: #fff;
-  --contrast-color-dark: #1d3557;
-
-  /* background-colors */
-  --page-background: #333;
-  --footer-background: #4f4f4f;
-
-  --text-color: white;
-
-  --markdown-octicon-link: white;
-  --markdown-syntax-background-color: #a0a0a0;
-  --markdown-link-color: #fb7881;
-  --markdown-blockquote-color: #c9e3ff;
+  /* search colors*/
+  --rocket-search-highlight-color: #2c3e50;
 }


### PR DESCRIPTION
## What I did

1. [x] P: Purple on white gives a contrast ratio of 4.3:1. On grey it's 3.7:1. That's less than the required 4.5:1 for small text P: Found text is using color only to be recognized. S: Make it bold
2. [x] P: Image in search has no alt (invalid HTML) S: Set alt to function of image (search)
3. [x] P: Accessible name: "rocket search". S: Change name to search
4. [x] P: There's no indication of the current page. S: Use aria-current and different styling on the current page
5. [x] P: Focus on logo-link practically invisible S: Add padding 2px to sidebar-nav.
6. [x] P: The follow guides-link (CTA) has small text and a contrast ratio of less than 4.5:1 with the background. S: Pick a different color combination.
7. [x] P: "see components" does not have a visual focus state S: Change styling to have a visual focus state.
8. [x] P: Link in the page are only recognizable by color. S: Underline links - links are actually underlined on hover
