### PR TITLE
fix(calendar): focusable disabled dates

### DIFF
--- a/docs/components/inputs/calendar/features.md
+++ b/docs/components/inputs/calendar/features.md
@@ -190,3 +190,42 @@ export const combinedDisabledDates = () => {
   `;
 };
 ```
+
+### Finding enabled dates
+
+The next available date may be multiple days/month in the future/past.
+For that we offer convenient helpers as
+
+- `findNextEnabledDate()`
+- `findPreviousEnabledDate()`
+- `findNearestEnabledDate()`
+
+```js preview-story
+export const findingEnabledDates = () => {
+  function getCalendar(ev) {
+    return ev.target.parentElement.querySelector('.js-calendar');
+  }
+  return html`
+    <style>
+      .demo-calendar {
+        border: 1px solid #adadad;
+        box-shadow: 0 0 16px #ccc;
+        max-width: 500px;
+      }
+    </style>
+    <lion-calendar
+      class="demo-calendar js-calendar"
+      .disableDates=${day => day.getDay() === 6 || day.getDay() === 0}
+    ></lion-calendar>
+    <button @click="${ev => getCalendar(ev).focusDate(getCalendar(ev).findNextEnabledDate())}">
+      focus findNextEnabledDate
+    </button>
+    <button @click="${ev => getCalendar(ev).focusDate(getCalendar(ev).findPreviousEnabledDate())}">
+      focus findPreviousEnabledDate
+    </button>
+    <button @click="${ev => getCalendar(ev).focusDate(getCalendar(ev).findNearestEnabledDate())}">
+      focus findNearestEnabledDate
+    </button>
+  `;
+};
+```

--- a/packages/calendar/src/calendarStyle.js
+++ b/packages/calendar/src/calendarStyle.js
@@ -54,6 +54,16 @@ export const calendarStyle = css`
     padding: 0;
     min-width: 40px;
     min-height: 40px;
+    /** give div[role=button][aria-disabled] same display type as native btn */
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    box-sizing: border-box;
+  }
+
+  .calendar__day-button:focus {
+    border: 1px solid blue;
+    outline: none;
   }
 
   .calendar__day-button__text {
@@ -77,9 +87,23 @@ export const calendarStyle = css`
     border: 1px solid green;
   }
 
-  .calendar__day-button[disabled] {
+  .calendar__day-button[aria-disabled='true'] {
     background-color: #fff;
     color: #eee;
     outline: none;
+  }
+
+  .u-sr-only {
+    position: absolute;
+    top: 0;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(100%);
+    clip: rect(1px, 1px, 1px, 1px);
+    white-space: nowrap;
+    border: 0;
+    margin: 0;
+    padding: 0;
   }
 `;

--- a/packages/calendar/src/utils/dayTemplate.js
+++ b/packages/calendar/src/utils/dayTemplate.js
@@ -56,14 +56,14 @@ export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }
       ?start-of-last-week=${startOfLastWeek}
       ?last-day=${lastDay}
     >
-      <button
+      <div
+        role="button"
         .date=${day.date}
         class="calendar__day-button"
         tabindex=${ifDefined(day.tabindex)}
-        aria-label=${`${dayNumber} ${monthName} ${year} ${weekdayName}`}
         aria-pressed=${ifDefined(day.ariaPressed)}
         aria-current=${ifDefined(day.ariaCurrent)}
-        ?disabled=${day.disabled}
+        aria-disabled=${day.disabled ? 'true' : 'false'}
         ?selected=${day.selected}
         ?past=${day.past}
         ?today=${day.today}
@@ -72,8 +72,9 @@ export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }
         ?current-month=${day.currentMonth}
         ?next-month=${day.nextMonth}
       >
-        <span class="calendar__day-button__text"> ${day.date.getDate()} </span>
-      </button>
+        <span class="calendar__day-button__text">${dayNumber}</span>
+        <span class="u-sr-only">${`${monthName} ${year} ${weekdayName}`}</span>
+      </div>
     </td>
   `;
 }

