### PR TITLE
fix(listbox): take into account sticky/fixed el for offsetTop calc

### DIFF
--- a/.changeset/dull-paws-prove.md
+++ b/.changeset/dull-paws-prove.md
@@ -1,0 +1,5 @@
+---
+'@lion/listbox': patch
+---
+
+Fix listbox to take into account that offsetTop by itself may not be sufficient with regards to scrolling active options in view when the page contains sticky or fixed elements blocking the view.

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -85,6 +85,22 @@ function isInView(container, element, partial = false) {
 }
 
 /**
+ * offsetTop is not sufficient by itself due to sticky/fixed elements, see:
+ * https://medium.com/@alexcambose/js-offsettop-property-is-not-great-and-here-is-why-b79842ef7582
+ *
+ * @param {HTMLElement | null} element
+ *
+ * @returns {number}
+ */
+function getOffsetTop(element) {
+  if (!element) {
+    return 0;
+  }
+
+  return element.offsetTop + getOffsetTop(/** @type {HTMLElement | null} */ (element.offsetParent));
+}
+
+/**
  * @type {ListboxMixin}
  * @param {import('@open-wc/dedupe-mixin').Constructor<import('@lion/core').LitElement>} superclass
  */
@@ -756,7 +772,7 @@ const ListboxMixinImplementation = superclass =>
         return;
       }
       this._activeDescendantOwnerNode.setAttribute('aria-activedescendant', el.id);
-      const offsetTop = this.getOffsetTop(el);
+      const offsetTop = getOffsetTop(el);
       const mockScrollTargetNode = {
         scrollTop: this._scrollTargetNode.scrollTop + offsetTop,
         clientHeight: this._scrollTargetNode.clientHeight - offsetTop,
@@ -768,23 +784,6 @@ const ListboxMixinImplementation = superclass =>
       if (!isInView(mockScrollTargetNode, mockElement)) {
         el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
       }
-    }
-
-    /**
-     * offsetTop is not sufficient by itself due to sticky/fixed elements, see:
-     * https://medium.com/@alexcambose/js-offsettop-property-is-not-great-and-here-is-why-b79842ef7582
-     *
-     * @param {HTMLElement | null} element
-     */
-    // eslint-disable-next-line class-methods-use-this
-    getOffsetTop(element) {
-      let _element = element;
-      let offsetTop = 0;
-      while (_element) {
-        offsetTop += _element.offsetTop;
-        _element = /** @type {HTMLElement | null} */ (_element.offsetParent);
-      }
-      return offsetTop;
     }
 
     /**

--- a/packages/listbox/test-suites/ListboxMixin.suite.js
+++ b/packages/listbox/test-suites/ListboxMixin.suite.js
@@ -322,36 +322,32 @@ export function runListboxMixinSuite(customConfig = {}) {
 
       it('scrolls active element into view when necessary, takes into account sticky/fixed elements', async () => {
         const el = await fixture(html`
-          <div style="position: relative">
-            <div style="position: sticky; top: 0px; width: 100%; height: 40px; background-color: purple; z-index: 1;">Header 1</div>
+          <div id="scrolling-element" style="position: relative;  overflow-y: scroll; height: 570px;">
+            <div style="position: sticky; top: 0px; width: 100%; height: 100px; background-color: purple; z-index: 1;">Header 1</div>
             <div style="position: relative">
-              <div style="position: sticky; top: 40px; width: 100%; height: 40px; background-color: beige; z-index: 1;">Header 2</div>
-              <${tag} id="color" name="color" label="Favorite color" has-no-default-selected>
-                <${optionTag} style="height: 300px" .choiceValue=${'red'}>Red</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'hotpink'}>Hotpink</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'teal'}>Teal</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'1'}>1</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'2'}>2</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'3'}>3</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'4'}>4</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'5'}>5</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'6'}>6</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'7'}>7</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'8'}>8</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'9'}>9</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'10'}>10</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'11'}>11</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'12'}>12</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'13'}>13</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'14'}>14</${optionTag}>
-                <${optionTag} style="height: 300px" .choiceValue=${'15'}>15</${optionTag}>
+              <div style="position: sticky; top: 100px; width: 100%; height: 50px; background-color: beige; z-index: 1;">Header 2</div>
+              <${tag} id="color" name="color" has-no-default-selected>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'red'}>Red</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'hotpink'}>Hotpink</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'teal'}>Teal</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'1'}>1</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'2'}>2</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'3'}>3</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'4'}>4</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'5'}>5</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'5'}>6</${optionTag}>
+                <${optionTag} style="height: 50px; scroll-margin-top: 150px;" .choiceValue=${'6'}>7</${optionTag}>
               </${tag}>
             </div>
           </div>
         `);
         const listboxEl = /** @type {LionListbox} */ (el.querySelector('#color'));
 
