### PR TITLE
chore: add missing arrow__graphic class to docs

### DIFF
--- a/docs/components/interaction/tooltip/features.md
+++ b/docs/components/interaction/tooltip/features.md
@@ -185,7 +185,7 @@ export const customArrow = () => {
         }
         _arrowTemplate() {
           return html`
-            <svg viewBox="0 0 20 8">
+            <svg viewBox="0 0 20 8" class="arrow__graphic">
               <path d="M 0,0 h 20 L 10,8 z"></path>
             </svg>
           `;


### PR DESCRIPTION
When checking these docs to extend tooltip arrow, I realized after scratching my head a lot, that my arrow wasn't looking right because I was missing the arrow__graphic classname ;)