### PR TITLE
remove errant semicolon from tabs npm install step

### DIFF
--- a/docs/components/content/tabs/overview.md
+++ b/docs/components/content/tabs/overview.md
@@ -21,7 +21,7 @@ export const main = () => html`
 ## Installation
 
 ```bash
-npm i --save @lion/tabs;
+npm i --save @lion/tabs
 ```
 
 ```js


### PR DESCRIPTION
## What I did

1. Removed an errant `;` from the Tabs npm install instructions