-        const firstOption = /** @type {LionOption} */ (listboxEl.formElements[0]);
+        Object.defineProperty(listboxEl, '_scrollTargetNode', {
+          get: () => el,
+        });
+
+        const thirdOption = /** @type {LionOption} */ (listboxEl.formElements[2]);
         const lastOption = /** @type {LionOption} */ (
           listboxEl.formElements[listboxEl.formElements.length - 1]
         );
@@ -362,13 +358,11 @@ export function runListboxMixinSuite(customConfig = {}) {
         lastOption.active = true;
         await aTimeout(1000);
 
-        // FIXME: For some reason in this test, it is not doing the scroll back up..
-        // Scroll to last option and wait for browser scroll animation
-        firstOption.active = true;
+        thirdOption.active = true;
         await aTimeout(1000);
 
         // top should be offset 2x40px (sticky header elems) instead of 0px
-        expect(firstOption.getBoundingClientRect().top).to.equal(80);
+        expect(el.scrollTop).to.equal(116);
       }).timeout(5000);
     });
 

--- a/packages/listbox/test-suites/ListboxMixin.suite.js
+++ b/packages/listbox/test-suites/ListboxMixin.suite.js
@@ -343,6 +343,15 @@ export function runListboxMixinSuite(customConfig = {}) {
         `);
         const listboxEl = /** @type {LionListbox} */ (el.querySelector('#color'));
 
+        // Skip test if listbox cannot receive focus, e.g. in combobox
+        // Skip test if the listbox is controlled by overlay system,
+        // since these overlays "overlay" any fixed/sticky items, meaning
+        // the active item will not be hidden by them.
+        // @ts-ignore allow protected members in tests
+        if (listboxEl._listboxReceivesNoFocus || listboxEl._overlayCtrl) {
+          return;
+        }
+
         Object.defineProperty(listboxEl, '_scrollTargetNode', {
           get: () => el,
         });
@@ -363,7 +372,7 @@ export function runListboxMixinSuite(customConfig = {}) {
 
         // top should be offset 2x40px (sticky header elems) instead of 0px
         expect(el.scrollTop).to.equal(116);
-      }).timeout(5000);
+      });
     });
 
     describe('Accessibility', () => {

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -31,7 +31,7 @@ export default {
   },
   testFramework: {
     config: {
-      timeout: '3000',
+      timeout: '5000',
     },
   },
   browsers: [
@@ -39,10 +39,8 @@ export default {
     playwrightLauncher({ product: 'chromium' }),
     playwrightLauncher({ product: 'webkit' }),
   ],
-  groups: packages.map(pkg => {
-    return {
-      name: pkg,
-      files: `packages/${pkg}/test/**/*.test.js`,
-    };
-  }),
+  groups: packages.map(pkg => ({
+    name: pkg,
+    files: `packages/${pkg}/test/**/*.test.js`,
+  })),
 };


### PR DESCRIPTION
fixes https://github.com/ing-bank/lion/issues/1413

https://webcomponents.dev/edit/cE9kPezoQwaAPfRbdQEd/ as shown here, our isInView util remains a bit naive of random elements blocking view of the option. 

Might be better after all to just call scrollIntoView, always, and let the browser decide if it is necessary to scroll, seems like browser is smarter in this regard?