### PR TITLE
fix: use node wildcard exports for docs

### DIFF
--- a/.changeset/bright-impalas-cheer.md
+++ b/.changeset/bright-impalas-cheer.md
@@ -1,0 +1,47 @@
+---
+'babel-plugin-extend-docs': patch
+'providence-analytics': patch
+'publish-docs': patch
+'remark-extend': patch
+'rocket-preset-extend-lion-docs': patch
+'@lion/accordion': patch
+'@lion/ajax': patch
+'@lion/button': patch
+'@lion/calendar': patch
+'@lion/checkbox-group': patch
+'@lion/collapsible': patch
+'@lion/combobox': patch
+'@lion/core': patch
+'@lion/dialog': patch
+'@lion/fieldset': patch
+'@lion/form': patch
+'@lion/form-core': patch
+'@lion/form-integrations': patch
+'@lion/helpers': patch
+'@lion/icon': patch
+'@lion/input': patch
+'@lion/input-amount': patch
+'@lion/input-date': patch
+'@lion/input-datepicker': patch
+'@lion/input-email': patch
+'@lion/input-iban': patch
+'@lion/input-range': patch
+'@lion/input-stepper': patch
+'@lion/listbox': patch
+'@lion/localize': patch
+'@lion/overlays': patch
+'@lion/pagination': patch
+'@lion/progress-indicator': patch
+'@lion/radio-group': patch
+'@lion/select': patch
+'@lion/select-rich': patch
+'singleton-manager': patch
+'@lion/steps': patch
+'@lion/switch': patch
+'@lion/tabs': patch
+'@lion/textarea': patch
+'@lion/tooltip': patch
+'@lion/validate-messages': patch
+---
+
+Replace deprecated node folder exports with wildcard exports for docs

--- a/packages-node/babel-plugin-extend-docs/package.json
+++ b/packages-node/babel-plugin-extend-docs/package.json
@@ -34,7 +34,7 @@
   },
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   },
   "imports": {
     "#source/counter": "./demo/src/SourceCounter.js",

--- a/packages-node/providence-analytics/package.json
+++ b/packages-node/providence-analytics/package.json
@@ -73,6 +73,6 @@
     ".": "./src/index.js",
     "./src/cli": "./src/cli/index.js",
     "./analyzers": "./src/program/analyzers/index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/publish-docs/package.json
+++ b/packages-node/publish-docs/package.json
@@ -40,6 +40,6 @@
   },
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/remark-extend/package.json
+++ b/packages-node/remark-extend/package.json
@@ -40,6 +40,6 @@
   },
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/accordion/@lion/accordion/package.json
+++ b/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/accordion/@lion/accordion/package.json
@@ -50,6 +50,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-accordion.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/checkbox-group/@lion/checkbox-group/package.json
+++ b/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/checkbox-group/@lion/checkbox-group/package.json
@@ -58,6 +58,6 @@
     "./define-checkbox-group": "./lion-checkbox-group.js",
     "./define-checkbox-indeterminate": "./lion-checkbox-indeterminate.js",
     "./define": "./define.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/core/@lion/core/package.json
+++ b/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/core/@lion/core/package.json
@@ -49,6 +49,6 @@
   "customElementsManifest": "custom-elements.json",
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/export-map-json/@lion/accordion/exports.json
+++ b/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/export-map-json/@lion/accordion/exports.json
@@ -50,6 +50,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-accordion.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/multi-line/@lion/core/package.json
+++ b/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/multi-line/@lion/core/package.json
@@ -49,6 +49,6 @@
   "customElementsManifest": "custom-elements.json",
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/no-node-modules-scope-folder/accordion/package.json
+++ b/packages-node/rocket-preset-extend-lion-docs/test-node/fixtures/no-node-modules-scope-folder/accordion/package.json
@@ -50,6 +50,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-accordion.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -50,6 +50,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-accordion.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -43,6 +43,6 @@
   },
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -56,6 +56,6 @@
     "./define-button-reset": "./lion-button-reset.js",
     "./define-button-submit": "./lion-button-submit.js",
     "./define": "./define.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -53,6 +53,6 @@
     "./define": "./lion-calendar.js",
     "./translations/*": "./translations/*",
     "./test-helpers": "./test-helpers/index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -58,6 +58,6 @@
     "./define-checkbox-group": "./lion-checkbox-group.js",
     "./define-checkbox-indeterminate": "./lion-checkbox-indeterminate.js",
     "./define": "./define.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -53,6 +53,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-collapsible.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -63,6 +63,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-combobox.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,6 +52,6 @@
     "./test-helpers": "./test-helpers/index.js",
     "./closestPolyfill": "./src/closestPolyfill.js",
     "./differentKeyEventNamesShimIE": "./src/differentKeyEventNamesShimIE.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -52,6 +52,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-dialog.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -52,6 +52,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-fieldset.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -57,6 +57,6 @@
     "./define": "./define.js",
     "./define-field": "./lion-field.js",
     "./define-validation-feedback": "./lion-validation-feedback.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/form-integrations/package.json
