### PR TITLE
Fix: Prevent default behavior while scrolling using arrow keys in a h…

### DIFF
--- a/.changeset/tasty-socks-hammer.md
+++ b/.changeset/tasty-socks-hammer.md
@@ -1,0 +1,5 @@
+---
+'@lion/listbox': patch
+---
+
+Fix: Prevent default behavior while scrolling using arrow keys in a horizontal listbox

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -589,6 +589,7 @@ const ListboxMixinImplementation = superclass =>
           }
           break;
         case 'ArrowLeft':
+          ev.preventDefault();
           if (this.orientation === 'horizontal') {
             this.activeIndex = this._getPreviousEnabledOption(this.activeIndex);
           }
@@ -600,6 +601,7 @@ const ListboxMixinImplementation = superclass =>
           }
           break;
         case 'ArrowRight':
+          ev.preventDefault();
           if (this.orientation === 'horizontal') {
             this.activeIndex = this._getNextEnabledOption(this.activeIndex);
           }


### PR DESCRIPTION
…orizontal listbox

## What I did

1. Added ev.preventDefault in the left and right arrow key handlers in the listboxmixin, to prevent the listbox from scrolling unintended when using these keys to navigate through the list when it is horizontal. The same fix has been already applied for vertical scrolling.

## How to test
1. On the current master, check the horizontal listbox example using a browser window that is smaller than the width of the listbox. Using arrow keys, it will start scrolling even if the next option is completely in view due to default scrolling behavior of these arrow keys.