### PR TITLE
feat(form-core): add [focused-visible] when matching :focus-visible

### DIFF
--- a/.changeset/short-llamas-share.md
+++ b/.changeset/short-llamas-share.md
@@ -1,0 +1,5 @@
+---
+'@lion/form-core': patch
+---
+
+support [focused-visible] when focusable node within matches :focus-visible

--- a/packages/form-core/src/LionField.js
+++ b/packages/form-core/src/LionField.js
@@ -106,4 +106,11 @@ export class LionField extends FormControlMixin(
   get _feedbackConditionMeta() {
     return { ...super._feedbackConditionMeta, focused: this.focused };
   }
+
+  /**
+   * @configure FocusMixin
+   */
+  get _focusableNode() {
+    return this._inputNode;
+  }
 }

--- a/packages/form-core/src/NativeTextFieldMixin.js
+++ b/packages/form-core/src/NativeTextFieldMixin.js
@@ -110,6 +110,13 @@ const NativeTextFieldMixinImplementation = superclass =>
         } catch (_) {}
       }
     }
+
+    /**
+     * @configure FocusMixin
+     */
+    get _focusableNode() {
+      return this._inputNode;
+    }
   };
 
 export const NativeTextFieldMixin = dedupeMixin(NativeTextFieldMixinImplementation);

--- a/packages/form-core/test/FocusMixin.test.js
+++ b/packages/form-core/test/FocusMixin.test.js
@@ -1,12 +1,72 @@
 import { LitElement } from '@lion/core';
 import { defineCE, expect, fixture, html, oneEvent, unsafeStatic } from '@open-wc/testing';
-import { getFormControlMembers } from '@lion/form-core/test-helpers';
+import sinon from 'sinon';
 import { FocusMixin } from '../src/FocusMixin.js';
