### PR TITLE
chore: remove generated type files from git

### DIFF
--- a/packages-node/publish-docs/index.d.ts
+++ b/packages-node/publish-docs/index.d.ts
@@ -1,8 +1,0 @@
-export { PublishDocs } from "./src/PublishDocs.js";
-export type PublishDocsOptions = {
-    projectDir: string;
-    gitHubUrl: string;
-    gitRootDir: string;
-    copyDir: string;
-    copyTarget: string;
-};

--- a/packages/calendar/index.d.ts
+++ b/packages/calendar/index.d.ts
@@ -1,2 +1,0 @@
-export { isSameDate } from "./src/utils/isSameDate.js";
-export { LionCalendar } from "./src/LionCalendar.js";


### PR DESCRIPTION
## What I did

1. they were probably committed by accident and are blocking the release CI because of this tsc error

```
error TS5055: Cannot write file '/home/runner/work/lion/lion/packages-node/publish-docs/index.d.ts' because it would overwrite input file.
error TS5055: Cannot write file '/home/runner/work/lion/lion/packages/calendar/index.d.ts' because it would overwrite input file.
```
