### PR TITLE
chore: trigger rebuild core documentation

### DIFF
--- a/.changeset/witty-years-matter.md
+++ b/.changeset/witty-years-matter.md
@@ -1,0 +1,5 @@
+---
+'@lion/core': patch
+---
+
+Bump to rebuild core documentation


### PR DESCRIPTION
For some reason, `prepublishOnly` was not performed for @lion/core last time. We need a new release to fix it