### PR TITLE
wip: allow disabled dates in current month view

### DIFF
--- a/packages/calendar/src/calendarStyle.js
+++ b/packages/calendar/src/calendarStyle.js
@@ -15,6 +15,7 @@ export const calendarStyle = css`
 
   .calendar__navigation {
     padding: 0 8px;
+    align-items: center;
   }
 
   .calendar__navigation__month,
@@ -24,6 +25,7 @@ export const calendarStyle = css`
 
   .calendar__navigation-heading {
     margin: 0.5em 0;
+    font-weight: bold;
   }
 
   .calendar__previous-button,
@@ -54,6 +56,11 @@ export const calendarStyle = css`
     padding: 0;
     min-width: 40px;
     min-height: 40px;
+    /** give div[role=button][aria-disabled] same display type as native btn */
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
   }
 
   .calendar__day-button__text {
@@ -74,12 +81,17 @@ export const calendarStyle = css`
   }
 
   .calendar__day-button:hover {
-    border: 1px solid green;
+    border: 1px solid lightgray;
   }
 
   .calendar__day-button[disabled] {
     background-color: #fff;
     color: #eee;
+    outline: none;
+  }
+
+  .calendar__day-button:focus {
+    border: 1px solid blue;
     outline: none;
   }
 `;

--- a/packages/calendar/src/utils/dayTemplate.js
+++ b/packages/calendar/src/utils/dayTemplate.js
@@ -56,24 +56,50 @@ export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }
       ?start-of-last-week=${startOfLastWeek}
       ?last-day=${lastDay}
     >
-      <button
-        .date=${day.date}
-        class="calendar__day-button"
-        tabindex=${ifDefined(day.tabindex)}
-        aria-label=${`${dayNumber} ${monthName} ${year} ${weekdayName}`}
-        aria-pressed=${ifDefined(day.ariaPressed)}
-        aria-current=${ifDefined(day.ariaCurrent)}
-        ?disabled=${day.disabled}
-        ?selected=${day.selected}
-        ?past=${day.past}
-        ?today=${day.today}
-        ?future=${day.future}
-        ?previous-month=${day.previousMonth}
-        ?current-month=${day.currentMonth}
-        ?next-month=${day.nextMonth}
-      >
-        <span class="calendar__day-button__text"> ${day.date.getDate()} </span>
-      </button>
+      ${!day.disabled
+        ? html` <button
+            .date=${day.date}
+            class="calendar__day-button"
+            tabindex=${ifDefined(day.tabindex)}
+            aria-label=${`${dayNumber} ${monthName} ${year} ${weekdayName}`}
+            aria-pressed=${ifDefined(day.ariaPressed)}
+            aria-current=${ifDefined(day.ariaCurrent)}
+            ?disabled=${day.disabled}
+            ?selected=${day.selected}
+            ?past=${day.past}
+            ?today=${day.today}
+            ?future=${day.future}
+            ?previous-month=${day.previousMonth}
+            ?current-month=${day.currentMonth}
+            ?next-month=${day.nextMonth}
+          >
+            <span class="calendar__day-button__text" aria-hidden="true">
+              ${day.date.getDate()}
+            </span>
+          </button>`
+        : html`
+            <div
+              role="button"
+              .date=${day.date}
+              class="calendar__day-button"
+              tabindex=${ifDefined(day.tabindex)}
+              aria-label=${`disabled, ${dayNumber} ${monthName} ${year} ${weekdayName}`}
+              aria-pressed=${ifDefined(day.ariaPressed)}
+              ?disabled=${day.disabled}
+              aria-disabled=${day.disabled ? 'true' : 'false'}
+              ?selected=${day.selected}
+              ?past=${day.past}
+              ?today=${day.today}
+              ?future=${day.future}
+              ?previous-month=${day.previousMonth}
+              ?current-month=${day.currentMonth}
+              ?next-month=${day.nextMonth}
+            >
+              <span class="calendar__day-button__text" aria-hidden="true">
+                ${day.date.getDate()}
+              </span>
+            </div>
+          `}
     </td>
   `;
 }

--- a/packages/calendar/types/day.d.ts
+++ b/packages/calendar/types/day.d.ts
@@ -12,7 +12,7 @@ export declare interface Day {
   future?: boolean;
   disabled?: boolean;
   tabindex?: string;
-  ariaPressed?: string;
+  ariaPressed?: 'true' | 'false' | 'mixed' | 'undefined';
   ariaCurrent?: string | undefined;
 }
 


### PR DESCRIPTION
Just a poc branch for https://github.com/ing-bank/lion/issues/194
Feel free to implement differently

It does:
- based on date boundaries of current view, makes disabled dates navigable
- keep buttons for enabled nav (because they give keyboard selection for free and backwards compatibility in case extension layers styled pseudo states)  
- add div[role=buttton][aria-disabled] for disabled days 
- normalize styling for the two types of buttons

Plus:
- normalize styling of headings (adopt font-size of context)
- doesn't put 2 h2s next to eachother

TODO:
- still buggy, it adds one day too much atm when navigating
- request translations for the "Unavailable prefix"
- While we're at it, also do: https://github.com/ing-bank/lion/issues/195
