### PR TITLE
feat: export lit/static-html.js from lion/core

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -37,6 +37,7 @@ export {
   reparentNodes,
   removeNodes,
 } from 'lit-html';
+export { html as staticHtml } from 'lit/static-html.js';
 export { asyncAppend } from 'lit-html/directives/async-append.js';
 export { asyncReplace } from 'lit-html/directives/async-replace.js';
 export { cache } from 'lit-html/directives/cache.js';


### PR DESCRIPTION
As a subclasser I'd like to use it in my tests but don't want to add lit as a direct dependency as I resolve it from lion.