### PR TITLE
feat(input-datepicker): export calendar overlay frame

### DIFF
--- a/.changeset/odd-fans-clap.md
+++ b/.changeset/odd-fans-clap.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-datepicker': patch
+---
+
+Export LionCalendarOverlayFrame as a good starter frame for subclassers.

--- a/packages/input-datepicker/index.js
+++ b/packages/input-datepicker/index.js
@@ -1,1 +1,2 @@
 export { LionInputDatepicker } from './src/LionInputDatepicker.js';
+export { LionCalendarOverlayFrame } from './src/LionCalendarOverlayFrame.js';


### PR DESCRIPTION
Let me know if you guys think it makes sense to export this or to expect subclassers to always write their own from scratch