### PR TITLE
fix: type info in OverlayMixinTypes

### DIFF
--- a/.changeset/grumpy-lemons-repeat.md
+++ b/.changeset/grumpy-lemons-repeat.md
@@ -1,0 +1,6 @@
+---
+'@lion/overlays': patch
+'@lion/select-rich': patch
+---
+
+Fix type information for the overlayMixin and remove obsolete toggle

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -5,7 +5,6 @@ import { isEqualConfig } from './utils/is-equal-config.js';
 /**
  * @typedef {import('../types/OverlayConfig').OverlayConfig} OverlayConfig
  * @typedef {import('../types/OverlayMixinTypes').DefineOverlayConfig} DefineOverlayConfig
- * @typedef {import('../types/OverlayMixinTypes').OverlayHost} OverlayHost
  * @typedef {import('../types/OverlayMixinTypes').OverlayMixin} OverlayMixin
  */
 

--- a/packages/overlays/types/OverlayMixinTypes.d.ts
+++ b/packages/overlays/types/OverlayMixinTypes.d.ts
@@ -21,9 +21,9 @@ export declare class OverlayHost {
   get config(): OverlayConfig;
   set config(value: OverlayConfig);
 
-  open(): void;
-  close(): void;
-  toggle(): void;
+  open(): Promise<void>;
+  close(): Promise<void>;
+  toggle(): Promise<void>;
   /**
    * Sometimes it's needed to recompute Popper position of an overlay, for instance when we have
    * an opened combobox and the surrounding context changes (the space consumed by the textbox

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -247,11 +247,6 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
     this._onFormElementsChanged();
   }
 
-  // TODO: move to overlayMixin and offer open and close
-  toggle() {
-    this.opened = !this.opened;
-  }
-
   /**
    * In the select disabled options are still going to a possible value for example
    * when prefilling or programmatically setting it.


### PR DESCRIPTION
## What I did

1.  The type for `open`, `close` and `toggle` of the overlayMixin were incorrect, because the functions are async. That means that the return type should be `Promise<void>` instead of `void`.
1. Removed type import as it was not used.  
1. Removed the `toggle` from `LionSelectRich` as this can be handled by the `overlayMixin` now (as the TODO states).

There are 2 failing tests that already failed before I started, so I assume my changes do not have effect on those tests. Let me know if I have to make them work in order to get this pull request merged. Also, let me know if I messed something up :)