### PR TITLE
Fix typo under Private heading of definitions

### DIFF
--- a/docs/guides/principles/definitions-and-terms.md
+++ b/docs/guides/principles/definitions-and-terms.md
@@ -30,7 +30,7 @@ class SoccerPlayer {
 
 ## Private
 
-Methods and properties are protected when they contain two underscores or are explicitly marked as private in the code. They can be only used within the class where they are defined (developers of Lion components).
+Methods and properties are private when they contain two underscores or are explicitly marked as private in the code. They can be only used within the class where they are defined (developers of Lion components).
 
 ```js
 class SoccerPlayer {


### PR DESCRIPTION
Fix documentation to specify private methods and properties, rather than protected, with two underscores.

## What I did

1. Changed the word `protected` under the `Private` heading to the word `private`.
