### PR TITLE
fix(tabs): prevent selection of disabled tabs.

### DIFF
--- a/.changeset/clever-tables-bow.md
+++ b/.changeset/clever-tables-bow.md
@@ -1,0 +1,5 @@
+---
+'@lion/tabs': patch
+---
+
+Select first not-disabled tab if the first one is disabled.

--- a/.changeset/fair-adults-carry.md
+++ b/.changeset/fair-adults-carry.md
@@ -1,0 +1,5 @@
+---
+'@lion/tabs': minor
+---
+
+Ensures that disabled tab elements are skipped when navigating a tab list with the keyboard.

--- a/docs/components/content/tabs/features.md
+++ b/docs/components/content/tabs/features.md
@@ -38,6 +38,31 @@ export const slotsOrder = () => html`
 `;
 ```
 
+## Disabled tabs
+
+You can disable specific tabs by adding the `disabled` attribute to a tab button.
+
+When using the arrow keys to switch tabs, it will skip disabled tabs, but it will not cycle from last to first or vice versa.
+
+```js preview-story
+export const tabsDisabled = () => html`
+  <lion-tabs>
+    <button slot="tab">tab 1</button>
+    <div slot="panel">panel 1</div>
+    <button slot="tab" disabled>tab 2</button>
+    <div slot="panel">panel 2</div>
+    <button slot="tab" disabled>tab 3</button>
+    <div slot="panel">panel 3</div>
+    <button slot="tab">tab 4</button>
+    <div slot="panel">panel 4</div>
+    <button slot="tab">tab 5</button>
+    <div slot="panel">panel 5</div>
+    <button slot="tab" disabled>tab 6</button>
+    <div slot="panel">panel 6</div>
+  </lion-tabs>
+`;
+```
+
 ## Nesting tabs
 
 You can include tabs within tabs

--- a/packages/tabs/test/lion-tabs.test.js
+++ b/packages/tabs/test/lion-tabs.test.js
@@ -15,6 +15,8 @@ const basicTabs = html`
     <div slot="panel">panel 2</div>
     <button slot="tab">tab 3</button>
     <div slot="panel">panel 3</div>
