### PR TITLE
Add required peer dependencies

### DIFF
--- a/docs/guides/how-to/get-started.md
+++ b/docs/guides/how-to/get-started.md
@@ -24,7 +24,7 @@ npm init @open-wc
 ### Install peer dependencies lit-html and lit-element
 
 ```bash
-npm i --save-dev lit-html lit-element
+npm i lit-html lit-element
 ```
 
 ### Install lion packages

--- a/docs/guides/how-to/get-started.md
+++ b/docs/guides/how-to/get-started.md
@@ -21,6 +21,12 @@ And create a repo, we suggest to use [the generator from open-wc](https://open-w
 npm init @open-wc
 ```
 
+### Install peer dependencies lit-html and lit-element
+
+```bash
+npm i --save-dev lit-html lit-element
+```
+
 ### Install lion packages
 
 ```bash


### PR DESCRIPTION
Out of the box, installing a @lion package in a new project doesn't include the required peer dependencies lit-html and lit-element. I suggest they are mentioned in this documentation.

## What I did

1. I added a section in the documentation.
