### PR TITLE
feat(form-core): support paste functionality in FormatMixin

### DIFF
--- a/.changeset/friendly-pianos-pay.md
+++ b/.changeset/friendly-pianos-pay.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-amount': patch
+---
+
+always format on paste

--- a/.changeset/wicked-games-dress.md
+++ b/.changeset/wicked-games-dress.md
@@ -1,0 +1,5 @@
+---
+'@lion/form-core': minor
+---
+
+support paste functionality in FormatMixin

--- a/docs/components/inputs/input-amount/features.md
+++ b/docs/components/inputs/input-amount/features.md
@@ -107,7 +107,7 @@ export const noDecimals = () => html`
 For copy pasting numbers into the input-amount, there is slightly different parsing behavior.
 
 Normally, when it receives an input with only 1 separator character, we check the locale to determine whether this character is a thousand separator, or a decimal separator.
-When a user pastes the input from a different source, we find this approach (locale-based) quite unreliable, because it may have been copied from somewhere with a different locale.
+When a user pastes the input from a different source, we find this approach (locale-based) quite unreliable, because it may have been copied from a 'mathematical context' (like an Excel sheet) or a context with a different locale.
 Therefore, we use the heuristics based method to parse the input when it is pasted by the user.
 
 ### What this means

--- a/packages/form-core/src/FormatMixin.js
+++ b/packages/form-core/src/FormatMixin.js
@@ -434,8 +434,8 @@ const FormatMixinImplementation = superclass =>
        * Whether the user is pasting content. Allows Subclassers to do this in their subclass:
        * @example
        * ```js
