### PR TITLE
Typo in `mulipleChoice`

### DIFF
--- a/docs/docs/systems/form/features.md
+++ b/docs/docs/systems/form/features.md
@@ -128,7 +128,7 @@ export const main = () => {
           label="Input range"
         ></lion-input-range>
         <lion-checkbox-group
-          .mulipleChoice="${false}"
+          .multipleChoice="${false}"
           name="terms"
           .validators="${[new Required()]}"
         >


### PR DESCRIPTION
I was seeking for exactly this example, just noticed it. Thanks for the Umbrella form, it's really valuable :) 