### PR TITLE
feat(core): rerender SlotMixin templates in update loop

### DIFF
--- a/.changeset/gentle-baboons-smash.md
+++ b/.changeset/gentle-baboons-smash.md
@@ -1,0 +1,5 @@
+---
+'@lion/core': patch
+---
+
+rerender SlotMixin templates in update loop


### PR DESCRIPTION
Some template parts must be plotted to light dom for a11y reasons, and are therefore opted out of the default render loop =>
Allow slot templates to rerender in update loop
