### PR TITLE
feat: Adds prefix and suffix slots to LionButton

### DIFF
--- a/packages/button/src/LionButton.js
+++ b/packages/button/src/LionButton.js
@@ -35,7 +35,13 @@ export class LionButton extends DisabledWithTabIndexMixin(LitElement) {
   }
 
   render() {
-    return html` <div class="button-content" id="${this._buttonId}"><slot></slot></div> `;
+    return html`
+      <div class="button-content" id="${this._buttonId}">
+        <slot name="prefix"></slot>
+        <slot></slot>
+        <slot name="suffix"></slot>
+      </div>
+    `;
   }
 
   static get styles() {


### PR DESCRIPTION
Enables subclassers to target part of the template rather than overriding the whole render function.