### PR TITLE
feat(switch): make key handlers protected, enable arrow keys

### DIFF
--- a/.changeset/perfect-bags-compare.md
+++ b/.changeset/perfect-bags-compare.md
@@ -1,0 +1,5 @@
+---
+'@lion/switch': minor
+---
+
+Make keyup handlers protected, enables subclassers to switch using alternative keys.

--- a/packages/switch/src/LionSwitchButton.js
+++ b/packages/switch/src/LionSwitchButton.js
@@ -80,9 +80,9 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
     /** @protected */
     this._toggleChecked = this._toggleChecked.bind(this);
     /** @private */
-    this.__handleKeydown = this.__handleKeydown.bind(this);
+    this.__handleKeydown = this._handleKeydown.bind(this);
     /** @private */
-    this.__handleKeyup = this.__handleKeyup.bind(this);
+    this.__handleKeyup = this._handleKeyup.bind(this);
   }
 
   connectedCallback() {
@@ -121,23 +121,23 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
   }
 
   /**
-   * @param {KeyboardEvent} e
-   * @private
+   * @param {KeyboardEvent} ev
+   * @protected
    */
   // eslint-disable-next-line class-methods-use-this
-  __handleKeydown(e) {
+  _handleKeydown(ev) {
     // prevent "space" scrolling on "macOS"
-    if (e.keyCode === 32) {
-      e.preventDefault();
+    if (ev.key === ' ') {
+      ev.preventDefault();
     }
   }
 
   /**
-   * @param {KeyboardEvent} e
-   * @private
+   * @param {KeyboardEvent} ev
+   * @protected
    */
-  __handleKeyup(e) {
-    if ([32 /* space */, 13 /* enter */].indexOf(e.keyCode) !== -1) {
+  _handleKeyup(ev) {
+    if ([' ', 'Enter'].includes(ev.key)) {
       this._toggleChecked();
     }
   }

--- a/packages/switch/test/lion-switch-button.test.js
+++ b/packages/switch/test/lion-switch-button.test.js
@@ -50,6 +50,19 @@ describe('lion-switch-button', () => {
     expect(el.hasAttribute('checked')).to.be.false;
   });
 
+  it('should toggle the value of "checked" on key-up', async () => {
+    expect(el.checked).to.be.false;
+    expect(el.hasAttribute('checked')).to.be.false;
+    el.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter' }));
+    await el.updateComplete;
+    expect(el.checked).to.be.true;
+    expect(el.hasAttribute('checked')).to.be.true;
+    el.dispatchEvent(new KeyboardEvent('keyup', { key: ' ' }));
+    await el.updateComplete;
+    expect(el.checked).to.be.false;
+    expect(el.hasAttribute('checked')).to.be.false;
+  });
+
   it('can be disabled', async () => {
     el.disabled = true;
     expect(el.checked).to.be.false;


### PR DESCRIPTION
## What I did

1. Make key handler methods protected. People may want to disable some of the keys, maybe add their own keys, etc.
2. By default also allow arrow keys to toggle the switch (but now overridable by subclassers), I think this is a better default especially given the visual cue of a switch which goes from one direction to another, therefore arrow keys make sense as interaction handlers for that. Often, ArrowUp gets paired with ArrowRight (on) in this case, and ArrowDown with ArrowLeft (off)
