### PR TITLE
Fix/providence dashboard path

### DIFF
--- a/.changeset/thin-birds-return.md
+++ b/.changeset/thin-birds-return.md
@@ -1,0 +1,5 @@
+---
+'providence-analytics': major
+---
+
+fix paths for dashboard

--- a/.changeset/tiny-cobras-hear.md
+++ b/.changeset/tiny-cobras-hear.md
@@ -1,5 +1,5 @@
 ---
-'providence-analytics': major
+'providence-analytics': patch
 ---
 
 fix paths for dashboard

--- a/packages-node/providence-analytics/dashboard/src/server.js
+++ b/packages-node/providence-analytics/dashboard/src/server.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 const { LogService } = require('../../src/program/services/LogService.js');
 
 LogService.warn(

--- a/packages-node/providence-analytics/dashboard/src/server.mjs
+++ b/packages-node/providence-analytics/dashboard/src/server.mjs
@@ -2,9 +2,7 @@ import fs from 'fs';
 import pathLib, { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { createConfig, startServer } from 'es-dev-server';
-// eslint-disable-next-line import/no-unresolved
 import { ReportService } from '../../src/program/services/ReportService.js';
-// eslint-disable-next-line import/no-unresolved
 import { getProvidenceConf } from '../../src/program/utils/get-providence-conf.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
## What I did

Accidentally put dashboard files in wrong folder after developing the solution in an external repo. This pr corrects that.

(Reminder: add smoke test for dashboard...)