-       * _reflectBackFormattedValueToUser() {
-       *   return super._reflectBackFormattedValueToUser() || this._isPasting;
+       * _reflectBackOn() {
+       *   return super._reflectBackOn() || this._isPasting;
        * }
        * ```
        * @protected

--- a/packages/form-core/src/NativeTextFieldMixin.js
+++ b/packages/form-core/src/NativeTextFieldMixin.js
@@ -1,6 +1,7 @@
 import { dedupeMixin } from '@lion/core';
 import { FormControlMixin } from './FormControlMixin.js';
 import { FocusMixin } from './FocusMixin.js';
+import { FormatMixin } from './FormatMixin.js';
 
 /**
  * @typedef {import('../types/NativeTextFieldMixinTypes').NativeTextFieldMixin} NativeTextFieldMixin
@@ -8,7 +9,7 @@ import { FocusMixin } from './FocusMixin.js';
  * @param {import('@open-wc/dedupe-mixin').Constructor<import('@lion/core').LitElement>} superclass} superclass
  */
 const NativeTextFieldMixinImplementation = superclass =>
-  class NativeTextFieldMixin extends FocusMixin(FormControlMixin(superclass)) {
+  class NativeTextFieldMixin extends FormatMixin(FocusMixin(FormControlMixin(superclass))) {
     /**
      * @protected
      * @type {HTMLInputElement | HTMLTextAreaElement}
@@ -93,6 +94,20 @@ const NativeTextFieldMixinImplementation = superclass =>
         }
       } else {
         this._inputNode.value = newValue;
+      }
+    }
+
+    /**
+     * @override FormatMixin
+     */
+    _reflectBackFormattedValueToUser() {
+      super._reflectBackFormattedValueToUser();
+      if (this._reflectBackOn() && this.focused) {
+        try {
+          // try/catch, because Safari is a bit sensitive here
+          this._inputNode.selectionStart = this._inputNode.value.length;
+          // eslint-disable-next-line no-empty
+        } catch (_) {}
       }
     }
   };

--- a/packages/form-core/types/FormatMixinTypes.d.ts
+++ b/packages/form-core/types/FormatMixinTypes.d.ts
@@ -1,5 +1,5 @@
 import { Constructor } from '@open-wc/dedupe-mixin';
-import { LitElement } from '@lion/core';
+import { BooleanAttributePart, LitElement } from '@lion/core';
 import { FormatNumberOptions } from '@lion/localize/types/LocalizeMixinTypes';
 import { ValidateHost } from './validate/ValidateMixinTypes';
 import { FormControlHost } from './FormControlMixinTypes';
@@ -18,6 +18,16 @@ export declare class FormatHost {
   set value(value: string);
 
   protected _isHandlingUserInput: boolean;
+  /**
+   * Whether the user is pasting content. Allows Subclassers to do this in their subclass:
+   * @example
+   * ```js
+   * _reflectBackFormattedValueToUser() {
+   *   return super._reflectBackFormattedValueToUser() || this._isPasting;
+   * }
+   * ```
+   */
+  protected _isPasting: boolean;
   protected _calculateValues(opts: { source: 'model' | 'serialized' | 'formatted' | null }): void;
   protected _onModelValueChanged(arg: { modelValue: unknown }): void;
   protected _dispatchModelValueChangedEvent(): void;
@@ -31,6 +41,7 @@ export declare class FormatHost {
   protected _callFormatter(): string;
 
   private __preventRecursiveTrigger: boolean;
+  private __prevViewValue: string;
 }
 
 export declare function FormatImplementation<T extends Constructor<LitElement>>(

--- a/packages/form-core/types/NativeTextFieldMixinTypes.d.ts
+++ b/packages/form-core/types/NativeTextFieldMixinTypes.d.ts
@@ -2,6 +2,7 @@ import { Constructor } from '@open-wc/dedupe-mixin';
 import { LitElement } from '@lion/core';
 import { FocusHost } from '@lion/form-core/types/FocusMixinTypes';
 import { FormControlHost } from '@lion/form-core/types/FormControlMixinTypes';
+import { FormatHost } from '@lion/form-core/types/FormatMixinTypes';
 
 export declare class NativeTextFieldHost {
   get selectionStart(): number;
@@ -15,6 +16,8 @@ export declare function NativeTextFieldImplementation<T extends Constructor<LitE
 ): T &
   Constructor<NativeTextFieldHost> &
   Pick<typeof NativeTextFieldHost, keyof typeof NativeTextFieldHost> &
+  Constructor<FormatHost> &
+  Pick<typeof FormatHost, keyof typeof FormatHost> &
   Constructor<FocusHost> &
   Pick<typeof FocusHost, keyof typeof FocusHost> &
   Constructor<FormControlHost> &

--- a/packages/input-amount/src/LionInputAmount.js
+++ b/packages/input-amount/src/LionInputAmount.js
@@ -68,16 +68,6 @@ export class LionInputAmount extends LocalizeMixin(LionInput) {
     this.formatter = formatAmount;
     /** @type {string | undefined} */
     this.currency = undefined;
-    /** @private */
-    this.__isPasting = false;
-
-    this.addEventListener('paste', () => {
-      /** @private */
-      this.__isPasting = true;
-      /** @private */
-      this.__parserCallcountSincePaste = 0;
-    });
-
     this.defaultValidators.push(new IsNumber());
   }
 
@@ -101,24 +91,12 @@ export class LionInputAmount extends LocalizeMixin(LionInput) {
   }
 
   /**
-   * @override of FormatMixin
-   * @protected
-   */
-  _callParser(value = this.formattedValue) {
-    // TODO: (@daKmor) input and change events both trigger parsing therefore we need to handle the second parse
-    this.__parserCallcountSincePaste += 1;
-    this.__isPasting = this.__parserCallcountSincePaste === 2;
-    this.formatOptions.mode = this.__isPasting === true ? 'pasted' : 'auto';
-    // @ts-ignore [allow-protected]
-    return super._callParser(value);
-  }
-
-  /**
-   * @override of FormatMixin
+   * @enhance FormatMixin: instead of only formatting on blur, also format when a user pasted
+   * content
    * @protected
    */
   _reflectBackOn() {
-    return super._reflectBackOn() || this.__isPasting;
+    return super._reflectBackOn() || this._isPasting;
   }
 
   /**


### PR DESCRIPTION
closes https://github.com/ing-bank/lion/issues/404
(fixing 404s...)

![instantFormatOnPaste](https://user-images.githubusercontent.com/13814138/115360057-8ceb7a00-a1bf-11eb-8043-11410480559b.gif)

Pasted “400,0” gets instantly formatted