+
+const windowWithOptionalPolyfill = /** @type {Window & typeof globalThis & {applyFocusVisiblePolyfill?: function}} */ (window);
+
+/**
+ * Checks two things:
+ * 1. whether focus-visible should apply (if focus and keyboard interaction present)
+ * 2. whether the polyfill is used or not
+ * When the polyfill is used, it mocks `.hasAttribute` method, otherwise `.matches` method
+ * of focusable element.
+ * @param {HTMLElement} focusableEl focusable element
+ * @param {{phase: 'focusin'|'focusout', hasKeyboardInteraction: boolean }} options
+ * @returns {function} restore function
+ */
+function mockFocusVisible(focusableEl, { phase, hasKeyboardInteraction }) {
+  const focusVisibleApplies = phase === 'focusin' && hasKeyboardInteraction;
+  if (!focusVisibleApplies) {
+    return () => {};
+  }
+
+  /** @type {any} */
+  const originalMatches = focusableEl.matches;
+  if (typeof windowWithOptionalPolyfill.applyFocusVisiblePolyfill !== 'function') {
+    // eslint-disable-next-line no-param-reassign
+    focusableEl.matches = selector =>
+      selector === ':focus-visible' || originalMatches.call(focusableEl, selector);
+    return () => {
+      // eslint-disable-next-line no-param-reassign
+      focusableEl.matches = originalMatches;
+    };
+  }
+
+  const originalHasAttribute = focusableEl.hasAttribute;
+  // eslint-disable-next-line no-param-reassign
+  focusableEl.hasAttribute = attr =>
+    attr === 'data-focus-visible-added' || originalHasAttribute.call(focusableEl, attr);
+  return () => {
+    // eslint-disable-next-line no-param-reassign
+    focusableEl.hasAttribute = originalHasAttribute;
+  };
+}
+
+/**
+ * @returns {function} restore function
+ */
+function mockPolyfill() {
+  const originalApplyFocusVisiblePolyfill = windowWithOptionalPolyfill.applyFocusVisiblePolyfill;
+  // @ts-ignore
+  window.applyFocusVisiblePolyfill = () => {};
+  return () => {
+    // @ts-ignore
+    window.applyFocusVisiblePolyfill = originalApplyFocusVisiblePolyfill;
+  };
+}
 
 describe('FocusMixin', () => {
   class Focusable extends FocusMixin(LitElement) {
     render() {
       return html`<slot name="input"></slot>`;
+    }
+
+    /**
+     * @configure FocusMixin
+     */
+    get _focusableNode() {
+      return /** @type {HTMLInputElement} */ (this.querySelector('input'));
     }
   }
 
@@ -17,12 +77,13 @@ describe('FocusMixin', () => {
     const el = /** @type {Focusable} */ (await fixture(html`
       <${tag}><input slot="input"></${tag}>
     `));
-    const { _inputNode } = getFormControlMembers(el);
+    // @ts-ignore [allow-protected] in test
+    const { _focusableNode } = el;
 
     el.focus();
-    expect(document.activeElement === _inputNode).to.be.true;
+    expect(document.activeElement === _focusableNode).to.be.true;
     el.blur();
-    expect(document.activeElement === _inputNode).to.be.false;
+    expect(document.activeElement === _focusableNode).to.be.false;
   });
 
   it('has an attribute focused when focused', async () => {
@@ -43,12 +104,13 @@ describe('FocusMixin', () => {
     const el = /** @type {Focusable} */ (await fixture(html`
       <${tag}><input slot="input"></${tag}>
     `));
-    const { _inputNode } = getFormControlMembers(el);
+    // @ts-ignore [allow-protected] in test
+    const { _focusableNode } = el;
 
     expect(el.focused).to.be.false;
-    _inputNode?.focus();
+    _focusableNode?.focus();
     expect(el.focused).to.be.true;
-    _inputNode?.blur();
+    _focusableNode?.blur();
     expect(el.focused).to.be.false;
   });
 
@@ -94,5 +156,156 @@ describe('FocusMixin', () => {
     expect(focusoutEv.target).to.equal(el);
     expect(focusoutEv.bubbles).to.be.true;
     expect(focusoutEv.composed).to.be.true;
+  });
+
+  describe('Having :focus-visible within', () => {
+    it('sets focusedVisible to true when focusable element matches :focus-visible', async () => {
+      const el = /** @type {Focusable} */ (await fixture(html`
+      <${tag}><input slot="input"></${tag}>
+    `));
+      // @ts-ignore [allow-protected] in test
+      const { _focusableNode } = el;
+
+      const restoreMock1 = mockFocusVisible(_focusableNode, {
+        phase: 'focusout',
+        hasKeyboardInteraction: true,
+      });
+      _focusableNode.dispatchEvent(new Event('focusout', { bubbles: true, composed: true }));
+      await el.updateComplete;
+      expect(el.focusedVisible).to.be.false;
+      restoreMock1();
+
+      const restoreMock2 = mockFocusVisible(_focusableNode, {
+        phase: 'focusin',
+        hasKeyboardInteraction: false,
+      });
+      _focusableNode.dispatchEvent(new Event('focusin', { bubbles: true, composed: true }));
+      await el.updateComplete;
+      expect(el.focusedVisible).to.be.false;
+      restoreMock2();
+
+      const restoreMock3 = mockFocusVisible(_focusableNode, {
+        phase: 'focusout',
+        hasKeyboardInteraction: false,
+      });
+      _focusableNode.dispatchEvent(new Event('focusout', { bubbles: true, composed: true }));
+      await el.updateComplete;
+      expect(el.focusedVisible).to.be.false;
+      restoreMock3();
+
+      const restoreMock4 = mockFocusVisible(_focusableNode, {
+        phase: 'focusin',
+        hasKeyboardInteraction: true,
+      });
+      _focusableNode.dispatchEvent(new Event('focusin', { bubbles: true, composed: true }));
+      await el.updateComplete;
+      expect(el.focusedVisible).to.be.true;
+      restoreMock4();
+    });
+
+    it('has an attribute focused-visible when focusedVisible is true', async () => {
+      const el = /** @type {Focusable} */ (await fixture(html`
+      <${tag}><input slot="input"></${tag}>
+    `));
+      // @ts-ignore [allow-protected] in test
+      const { _focusableNode } = el;
+
+      const restoreMock1 = mockFocusVisible(_focusableNode, {
+        phase: 'focusout',
+        hasKeyboardInteraction: true,
+      });
+      _focusableNode.dispatchEvent(new Event('focusout', { bubbles: true, composed: true }));
+      await el.updateComplete;
+      expect(el.hasAttribute('focused-visible')).to.be.false;
+      restoreMock1();
+
+      const restoreMock2 = mockFocusVisible(_focusableNode, {
+        phase: 'focusin',
+        hasKeyboardInteraction: true,
+      });
+      _focusableNode.dispatchEvent(new Event('focusin', { bubbles: true, composed: true }));
+      await el.updateComplete;
+      expect(el.hasAttribute('focused-visible')).to.be.true;
+      restoreMock2();
+    });
+
+    // For polyfill, see https://github.com/WICG/focus-visible
+    describe('Using polyfill', () => {
+      const restoreMockPolyfill = mockPolyfill();
+      after(() => {
+        restoreMockPolyfill();
+      });
+
+      it('calls polyfill once per node', async () => {
+        class UniqueHost extends LitElement {
+          render() {
+            return html`<${tag}><input slot="input"></${tag}><${tag}><input slot="input"></${tag}>`;
+          }
+        }
+        const hostTagString = defineCE(UniqueHost);
+        const hostTag = unsafeStatic(hostTagString);
+
+        const polySpy = sinon.spy(windowWithOptionalPolyfill, 'applyFocusVisiblePolyfill');
+        await fixture(html`<${hostTag}></${hostTag}>`);
+        expect(polySpy).to.have.been.calledOnce;
+      });
+
+      it('sets focusedVisible to true when focusable element if :focus-visible polyfill is loaded', async () => {
+        const el = /** @type {Focusable} */ (await fixture(html`
+        <${tag}><input slot="input"></${tag}>
+      `));
+
+        // @ts-ignore [allow-protected] in test
+        const { _focusableNode } = el;
+
+        const restoreMock1 = mockFocusVisible(_focusableNode, {
+          phase: 'focusout',
+          hasKeyboardInteraction: true,
+        });
+        const spy1 = sinon.spy(_focusableNode, 'hasAttribute');
+        _focusableNode.dispatchEvent(new Event('focusout', { bubbles: true, composed: true }));
+        await el.updateComplete;
+        expect(el.focusedVisible).to.be.false;
+        expect(spy1).to.not.have.been.calledWith('data-focus-visible-added');
+        spy1.restore();
+        restoreMock1();
+
+        const restoreMock2 = mockFocusVisible(_focusableNode, {
+          phase: 'focusin',
+          hasKeyboardInteraction: false,
+        });
+        const spy2 = sinon.spy(_focusableNode, 'hasAttribute');
+        _focusableNode.dispatchEvent(new Event('focusin', { bubbles: true, composed: true }));
+        await el.updateComplete;
+        expect(el.focusedVisible).to.be.false;
+        expect(spy2).to.have.been.calledWith('data-focus-visible-added');
+        spy2.restore();
+        restoreMock2();
+
+        const restoreMock3 = mockFocusVisible(_focusableNode, {
+          phase: 'focusout',
+          hasKeyboardInteraction: false,
+        });
+        const spy3 = sinon.spy(_focusableNode, 'hasAttribute');
+        _focusableNode.dispatchEvent(new Event('focusout', { bubbles: true, composed: true }));
+        await el.updateComplete;
+        expect(el.focusedVisible).to.be.false;
+        expect(spy3).to.not.have.been.calledWith('data-focus-visible-added');
+        spy3.restore();
+        restoreMock3();
+
+        const restoreMock4 = mockFocusVisible(_focusableNode, {
+          phase: 'focusin',
+          hasKeyboardInteraction: true,
+        });
+        const spy4 = sinon.spy(_focusableNode, 'hasAttribute');
+        _focusableNode.dispatchEvent(new Event('focusin', { bubbles: true, composed: true }));
+        await el.updateComplete;
+        expect(el.focusedVisible).to.be.true;
+        expect(spy4).to.have.been.called;
+        spy4.restore();
+        restoreMock4();
+      });
+    });
   });
 });

--- a/packages/form-core/test/FormControlMixin.test.js
+++ b/packages/form-core/test/FormControlMixin.test.js
@@ -161,7 +161,14 @@ describe('FormControlMixin', () => {
         const groupTag = unsafeStatic(groupTagString);
 
         const focusableTagString = defineCE(
-          class extends FocusMixin(FormControlMixin(LitElement)) {},
+          class extends FocusMixin(FormControlMixin(LitElement)) {
+            /**
+             * @configure FocusMixin
+             */
+            get _focusableNode() {
+              return this._inputNode;
+            }
+          },
         );
         const focusableTag = unsafeStatic(focusableTagString);
 

--- a/packages/form-core/types/FocusMixinTypes.d.ts
+++ b/packages/form-core/types/FocusMixinTypes.d.ts
@@ -1,11 +1,32 @@
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { LitElement } from '@lion/core';
-import { FormControlHost } from './FormControlMixinTypes';
 
 export declare class FocusHost {
+  /**
+   * Whether the focusable element within (`._focusableNode`) is focused.
+   * Reflects to attribute '[focused]' as a styling hook
+   */
   focused: boolean;
+  /**
+   * Whether the focusable element within (`._focusableNode`) matches ':focus-visible'
+   * Reflects to attribute '[focused-visible]' as a styling hook
+   * @see https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
+   */
+  focusedVisible: boolean;
+  /**
+   * Calls `focus()` on focusable element within
+   */
   focus(): void;
+  /**
+   * Calls `blur()` on focusable element within
+   */
   blur(): void;
+
+  /**
+   * The focusable element:
+   * could be an input, textarea, select, button or any other element with tabindex > -1
+   */
+  protected get _focusableNode(): HTMLElement;
 
   private __onFocus(): void;
   private __onBlur(): void;
@@ -18,8 +39,6 @@ export declare function FocusImplementation<T extends Constructor<LitElement>>(
 ): T &
   Constructor<FocusHost> &
   Pick<typeof FocusHost, keyof typeof FocusHost> &
-  Constructor<FormControlHost> &
-  Pick<typeof FormControlHost, keyof typeof FormControlHost> &
   Pick<typeof LitElement, keyof typeof LitElement>;
 
 export type FocusMixin = typeof FocusImplementation;

--- a/packages/listbox/src/LionListbox.js
+++ b/packages/listbox/src/LionListbox.js
@@ -17,4 +17,11 @@ export class LionListbox extends ListboxMixin(
   get _feedbackConditionMeta() {
     return { ...super._feedbackConditionMeta, focused: this.focused };
   }
+
+  /**
+   * @configure FocusMixin
+   */
+  get _focusableNode() {
+    return this._inputNode;
+  }
 }


### PR DESCRIPTION
closes https://github.com/ing-bank/lion/issues/1206

Basically, leaves the choice to do progressive enhancement to the consumer:
- for progressive enhancement, do nothing
- otherwise, just load the polyfill in the index of your app
