### PR TITLE
feat(localize): await loadingComplete before sending locale changed

### DIFF
--- a/.changeset/unlucky-cameras-joke.md
+++ b/.changeset/unlucky-cameras-joke.md
@@ -1,0 +1,5 @@
+---
+'@lion/localize': minor
+---
+
+BREAKING: Fires localeChanged event (and as a result, invokes onLocaleChanged / onLocaleUpdated) after localize loading has completed. This means if the user switches the locale to a locale which has not loaded yet, it will load it first before sending the event. This will allow users to immediately call localize.msg and get the right output, without having to await localize.loadingComplete themselves. This is slightly breaking with regards to timing and might break tests in extensions. In that case, you probably need a `await localize.loadingComplete` statement in front of the failing assertion.

--- a/packages/calendar/test/lion-calendar.test.js
+++ b/packages/calendar/test/lion-calendar.test.js
@@ -1393,6 +1393,7 @@ describe('<lion-calendar>', () => {
       ]);
 
       localize.locale = 'nl-NL';
+      await localize.loadingComplete;
       await el.updateComplete;
       expect(elObj.nextMonthButtonEl?.getAttribute('aria-label')).to.equal(
         'Volgende maand, december 2019',

--- a/packages/calendar/test/lion-calendar.test.js
+++ b/packages/calendar/test/lion-calendar.test.js
@@ -1393,7 +1393,7 @@ describe('<lion-calendar>', () => {
       ]);
 
       localize.locale = 'nl-NL';
-      await localize.loadingComplete;
+      await el.localizeNamespacesLoaded;
       await el.updateComplete;
       expect(elObj.nextMonthButtonEl?.getAttribute('aria-label')).to.equal(
         'Volgende maand, december 2019',

--- a/packages/form-core/src/validate/ValidateMixin.js
+++ b/packages/form-core/src/validate/ValidateMixin.js
@@ -644,7 +644,6 @@ export const ValidateMixinImplementation = superclass =>
      * @private
      */
     async __getFeedbackMessages(validators) {
-      await localize.loadingComplete;
       let fieldName = await this.fieldName;
       return Promise.all(
         validators.map(async validator => {

--- a/packages/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -332,6 +332,7 @@ export function runValidateMixinFeedbackPart() {
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Message for MinLength');
 
       localize.locale = 'de-DE';
+      await localize.loadingComplete;
       await el.feedbackComplete;
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Nachricht für MinLength');
     });

--- a/packages/form-integrations/test/form-validation-integrations.test.js
+++ b/packages/form-integrations/test/form-validation-integrations.test.js
@@ -127,7 +127,6 @@ describe('Form Validation Integrations', () => {
         }
 
         async updateLabel() {
-          await localize.loadingComplete;
           this.label = localize.msg('test-default-label:label');
         }
 
@@ -143,8 +142,14 @@ describe('Form Validation Integrations', () => {
             },
           });
           this.boundUpdateLabel = this.updateLabel.bind(this);
-          this.boundUpdateLabel();
+
+          // localeChanged is fired AFTER localize has finished loading missing translations
+          // so no need to await localize.loadingComplete
           localize.addEventListener('localeChanged', this.boundUpdateLabel);
+
+          // Wait for it to complete when updating the label for the first time
+          await localize.loadingComplete;
+          this.boundUpdateLabel();
         }
       }
       const elTagString = defineCE(DefaultLabelInput);

--- a/packages/form-integrations/test/form-validation-integrations.test.js
+++ b/packages/form-integrations/test/form-validation-integrations.test.js
@@ -164,12 +164,14 @@ describe('Form Validation Integrations', () => {
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Please enter a(n) Text.');
 
       localize.locale = 'nl-NL';
+      await localize.loadingComplete;
       await el.updateComplete;
       await el.feedbackComplete;
       expect(el.label).to.equal('Tekst');
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Vul een Tekst in.');
 
       localize.locale = 'en-GB';
+      await localize.loadingComplete;
       await el.updateComplete;
       await el.feedbackComplete;
       expect(el.label).to.equal('Text');

--- a/packages/localize/src/LocalizeManager.js
+++ b/packages/localize/src/LocalizeManager.js
@@ -490,6 +490,8 @@ export class LocalizeManager {
    * @protected
    */
   _onLocaleChanged(newLocale, oldLocale) {
+    // Event firing immediately, does not wait for loading the translations
+    this.dispatchEvent(new CustomEvent('__localeChanging'));
     if (newLocale === oldLocale) {
       return;
     }

--- a/packages/localize/test-helpers/fake-imports.js
+++ b/packages/localize/test-helpers/fake-imports.js
@@ -21,7 +21,7 @@ export function setupEmptyFakeImportsFor(namespaces, locales) {
   namespaces.forEach(namespace => {
     locales.forEach(locale => {
       setupFakeImport(`./${namespace}/${locale}.js`, {
-        default: {},
+        default: { foo: `bar-${locale}` },
       });
     });
   });

--- a/packages/localize/test/LocalizeMixin.test.js
+++ b/packages/localize/test/LocalizeMixin.test.js
@@ -146,11 +146,13 @@ describe('LocalizeMixin', () => {
     await el.localizeNamespacesLoaded;
     expect(onLocaleChangedSpy.callCount).to.equal(0);
 
+    // Appending to DOM will result in onLocaleChanged to be invoked
     wrapper.appendChild(el);
 
+    // Changing locale will result in onLocaleChanged to be invoked
     localize.locale = 'ru-RU';
     await el.localizeNamespacesLoaded;
-    expect(onLocaleChangedSpy.callCount).to.equal(1);
+    expect(onLocaleChangedSpy.callCount).to.equal(2);
     expect(onLocaleChangedSpy.calledWithExactly('ru-RU', 'nl-NL')).to.be.true;
   });
 
@@ -189,12 +191,10 @@ describe('LocalizeMixin', () => {
 
     localize.locale = 'nl-NL';
     await el.localizeNamespacesLoaded;
-    await nextFrame();
     expect(el.foo).to.equal('bar-nl-NL');
 
     localize.locale = 'ru-RU';
     await el.localizeNamespacesLoaded;
-    await nextFrame();
     expect(el.foo).to.equal('bar-ru-RU');
   });
 
@@ -226,7 +226,6 @@ describe('LocalizeMixin', () => {
 
     localize.locale = 'nl-NL';
     await el.localizeNamespacesLoaded;
-    await nextFrame();
     expect(onLocaleUpdatedSpy.callCount).to.equal(2);
   });
 
@@ -266,7 +265,6 @@ describe('LocalizeMixin', () => {
 
     localize.locale = 'nl-NL';
     await el.localizeNamespacesLoaded;
-    await nextFrame();
     expect(el.label).to.equal('two');
   });
 
@@ -292,6 +290,8 @@ describe('LocalizeMixin', () => {
 
     localize.locale = 'nl-NL';
     await el.localizeNamespacesLoaded;
+
+    // await next frame for requestUpdate to be fired
     await nextFrame();
     expect(updateSpy.callCount).to.equal(1);
   });
@@ -436,7 +436,7 @@ describe('LocalizeMixin', () => {
       localize.locale = 'en-US';
       expect(p.innerText).to.equal('Hi!');
       await el.localizeNamespacesLoaded;
-      await aTimeout(25); // needed because msgLit relies on until directive
+      await nextFrame(); // needed because msgLit relies on until directive to re-render
       await el.updateComplete;
       expect(p.innerText).to.equal('Howdy!');
     }

--- a/packages/localize/types/LocalizeMixinTypes.d.ts
+++ b/packages/localize/types/LocalizeMixinTypes.d.ts
@@ -60,7 +60,7 @@ declare class LocalizeMixinHost {
 
   static get waitForLocalizeNamespaces(): boolean;
 
-  public localizeNamespacesLoaded(): Promise<Object>;
+  public localizeNamespacesLoaded: Promise<Object> | undefined;
 
   /**
    * Hook into LitElement to only render once all translations are loaded
@@ -74,10 +74,13 @@ declare class LocalizeMixinHost {
   public disconnectedCallback(): void;
   public msgLit(keys: string | string[], variables?: msgVariables, options?: msgOptions): void;
 
-  private __getUniqueNamespaces(): void;
-  private __localizeAddLocaleChangedListener(): void;
-  private __localizeRemoveLocaleChangedListener(): void;
+  private __boundLocalizeOnLocaleChanged(...args: Object[]): void;
+  private __boundLocalizeOnLocaleChanging(...args: Object[]): void;
+  private __getUniqueNamespaces(): string[];
   private __localizeOnLocaleChanged(event: CustomEvent): void;
+  private __localizeMessageSync: boolean;
+  private __localizeStartLoadingNamespaces(): void;
+  private __localizeOnLocaleChanging(): void;
 }
 
 declare function LocalizeMixinImplementation<T extends Constructor<LitElement>>(


### PR DESCRIPTION
## What I did

See changeset, it explains it in more detail. Hopefully the test I added also shows why it is more user-friendly this way. Mostly, `localize.msg()` calls may fail when called directly after locale switches where the new locale is still loading. now this is fixed :)