+++ b/packages/form-integrations/package.json
@@ -66,6 +66,6 @@
   },
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -50,6 +50,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-form.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -52,6 +52,6 @@
     "./define": "./define.js",
     "./define-sb-action-logger": "./sb-action-logger.js",
     "./define-sb-locale-switcher": "./sb-locale-switcher.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -52,6 +52,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-icon.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -54,6 +54,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-input-amount.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -54,6 +54,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-input-date.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -61,6 +61,6 @@
     "./define": "./lion-input-datepicker.js",
     "./test-helpers": "./test-helpers.js",
     "./translations/*": "./translations/*",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -54,6 +54,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-input-email.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -56,6 +56,6 @@
     ".": "./index.js",
     "./define": "./lion-input-iban.js",
     "./translations/*": "./translations/*",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-range/package.json
+++ b/packages/input-range/package.json
@@ -53,6 +53,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-input-range.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input-stepper/package.json
+++ b/packages/input-stepper/package.json
@@ -53,6 +53,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-input-stepper.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -50,7 +50,7 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-input.js",
-    "./docs/": "./docs/",
+    "./docs/*": "./docs/*",
     "./test-helpers": "./test-helpers/index.js"
   }
 }

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -60,6 +60,6 @@
     "./define-listbox": "./lion-listbox.js",
     "./define-option": "./lion-option.js",
     "./define-options": "./lion-options.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -48,6 +48,6 @@
   "exports": {
     ".": "./index.js",
     "./test-helpers": "./test-helpers/index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -54,6 +54,6 @@
     "./test-suites": "./test-suites/index.js",
     "./translations/*": "./translations/*",
     "./test-helpers": "./test-helpers/index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -52,6 +52,6 @@
     ".": "./index.js",
     "./define": "./lion-pagination.js",
     "./translations/*": "./translations/*",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/progress-indicator/package.json
+++ b/packages/progress-indicator/package.json
@@ -54,6 +54,6 @@
     ".": "./index.js",
     "./define": "./lion-progress-indicator.js",
     "./translations/*": "./translations/*",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -56,6 +56,6 @@
     "./define": "./define.js",
     "./define-radio": "./lion-radio.js",
     "./define-radio-group": "./lion-radio-group.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/select-rich/package.json
+++ b/packages/select-rich/package.json
@@ -66,6 +66,6 @@
     "./define-options": "./lion-options.js",
     "./define-select-invoker": "./lion-select-invoker.js",
     "./define-select-rich": "./lion-select-rich.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -51,6 +51,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-select.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/singleton-manager/package.json
+++ b/packages/singleton-manager/package.json
@@ -43,6 +43,6 @@
   },
   "exports": {
     ".": "./index.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -54,6 +54,6 @@
     "./define": "./define.js",
     "./define-step": "./lion-step.js",
     "./define-steps": "./lion-steps.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -56,6 +56,6 @@
     "./define": "./define.js",
     "./define-switch": "./lion-switch.js",
     "./define-switch-button": "./lion-switch-button.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -50,6 +50,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-tabs.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -53,6 +53,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-textarea.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -51,6 +51,6 @@
   "exports": {
     ".": "./index.js",
     "./define": "./lion-tooltip.js",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }

--- a/packages/validate-messages/package.json
+++ b/packages/validate-messages/package.json
@@ -49,6 +49,6 @@
   "exports": {
     ".": "./index.js",
     "./translations/*": "./translations/*",
-    "./docs/": "./docs/"
+    "./docs/*": "./docs/*"
   }
 }


### PR DESCRIPTION
## What I did

1. Exports with an ending `/` are deprecated and are no longer supported in node 17
2. Change them to a valid syntax
