### PR TITLE
fix(textarea): firefox bug with disabled textarea drag

### DIFF
--- a/.changeset/swift-cups-tease.md
+++ b/.changeset/swift-cups-tease.md
@@ -1,0 +1,5 @@
+---
+'@lion/textarea': patch
+---
+
+Temporary fix for a bug in FireFox where disabled textareas can crash the browser if dragged (resized).

--- a/packages/textarea/src/LionTextarea.js
+++ b/packages/textarea/src/LionTextarea.js
@@ -157,6 +157,11 @@ export class LionTextarea extends NativeTextFieldMixin(LionFieldWithTextArea) {
         .input-group__container > .input-group__input ::slotted(.form-control) {
           overflow-x: hidden; /* for FF adds height to the TextArea to reserve place for scroll-bars */
         }
+
+        /* Workaround https://bugzilla.mozilla.org/show_bug.cgi?id=1739079 */
+        :host([disabled]) ::slotted(textarea) {
+          user-select: none;
+        }
       `,
     ];
   }


### PR DESCRIPTION
https://lit-and-friends.slack.com/archives/CJGFWJN9J/p1636110255076200

https://bugzilla.mozilla.org/show_bug.cgi?id=1739079