### PR TITLE
feat(core): export latest added lit directives

### DIFF
--- a/.changeset/cuddly-ties-repeat.md
+++ b/.changeset/cuddly-ties-repeat.md
@@ -1,0 +1,5 @@
+---
+'@lion/core': patch
+---
+
+Re-export latest added lit directives.

--- a/package.json
+++ b/package.json
@@ -102,11 +102,11 @@
   "bundlesize": [
     {
       "path": "./bundlesize/dist/core/*.js",
-      "maxSize": "11 kB"
+      "maxSize": "12 kB"
     },
     {
       "path": "./bundlesize/dist/all/*.js",
-      "maxSize": "46 kB"
+      "maxSize": "47 kB"
     }
   ],
   "prettier": {

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -55,9 +55,13 @@ export { cache } from 'lit/directives/cache.js';
 export { classMap } from 'lit/directives/class-map.js';
 export { guard } from 'lit/directives/guard.js';
 export { ifDefined } from 'lit/directives/if-defined.js';
+export { live } from 'lit/directives/live.js';
+export { ref, createRef } from 'lit/directives/ref.js';
 export { repeat } from 'lit/directives/repeat.js';
 export { styleMap } from 'lit/directives/style-map.js';
+export { templateContent } from 'lit/directives/template-content.js';
 export { unsafeHTML } from 'lit/directives/unsafe-html.js';
+export { unsafeSVG } from 'lit/directives/unsafe-svg.js';
 export { until } from 'lit/directives/until.js';
 
 // open-wc


### PR DESCRIPTION
Bundlesize core went <11kb to 11.3 kb and all <46kb to 46.06KB, kinda makes sense when adding 4 directives to the re-exports I think :)