### PR TITLE
Fix black bars on dialogs with preventsScroll enabled on ios 15

### DIFF
--- a/.changeset/short-horses-run.md
+++ b/.changeset/short-horses-run.md
@@ -1,0 +1,6 @@
+---
+"@lion/overlays": patch
+---
+
+Fix: black bars on dialogs with preventsScroll enabled on ios 15. 
+See https://stackoverflow.com/questions/69589924/ios-15-minimized-address-bar-issue-with-fixed-position-full-screen-content

--- a/packages/overlays/src/OverlaysManager.js
+++ b/packages/overlays/src/OverlaysManager.js
@@ -205,6 +205,7 @@ export class OverlaysManager {
       // iOS has issues with overlays with input fields. This is fixed by applying
       // position: fixed to the body. As a side effect, this will scroll the body to the top.
       document.body.classList.add('global-overlays-scroll-lock-ios-fix');
+      document.documentElement.classList.add('global-overlays-scroll-lock-ios-fix');
     }
   }
 
@@ -213,6 +214,7 @@ export class OverlaysManager {
       document.body.classList.remove('global-overlays-scroll-lock');
       if (isIOS) {
         document.body.classList.remove('global-overlays-scroll-lock-ios-fix');
+        document.documentElement.classList.remove('global-overlays-scroll-lock-ios-fix');
       }
     }
   }

--- a/packages/overlays/src/globalOverlaysStyle.js
+++ b/packages/overlays/src/globalOverlaysStyle.js
@@ -122,4 +122,8 @@ export const globalOverlaysStyle = css`
     position: fixed;
     width: 100%;
   }
+
+  html.global-overlays-scroll-lock-ios-fix {
+    height: 100vh;
+  }
 `;


### PR DESCRIPTION
## What I did

1. Found that the global-overlays-scroll-lock-ios-fix sets position: fixed on the body. 
2. Found out that iOS does not like that, and how to fix it : [Stackoverflow](https://stackoverflow.com/questions/69589924/ios-15-minimized-address-bar-issue-with-fixed-position-full-screen-content)
3. Fix it by applying height: 100vh; to the <html> root element in the same way the other iOS fix is applied.
