### PR TITLE
Race condition in LocalizeManager

### DIFF
--- a/.changeset/mighty-cars-grow.md
+++ b/.changeset/mighty-cars-grow.md
@@ -1,0 +1,5 @@
+---
+'@lion/localize': patch
+---
+
+Fix localize race condition where data was being added while namespace loader promise was no longer in cache.

--- a/packages/localize/src/LocalizeManager.js
+++ b/packages/localize/src/LocalizeManager.js
@@ -340,8 +340,14 @@ export class LocalizeManager {
        * @param {Object} obj.default
        */
       obj => {
-        const data = isLocalizeESModule(obj) ? obj.default : obj;
-        this.addData(locale, namespace, data);
+        // add data only if we have the promise in cache
+        if (
+          this.__namespaceLoaderPromisesCache[locale] &&
+          this.__namespaceLoaderPromisesCache[locale][namespace] === loaderPromise
+        ) {
+          const data = isLocalizeESModule(obj) ? obj.default : obj;
+          this.addData(locale, namespace, data);
+        }
       },
     );
   }

--- a/packages/localize/test/LocalizeManager.test.js
+++ b/packages/localize/test/LocalizeManager.test.js
@@ -60,6 +60,30 @@ describe('LocalizeManager', () => {
     expect(document.documentElement.lang).to.equal('en-GB');
   });
 
+  it('empties storage after reset() is invoked', async () => {
+    manager = new LocalizeManager();
+
+    let deferredResolve;
+    manager.loadNamespace({
+      generic: () =>
+        new Promise(resolve => {
+          deferredResolve = () => resolve({ greeting: 'Hello!' });
+        }),
+    });
+
+    const { loadingComplete } = manager;
+
+    manager.reset();
+    expect(getProtectedMembers(manager).storage).to.be.empty;
+
+    // @ts-ignore
+    deferredResolve();
+    await loadingComplete;
+
+    // storage still needs to be empty after promise is fulfilled.
+    expect(getProtectedMembers(manager).storage).to.be.empty;
+  });
+
   it('has teardown() method removing all side effects', () => {
     manager = new LocalizeManager();
     const disconnectObserverSpy = sinon.spy(


### PR DESCRIPTION
Long running imports were polluting newly reset storage (#1376)

## What I did

1.  When the promise is fulfilled, it is checked if it's still in the .__namespaceLoaderPromisesCache before calling addData.