+    <button slot="tab">tab 4</button>
+    <div slot="panel">panel 4</div>
   </lion-tabs>
 `;
 
@@ -216,7 +218,7 @@ describe('<lion-tabs>', () => {
       const el = /** @type {LionTabs} */ (await fixture(basicTabs));
       const tabs = el.querySelectorAll('[slot=tab]');
       tabs[0].dispatchEvent(new KeyboardEvent('keyup', { key: 'End' }));
-      expect(el.selectedIndex).to.equal(2);
+      expect(el.selectedIndex).to.equal(3);
     });
 
     it('selects first tab on [arrow-right] if on last tab', async () => {
@@ -254,6 +256,90 @@ describe('<lion-tabs>', () => {
       tabs[0].dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft' }));
       expect(el.selectedIndex).to.equal(2);
     });
+
+    it('selects next available not disabled tab if first tab is disabled', async () => {
+      const el = /** @type {LionTabs} */ (
+        await fixture(html`
+          <lion-tabs>
+            <button slot="tab" disabled>tab 1</button>
+            <div slot="panel">panel 1</div>
+            <button slot="tab">tab 2</button>
+            <div slot="panel">panel 2</div>
+            <button slot="tab">tab 3</button>
+            <div slot="panel">panel 3</div>
+          </lion-tabs>
+        `)
+      );
+      expect(el.selectedIndex).to.equal(1);
+    });
+
+    it('selects next available not disabled tab on [arrow-right] and [arrow-down]', async () => {
+      const el = /** @type {LionTabs} */ (
+        await fixture(html`
+          <lion-tabs>
+            <button slot="tab">tab 1</button>
+            <div slot="panel">panel 1</div>
+            <button slot="tab" disabled>tab 2</button>
+            <div slot="panel">panel 2</div>
+            <button slot="tab">tab 3</button>
+            <div slot="panel">panel 3</div>
+            <button slot="tab" disabled>tab 3</button>
+            <div slot="panel">panel 3</div>
+          </lion-tabs>
+        `)
+      );
+      const tabs = el.querySelectorAll('[slot=tab]');
+      tabs[0].dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight' }));
+      expect(el.selectedIndex).to.equal(2);
+    });
+
+    it('selects next available not disabled tab on [arrow-left] and [arrow-up]', async () => {
+      const el = /** @type {LionTabs} */ (
+        await fixture(html`
+          <lion-tabs>
+            <button slot="tab">tab 1</button>
+            <div slot="panel">panel 1</div>
+            <button slot="tab" disabled>tab 2</button>
+            <div slot="panel">panel 2</div>
+            <button slot="tab">tab 3</button>
+            <div slot="panel">panel 3</div>
+            <button slot="tab" disabled>tab 3</button>
+            <div slot="panel">panel 3</div>
+          </lion-tabs>
+        `)
+      );
+      el.selectedIndex = 2;
+      const tabs = el.querySelectorAll('[slot=tab]');
+      tabs[2].dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft' }));
+      expect(el.selectedIndex).to.equal(0);
+    });
+
+    it('cycles through tabs even if the last or first tabs are disabled', async () => {
+      const el = /** @type {LionTabs} */ (
+        await fixture(html`
+          <lion-tabs>
+            <button slot="tab" disabled>tab 0</button>
+            <div slot="panel">panel 0</div>
+            <button slot="tab">tab 1</button>
+            <div slot="panel">panel 1</div>
+            <button slot="tab">tab 2</button>
+            <div slot="panel">panel 2</div>
+            <button slot="tab" disabled>tab 3</button>
+            <div slot="panel">panel 3</div>
+          </lion-tabs>
+        `)
+      );
+      const tabs = el.querySelectorAll('[slot=tab]');
+      el.selectedIndex = 1;
+
+      // 0 is disabled, same for 3, so should go to 2
+      tabs[1].dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowLeft' }));
+      expect(el.selectedIndex).to.equal(2);
+
+      // 3 is disabled, same for 0, so should go to 1
+      tabs[2].dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowRight' }));
+      expect(el.selectedIndex).to.equal(1);
+    });
   });
 
   describe('Content distribution', () => {
@@ -276,12 +362,12 @@ describe('<lion-tabs>', () => {
       const selectedTab = Array.from(el.children).find(
         child => child.slot === 'tab' && child.hasAttribute('selected'),
       );
-      expect(selectedTab && selectedTab.textContent).to.equal('tab 5');
+      expect(selectedTab && selectedTab.textContent).to.equal('tab 6');
 
       const selectedPanel = Array.from(el.children).find(
         child => child.slot === 'panel' && child.hasAttribute('selected'),
       );
-      expect(selectedPanel && selectedPanel.textContent).to.equal('panel 5');
+      expect(selectedPanel && selectedPanel.textContent).to.equal('panel 6');
     });
   });
 


### PR DESCRIPTION
## What I did

1. Added a function to retrieve the next available index of a not-disabled tab. Depending on the keyboard direction, the next available not-disabled tab will be selected.  
3. Added tests to ensure disabled tabs are skipped with [arrow-right]/[arrow-down] and [arrow-left]/[arrow-up].

## Context
Currently, any disabled tabs within a tab list are still selectable. A user shouldn't be able to interact with a disabled tab – please see a minimal reproduction [here](https://codesandbox.io/s/lion-tabs-disabled-attr-issue-nwrzu?file=/src/index.js). 

Unfortunately,  adding an early return if the next tab element is disabled will not cover all edge cases (as originally mentioned in the Slack channel). We could have instances where there are disabled tabs in varying orders within the tab list.

## Visual

https://user-images.githubusercontent.com/30320536/144885840-cd804b7a-4ef7-4f02-b3ba-67c11a1c0ca7.mov


