### PR TITLE
fix(babel-plugin-extend-docs): handle scopedElement renames

### DIFF
--- a/.changeset/purple-ways-shout.md
+++ b/.changeset/purple-ways-shout.md
@@ -1,0 +1,5 @@
+---
+'babel-plugin-extend-docs': patch
+---
+
+Replace `scopedElements` keys (= tag names) when extending

--- a/packages-node/babel-plugin-extend-docs/test-node/babelPluginExtendDocs.test.js
+++ b/packages-node/babel-plugin-extend-docs/test-node/babelPluginExtendDocs.test.js
@@ -126,6 +126,59 @@ describe('babel-plugin-extend-docs', () => {
     expect(executeBabel(code, testConfig)).to.equal(output);
   });
 
+  it('replaces tags in static get scopedElements()', () => {
+    const code = [
+      "import { html, LitElement, ScopedElementsMixin } from '@lion/core';",
+      "import { LionInput } from '@lion/input';",
+      '',
+      'class MyComponent extends ScopedElementsMixin(LitElement) {',
+      '  static get scopedElements() {',
+      '    return {',
+      '      "lion-input": LionInput',
+      '    };',
+      '  }',
+      '}',
+    ].join('\n');
+    const output = [
+      'import { html, LitElement, ScopedElementsMixin } from "@lion/core";',
+      'import { WolfInput } from "wolf-web/input";',
+      '',
+      'class MyComponent extends ScopedElementsMixin(LitElement) {',
+      '  static get scopedElements() {',
+      '    return {',
+      '      "wolf-input": WolfInput',
+      '    };',
+      '  }',
+      '',
+      '}',
+    ].join('\n');
+    expect(executeBabel(code, testConfig)).to.equal(output);
+  });
+
+  it('replaces tags in static scopedElements =', () => {
+    const code = [
+      "import { html, LitElement, ScopedElementsMixin } from '@lion/core';",
+      "import { LionInput } from '@lion/input';",
+      '',
+      'class MyComponent extends ScopedElementsMixin(LitElement) {',
+      '  static scopedElements = {',
+      '    "lion-input": LionInput',
+      '  };',
+      '}',
+    ].join('\n');
+    const output = [
+      'import { html, LitElement, ScopedElementsMixin } from "@lion/core";',
+      'import { WolfInput } from "wolf-web/input";',
+      '',
+      'class MyComponent extends ScopedElementsMixin(LitElement) {',
+      '  static scopedElements = {',
+      '    "wolf-input": WolfInput',
+      '  };',
+      '}',
+    ].join('\n');
+    expect(executeBabel(code, testConfig)).to.equal(output);
+  });
+
   it("replaces tags also if using ${{key: 'value'}}", () => {
     const code = [
       'export const forceLocale = () => html`',


### PR DESCRIPTION
## What I did

1. Replace `scopedElements` keys (= tag names) when extending
