### PR TITLE
fix(providence): add entries for debugging

### DIFF
--- a/.changeset/dull-geckos-fail.md
+++ b/.changeset/dull-geckos-fail.md
@@ -2,4 +2,5 @@
 'providence-analytics': patch
 ---
 
-Enable debug logs in analyzers
+- enable debug logs in analyzers
+- export QueryService

--- a/.changeset/dull-geckos-fail.md
+++ b/.changeset/dull-geckos-fail.md
@@ -1,0 +1,5 @@
+---
+'providence-analytics': patch
+---
+
+Enable debug logs in analyzers

--- a/packages-node/providence-analytics/index.js
+++ b/packages-node/providence-analytics/index.js
@@ -1,0 +1,2 @@
+export { providence } from './src/program/providence.js';
+export { QueryService } from './src/program/services/QueryService.js';

--- a/packages-node/providence-analytics/package.json
+++ b/packages-node/providence-analytics/package.json
@@ -69,7 +69,7 @@
     "access": "public"
   },
   "exports": {
-    ".": "./src/program/providence.js",
+    ".": "./index.js",
     "./src/cli": "./src/cli/index.js",
     "./analyzers": "./src/program/analyzers/index.js",
     "./docs/": "./docs/"

--- a/packages-node/providence-analytics/src/program/analyzers/find-exports.js
+++ b/packages-node/providence-analytics/src/program/analyzers/find-exports.js
@@ -5,6 +5,7 @@ const { Analyzer } = require('./helpers/Analyzer.js');
 const { trackDownIdentifier } = require('./helpers/track-down-identifier.js');
 const { normalizeSourcePaths } = require('./helpers/normalize-source-paths.js');
 const { aForEach } = require('../utils/async-array-utils.js');
+const { LogService } = require('../services/LogService.js');
 
 /** @typedef {import('./helpers/track-down-identifier.js').RootFile} RootFile */
 
@@ -136,6 +137,8 @@ function getLocalNameSpecifiers(node) {
  * @param {FindExportsConfig} config
  */
 function findExportsPerAstEntry(ast, { skipFileImports }) {
+  LogService.debug(`Analyzer "find-exports": started findExportsPerAstEntry method`);
+
   // Visit AST...
   const transformedEntry = [];
   // Unfortunately, we cannot have async functions in babel traverse.

--- a/packages-node/providence-analytics/src/program/analyzers/find-imports.js
+++ b/packages-node/providence-analytics/src/program/analyzers/find-imports.js
@@ -3,6 +3,7 @@ const { default: traverse } = require('@babel/traverse');
 const { isRelativeSourcePath } = require('../utils/relative-source-path.js');
 const { normalizeSourcePaths } = require('./helpers/normalize-source-paths.js');
 const { Analyzer } = require('./helpers/Analyzer.js');
+const { LogService } = require('../services/LogService.js');
 
 /**
  * Options that allow to filter 'on a file basis'.
@@ -45,6 +46,8 @@ function getImportOrReexportsSpecifiers(node) {
  * @param {string} context.relativePath the file being currently processed
  */
 function findImportsPerAstEntry(ast) {
+  LogService.debug(`Analyzer "find-imports": started findImportsPerAstEntry method`);
+
   // Visit AST...
   const transformedEntry = [];
   traverse(ast, {

--- a/packages-node/providence-analytics/src/program/analyzers/helpers/Analyzer.js
+++ b/packages-node/providence-analytics/src/program/analyzers/helpers/Analyzer.js
@@ -180,6 +180,7 @@ class Analyzer {
    * @returns {CachedAnalyzerResult|undefined}
    */
   _prepare(cfg) {
+    LogService.debug(`Analyzer "${this.name}": started _prepare method`);
     this.constructor.__unwindProvidedResults(cfg);
 
     if (!cfg.targetProjectResult) {
@@ -264,6 +265,8 @@ class Analyzer {
    * @returns {AnalyzerResult}
    */
   _finalize(queryOutput, cfg) {
+    LogService.debug(`Analyzer "${this.name}": started _finalize method`);
+
     const analyzerResult = ensureAnalyzerResultFormat(queryOutput, cfg, this);
     LogService.success(`finished ${LogService.pad(this.name, 16)} for ${this.identifier}`);
     return analyzerResult;
@@ -273,6 +276,8 @@ class Analyzer {
    * @param {function} traverseEntry
    */
   async _traverse(traverseEntry) {
+    LogService.debug(`Analyzer "${this.name}": started _traverse method`);
+
     /**
      * Create ASTs for our inputData
      */
@@ -281,6 +286,8 @@ class Analyzer {
   }
 
   async execute(customConfig = {}) {
+    LogService.debug(`Analyzer "${this.name}": started execute method`);
+
     const cfg = {
       targetProjectPath: null,
       referenceProjectPath: null,

--- a/packages-node/providence-analytics/src/program/services/QueryService.js
+++ b/packages-node/providence-analytics/src/program/services/QueryService.js
@@ -176,6 +176,7 @@ class QueryService {
    * @returns {QueryResult}
    */
   static async astSearch(queryConfig, customConfig) {
+    LogService.debug('started astSearch method');
     if (queryConfig.type !== 'analyzer') {
       LogService.error('Only analyzers supported for ast searches at the moment');
       process.exit(1);


### PR DESCRIPTION
When boolean `isDebugEnabled` is provided to main providence method, you will see the path it traverses within analyzers in your console