### PR TITLE
fix: try awaiting render for missing name attributes

### DIFF
--- a/packages/form-core/src/choice-group/ChoiceGroupMixin.js
+++ b/packages/form-core/src/choice-group/ChoiceGroupMixin.js
@@ -181,11 +181,11 @@ const ChoiceGroupMixinImplementation = superclass =>
      * @param {FormControl} child
      * @param {number} indexToInsertAt
      */
-    addFormElement(child, indexToInsertAt) {
+    async addFormElement(child, indexToInsertAt) {
       this._throwWhenInvalidChildModelValue(child);
       // eslint-disable-next-line no-param-reassign
       child.name = this.name;
-      super.addFormElement(child, indexToInsertAt);
+      await super.addFormElement(child, indexToInsertAt);
     }
 
     clear() {

--- a/packages/form-core/src/form-group/FormGroupMixin.js
+++ b/packages/form-core/src/form-group/FormGroupMixin.js
@@ -514,8 +514,21 @@ const FormGroupMixinImplementation = superclass =>
      * @param {FormControl & {serializedValue:string|object}} child
      * @param {number} indexToInsertAt
      */
-    addFormElement(child, indexToInsertAt) {
-      super.addFormElement(child, indexToInsertAt);
+    async addFormElement(child, indexToInsertAt) {
+      // Sync pending values first
+      if (!child.modelValue) {
+        const pVals = this.__pendingValues;
+        if (pVals.modelValue && pVals.modelValue[child.name]) {
+          // eslint-disable-next-line no-param-reassign
+          child.modelValue = pVals.modelValue[child.name];
+        } else if (pVals.serializedValue && pVals.serializedValue[child.name]) {
+          // eslint-disable-next-line no-param-reassign
+          child.serializedValue = pVals.serializedValue[child.name];
+        }
+      }
+
+      await super.addFormElement(child, indexToInsertAt);
+
       if (this.disabled) {
         child.makeRequestToBeDisabled();
       }
@@ -527,16 +540,6 @@ const FormGroupMixinImplementation = superclass =>
 
       if (typeof child.addToAriaLabelledBy === 'function' && this._labelNode) {
         child.addToAriaLabelledBy(this._labelNode, { reorder: false });
-      }
-      if (!child.modelValue) {
-        const pVals = this.__pendingValues;
-        if (pVals.modelValue && pVals.modelValue[child.name]) {
-          // eslint-disable-next-line no-param-reassign
-          child.modelValue = pVals.modelValue[child.name];
-        } else if (pVals.serializedValue && pVals.serializedValue[child.name]) {
-          // eslint-disable-next-line no-param-reassign
-          child.serializedValue = pVals.serializedValue[child.name];
-        }
       }
     }
 

--- a/packages/form-core/src/registration/FormRegistrarMixin.js
+++ b/packages/form-core/src/registration/FormRegistrarMixin.js
@@ -4,12 +4,13 @@ import { FormControlsCollection } from './FormControlsCollection.js';
 import { FormRegisteringMixin } from './FormRegisteringMixin.js';
 
 /**
+ * @typedef {import('@lion/core').LitElement} LitElement
  * @typedef {import('../../types/FormControlMixinTypes').FormControlHost} FormControlHost
  * @typedef {import('../../types/registration/FormRegistrarMixinTypes').FormRegistrarMixin} FormRegistrarMixin
  * @typedef {import('../../types/registration/FormRegistrarMixinTypes').FormRegistrarHost} FormRegistrarHost
  * @typedef {import('../../types/registration/FormRegistrarMixinTypes').ElementWithParentFormGroup} ElementWithParentFormGroup
  * @typedef {import('../../types/registration/FormRegisteringMixinTypes').FormRegisteringHost} FormRegisteringHost
- * @typedef {FormControlHost & HTMLElement & {_parentFormGroup?:HTMLElement, checked?:boolean}} FormControl
+ * @typedef {FormControlHost & LitElement & {_parentFormGroup?:LitElement, checked?:boolean}} FormControl
  */
 
 /**
@@ -140,7 +141,7 @@ const FormRegistrarMixinImplementation = superclass =>
      * @param {FormControl} child the child element (field)
      * @param {number} indexToInsertAt index to insert the form element at
      */
-    addFormElement(child, indexToInsertAt) {
+    async addFormElement(child, indexToInsertAt) {
       // This is a way to let the child element (a lion-fieldset or lion-field) know, about its parent
       // eslint-disable-next-line no-param-reassign
       child._parentFormGroup = /** @type {* & FormRegistrarHost} */ (this);
@@ -154,10 +155,16 @@ const FormRegistrarMixinImplementation = superclass =>
 
       // 2. Add children as object key
       if (this._isFormOrFieldset) {
-        const { name } = child;
+        let { name } = child;
         if (!name) {
-          console.info('Error Node:', child); // eslint-disable-line no-console
-          throw new TypeError('You need to define a name');
+          // Give child a chance to render if property bindings are done later
+          // E.g. for @lit-labs/react
+          await child.updateComplete;
+          name = child.name;
+          if (!name) {
+            console.info('Error Node:', child); // eslint-disable-line no-console
+            throw new TypeError('You need to define a name');
+          }
         }
         if (name === this.name) {
           console.info('Error Node:', child); // eslint-disable-line no-console

--- a/packages/form-core/test-suites/choice-group/ChoiceGroupMixin.suite.js
+++ b/packages/form-core/test-suites/choice-group/ChoiceGroupMixin.suite.js
@@ -93,9 +93,14 @@ export function runChoiceGroupMixinSuite({ parentTagString, childTagString, choi
       `)
       );
 
-      expect(() => {
-        el.addFormElement(invalidChild);
-      }).to.throw(
+      let error;
+      try {
+        await el.addFormElement(invalidChild);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error.message).to.equal(
         `The ${cfg.parentTagString} name="gender[]" does not allow to register ${cfg.childTagString} with .modelValue="Lara" - The modelValue should represent an Object { value: "foo", checked: false }`,
       );
     });

--- a/packages/form-core/test-suites/form-group/FormGroupMixin.suite.js
+++ b/packages/form-core/test-suites/form-group/FormGroupMixin.suite.js
@@ -133,9 +133,7 @@ export function runFormGroupMixinSuite(cfg = {}) {
       let error;
       const el = /**  @type {FormGroup} */ (await fixture(html`<${tag}></${tag}>`));
       try {
-        // we test the api directly as errors thrown from a web component are in a
-        // different context and we can not catch them here => register fake elements
-        el.addFormElement(
+        await el.addFormElement(
           /**  @type {HTMLElement & import('../../types/FormControlMixinTypes').FormControlHost} */ ({}),
         );
       } catch (err) {
@@ -156,7 +154,7 @@ export function runFormGroupMixinSuite(cfg = {}) {
       try {
         // we test the api directly as errors thrown from a web component are in a
         // different context and we can not catch them here => register fake elements
-        el.addFormElement(
+        await el.addFormElement(
           /**  @type {HTMLElement & import('../../types/FormControlMixinTypes').FormControlHost} */ ({
             name: 'foo',
           }),
@@ -184,7 +182,7 @@ export function runFormGroupMixinSuite(cfg = {}) {
             name: 'fooBar',
           }),
         );
-        el.addFormElement(
+        await el.addFormElement(
           /**  @type {HTMLElement & import('../../types/FormControlMixinTypes').FormControlHost} */ ({
             name: 'fooBar',
           }),
@@ -498,9 +496,11 @@ export function runFormGroupMixinSuite(cfg = {}) {
         expect(el.validationStates.error.HasEvenNumberOfChildren).to.be.true;
 
         el.appendChild(child2);
+        await el.validateComplete;
         expect(el.validationStates.error.HasEvenNumberOfChildren).to.equal(undefined);
 
         el.removeChild(child2);
+        await el.validateComplete;
         expect(el.validationStates.error.HasEvenNumberOfChildren).to.be.true;
 
         // Edge case: remove all children

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -453,28 +453,26 @@ const ListboxMixinImplementation = superclass =>
      * @param {FormControlHost & LionOption} child
      * @param {Number} indexToInsertAt
      */
-    addFormElement(child, indexToInsertAt) {
-      super.addFormElement(/** @type {FormControl} */ child, indexToInsertAt);
+    async addFormElement(child, indexToInsertAt) {
+      this.__proxyChildModelValueChanged(
+        /** @type {CustomEvent & { target: FormControlHost & LionOption; }} */ ({ target: child }),
+      );
+
+      await super.addFormElement(/** @type {FormControl} */ child, indexToInsertAt);
       // we need to adjust the elements being registered
       /* eslint-disable no-param-reassign */
       child.id = child.id || `${this.localName}-option-${uuid()}`;
-
+      /* eslint-enable no-param-reassign */
       if (this.disabled) {
         child.makeRequestToBeDisabled();
       }
-
       // TODO: small perf improvement could be made if logic below would be scheduled to next update,
       // so it occurs once for all options
       this.__setAttributeForAllFormElements('aria-setsize', this.formElements.length);
       this.formElements.forEach((el, idx) => {
         el.setAttribute('aria-posinset', idx + 1);
       });
-
-      this.__proxyChildModelValueChanged(
-        /** @type {CustomEvent & { target: FormControlHost & LionOption; }} */ ({ target: child }),
-      );
       this.resetInteractionState();
-      /* eslint-enable no-param-reassign */
     }
 
     resetInteractionState() {

--- a/packages/listbox/test-suites/ListboxMixin.suite.js
+++ b/packages/listbox/test-suites/ListboxMixin.suite.js
@@ -133,9 +133,14 @@ export function runListboxMixinSuite(customConfig = {}) {
           html` <${optionTag} .modelValue=${'Lara'}></${optionTag}> `,
         );
 
-        expect(() => {
-          el.addFormElement(invalidChild);
-        }).to.throw(
+        let error;
+        try {
+          await el.addFormElement(invalidChild);
+        } catch (err) {
+          error = err;
+        }
+
+        expect(error.message).to.equal(
           `The ${cfg.tagString} name="foo" does not allow to register lion-option with .modelValue="Lara" - The modelValue should represent an Object { value: "foo", checked: false }`,
         );
       });

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -219,8 +219,7 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
    * @param {LionOption & FormControlHost} child
    * @param {Number} indexToInsertAt
    */
-  addFormElement(child, indexToInsertAt) {
-    super.addFormElement(child, indexToInsertAt);
+  async addFormElement(child, indexToInsertAt) {
     // the first elements checked by default
     if (
       !this.hasNoDefaultSelected &&
@@ -233,8 +232,10 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
       /* eslint-enable no-param-reassign */
       this.__hasInitialSelectedFormElement = true;
     }
-    this._alignInvokerWidth();
 
+    await super.addFormElement(child, indexToInsertAt);
+
+    this._alignInvokerWidth();
     this._onFormElementsChanged();
   }
 

--- a/packages/select-rich/test/lion-select-rich.test.js
+++ b/packages/select-rich/test/lion-select-rich.test.js
@@ -388,9 +388,7 @@ describe('lion-select-rich', () => {
       const newOption = /** @type {LionOption} */ (document.createElement('lion-option'));
       newOption.choiceValue = 30;
       _inputNode.appendChild(newOption);
-      // @ts-ignore [test] allow to not provide args for testing purposes
-      el.requestUpdate();
-      await el.updateComplete;
+      await nextFrame();
       expect(el.singleOption).to.be.false;
       expect(_invokerNode.singleOption).to.be.false;
     });


### PR DESCRIPTION
## What I did

Draft fix for issue described by @alangdm https://lit-and-friends.slack.com/archives/CJGFWJN9J/p1622445542027800

Apparently React or lit-labs/react first initialises the component with default values and assigns the properties on a second pass, so when the form element is first connected it still doesn't have a name

Before merging this we should add a test that specifically tests that a form element is able to register when its `name` attribute is set during render (`update` lifecycle in Lit perhaps), so that it can be expected after updateComplete but not before.
