### PR TITLE
fix(button): register element registration side effects

### DIFF
--- a/.changeset/thirty-dryers-listen.md
+++ b/.changeset/thirty-dryers-listen.md
@@ -1,0 +1,5 @@
+---
+'@lion/button': patch
+---
+
+Add files that result in customElements.define to sideEffect so build tools don't tree shake them

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -33,7 +33,10 @@
     "test": "cd ../../ && npm run test:browser -- --group button"
   },
   "sideEffects": [
-    "lion-button.js"
+    "lion-button.js",
+    "lion-button-reset.js",
+    "lion-button-submit.js",
+    "define.js"
   ],
   "dependencies": {
     "@lion/core": "0.18.2"


### PR DESCRIPTION
## What I did

1. Add files that result in customElements.define to sideEffect so build tools don't tree shake them
2. This also fixes our not working demos on the lion docs side (for example https://lion-web.netlify.app/components/interaction/button/overview/)
