### PR TITLE
chore: lint-versions to do semver satisfy check

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
         '**/demo/**/*.js',
         '**/docs/**/*.js',
         '**/*.config.js',
+        'scripts/**/*.js',
       ],
       rules: {
         'lit/binding-positions': 'off',

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "remark-html": "^13.0.1",
     "rimraf": "^2.6.3",
     "rollup": "^2.0.0",
+    "semver": "^7.3.5",
     "sinon": "^7.2.2",
     "ssl-root-cas": "^1.3.1",
     "typescript": "4.5.5",


### PR DESCRIPTION
Sooo after we merged the last PR, in the release workflow we would run changeset version which bumps `@lion/core`.

lint-versions was ran afterwards on precommit and started complaining, because it decided 0.21.1 was not okay with ^0.21.0, however, this should be okay because we use caret.

I adjusted the script to do a `semver.satisfies` which takes the version (0.21.1) and checks if it satisfies the range (^0.21.0).

There is also a situation where two ranges are compared, e.g. when root package.json has a devDependency and a subpackage has that same dependency (but as a real dependency), e.g. semver ^7.1.3 and ^7.3.5. 
I'm not sure if we're supposed to be comparing them, but I guess it's a good practice to have them aligned from semver perspective.
In this case, you can convert both ranges to full ranges with semver, and check if they sufficiently overlap: one range needs to fully contains the other. That makes them compatible, I think, meaning they would always resolve to the same installation which gets deduped. I tried to check it with a small manual test and it seemed ok:
![image](https://user-images.githubusercontent.com/36734656/156175448-59e2c168-1120-4f9b-8fa7-9a7f915be337.png)