--- a/packages/calendar/test-helpers/DayObject.js
+++ b/packages/calendar/test-helpers/DayObject.js
@@ -34,7 +34,7 @@ export class DayObject {
    */
 
   get isDisabled() {
-    return this.buttonEl.hasAttribute('disabled');
+    return this.buttonEl.getAttribute('aria-disabled') === 'true';
   }
 
   get isSelected() {
@@ -54,7 +54,7 @@ export class DayObject {
   }
 
   get monthday() {
-    return Number(this.buttonEl.textContent);
+    return Number(this.buttonEl.children[0].textContent);
   }
 
   /**

--- a/packages/calendar/test/utils/dayTemplate.test.js
+++ b/packages/calendar/test/utils/dayTemplate.test.js
@@ -11,14 +11,18 @@ describe('dayTemplate', () => {
     const el = await fixture(dayTemplate(day, { weekdays }));
     expect(el).dom.to.equal(`
       <td role="gridcell" class="calendar__day-cell">
-        <button
+        <div
+          aria-disabled="false"
+          role="button"
           class="calendar__day-button"
-          aria-label="19 April 2019 Friday"
           aria-pressed="false"
           tabindex="-1"
         >
           <span class="calendar__day-button__text">19</span>
-        </button>
+          <span class="u-sr-only">
+            April 2019 Friday
+          </span>
+        </div>
       </td>
     `);
   });

--- a/packages/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
+++ b/packages/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
@@ -52,434 +52,518 @@ export default html`
       <tbody>
         <tr role="row">
           <td class="calendar__day-cell" role="gridcell" start-of-last-week>
-            <button
-              aria-label="25 November 2018 Sunday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">25</span>
-            </button>
+              <span class="u-sr-only"> November 2018 Sunday</span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="26 November 2018 Monday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">26</span>
-            </button>
+              <span class="u-sr-only"> November 2018 Monday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="27 November 2018 Tuesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">27</span>
-            </button>
+              <span class="u-sr-only"> November 2018 Tuesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="28 November 2018 Wednesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">28</span>
-            </button>
+              <span class="u-sr-only"> November 2018 Wednesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="29 November 2018 Thursday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">29</span>
-            </button>
+              <span class="u-sr-only"> November 2018 Thursday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell" last-day>
-            <button
-              aria-label="30 November 2018 Friday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">30</span>
-            </button>
+              <span class="u-sr-only"> November 2018 Friday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell" end-of-first-week first-day>
-            <button
-              aria-label="1 December 2018 Saturday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">1</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Saturday </span>
+            </div>
           </td>
         </tr>
         <tr role="row">
           <td class="calendar__day-cell" role="gridcell" start-of-first-full-week>
-            <button
-              aria-label="2 December 2018 Sunday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">2</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Sunday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="3 December 2018 Monday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">3</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Monday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="4 December 2018 Tuesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">4</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Tuesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="5 December 2018 Wednesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">5</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Wednesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="6 December 2018 Thursday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">6</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Thursday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="7 December 2018 Friday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">7</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Friday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="8 December 2018 Saturday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">8</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Saturday </span>
+            </div>
           </td>
         </tr>
         <tr role="row">
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="9 December 2018 Sunday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">9</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Sunday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="10 December 2018 Monday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">10</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Monday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="11 December 2018 Tuesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">11</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Tuesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="12 December 2018 Wednesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">12</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Wednesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="13 December 2018 Thursday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">13</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Thursday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="14 December 2018 Friday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">14</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Friday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="15 December 2018 Saturday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">15</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Saturday </span>
+            </div>
           </td>
         </tr>
         <tr role="row">
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="16 December 2018 Sunday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">16</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Sunday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="17 December 2018 Monday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">17</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Monday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="18 December 2018 Tuesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">18</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Tuesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="19 December 2018 Wednesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">19</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Wednesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="20 December 2018 Thursday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">20</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Thursday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="21 December 2018 Friday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">21</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Friday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="22 December 2018 Saturday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">22</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Saturday </span>
+            </div>
           </td>
         </tr>
         <tr role="row">
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="23 December 2018 Sunday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">23</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Sunday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="24 December 2018 Monday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">24</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Monday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="25 December 2018 Tuesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">25</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Tuesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="26 December 2018 Wednesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">26</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Wednesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="27 December 2018 Thursday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">27</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Thursday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="28 December 2018 Friday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">28</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Friday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell" end-of-last-full-week>
-            <button
-              aria-label="29 December 2018 Saturday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">29</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Saturday </span>
+            </div>
           </td>
         </tr>
         <tr role="row">
           <td class="calendar__day-cell" role="gridcell" start-of-last-week>
-            <button
-              aria-label="30 December 2018 Sunday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">30</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Sunday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" last-day role="gridcell">
-            <button
-              aria-label="31 December 2018 Monday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">31</span>
-            </button>
+              <span class="u-sr-only"> December 2018 Monday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell" first-day>
-            <button
-              aria-label="1 January 2019 Tuesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">1</span>
-            </button>
+              <span class="u-sr-only"> January 2019 Tuesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="2 January 2019 Wednesday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">2</span>
-            </button>
+              <span class="u-sr-only"> January 2019 Wednesday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="3 January 2019 Thursday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">3</span>
-            </button>
+              <span class="u-sr-only"> January 2019 Thursday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell">
-            <button
-              aria-label="4 January 2019 Friday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">4</span>
-            </button>
+              <span class="u-sr-only"> January 2019 Friday </span>
+            </div>
           </td>
           <td class="calendar__day-cell" role="gridcell" end-of-first-week>
-            <button
-              aria-label="5 January 2019 Saturday"
+            <div
+              role="button"
+              aria-disabled="false"
               aria-pressed="false"
               class="calendar__day-button"
               tabindex="-1"
             >
               <span class="calendar__day-button__text">5</span>
-            </button>
+              <span class="u-sr-only"> January 2019 Saturday </span>
+            </div>
           </td>
         </tr>
       </tbody>


### PR DESCRIPTION
## What I did

1. Do not automatically force selection of a valid date
2. Enables focus to disabled dates to make it more reasonable for screen readers
3. Add helper functions to find next/previous/nearest enabled date

TODO:
- [ ] check integration with input-datepicker
- [ ] add changeset
