### PR TITLE
fix(remark-extend): support importing of tables

### DIFF
--- a/.changeset/strong-icons-argue.md
+++ b/.changeset/strong-icons-argue.md
@@ -1,0 +1,5 @@
+---
+'remark-extend': patch
+---
+
+Support GitHub Flavored Markdown (gfm) tables when importing markdown

--- a/packages-node/remark-extend/package.json
+++ b/packages-node/remark-extend/package.json
@@ -25,6 +25,7 @@
     "test:watch": "mocha test-node --watch"
   },
   "dependencies": {
+    "remark-gfm": "^1.0.0",
     "remark-parse": "^9.0.0",
     "unified": "^9.2.0",
     "unist-util-is": "^4.0.2",

--- a/packages-node/remark-extend/src/remarkExtend.js
+++ b/packages-node/remark-extend/src/remarkExtend.js
@@ -4,6 +4,7 @@ const visit = require('unist-util-visit');
 const { select } = require('unist-util-select');
 const unified = require('unified');
 const markdown = require('remark-parse');
+const gfm = require('remark-gfm');
 const is = require('unist-util-is');
 const fs = require('fs');
 const path = require('path');
@@ -172,6 +173,7 @@ function remarkExtend({ rootDir = process.cwd(), page } = {}) {
         toInsertNodes = [];
         const parser = unified()
           .use(markdown)
+          .use(gfm)
           .use(handleImportedFile, {
             startSelector,
             endSelector,

--- a/packages-node/remark-extend/test-node/fixtures/import-table.md
+++ b/packages-node/remark-extend/test-node/fixtures/import-table.md
@@ -1,0 +1,6 @@
+## Currencies
+
+| Sign | Name   |
+| ---- | ------ |
+| $    | Dollar |
+| €    | Euro   |

--- a/packages-node/remark-extend/test-node/remark-extend.test.js
+++ b/packages-node/remark-extend/test-node/remark-extend.test.js
@@ -329,4 +329,42 @@ describe('remarkExtend', () => {
       ].join('\n'),
     );
   });
+
+  it('can import files with a table', async () => {
+    const result = await execute(
+      [
+        //
+        '### Static Headline',
+        "```js ::importBlock('./fixtures/import-table.md', '## Currencies')",
+        '```',
+      ].join('\n'),
+    );
+
+    expect(result).to.equal(
+      [
+        //
+        '<h3>Static Headline</h3>',
+        '<h2>Currencies</h2>',
+        '<table>',
+        '<thead>',
+        '<tr>',
+        '<th>Sign</th>',
+        '<th>Name</th>',
+        '</tr>',
+        '</thead>',
+        '<tbody>',
+        '<tr>',
+        '<td>$</td>',
+        '<td>Dollar</td>',
+        '</tr>',
+        '<tr>',
+        '<td>€</td>',
+        '<td>Euro</td>',
+        '</tr>',
+        '</tbody>',
+        '</table>',
+        '',
+      ].join('\n'),
+    );
+  });
 });


### PR DESCRIPTION
## What I did

1. Support GitHub Flavored Markdown (gfm) tables when importing markdown
