### PR TITLE
feat(breadcrumb): new component LionBreadcrumb

### DIFF
--- a/docs/components/navigation/breadcrumb/examples.md
+++ b/docs/components/navigation/breadcrumb/examples.md
@@ -1,0 +1,47 @@
+# Navigation >> Breadcrumb >> Examples ||30
+
+```js script
+import { css, html } from '@mdjs/mdjs-preview';
+import { LionBreadcrumb } from '@lion/breadcrumb';
+```
+
+```js preview-story
+export const customBreadcrumbSeparator = () => {
+  if (!customElements.get('custom-breadcrumb')) {
+    customElements.define(
+      'custom-breadcrumb',
+      class extends LionBreadcrumb {
+        static get styles() {
+          return [
+            ...super.styles,
+            css`
+              :host {
+                --lion-breadcrumb-separator: '→';
+              }
+              nav.breadcrumb {
+                padding: 0.8em 1em;
+                border: 1px solid hsl(0deg 0% 90%);
+                border-radius: 4px;
+                background: hsl(300deg 14% 97%);
+              }
+              nav.breadcrumb [aria-current='page'] {
+                color: #000;
+                font-weight: 700;
+                text-decoration: none;
+              }
+            `,
+          ];
+        }
+      },
+    );
+  }
+  return html`
+    <custom-breadcrumb>
+      <a href="../../../">Home</a>
+      <a href="../../">Category</a>
+      <a href="../">Sub Category</a>
+      <a href="./">Product</a>
+    </custom-breadcrumb>
+  `;
+};
+```

--- a/docs/components/navigation/breadcrumb/index.md
+++ b/docs/components/navigation/breadcrumb/index.md
@@ -1,0 +1,3 @@
+# Navigation >> Breadcrumb
+
+-> go to Overview

--- a/docs/components/navigation/breadcrumb/overview.md
+++ b/docs/components/navigation/breadcrumb/overview.md
@@ -1,0 +1,37 @@
+# Navigation >> Breadcrumb >> Overview ||20
+
+A breadcrumb trail consists of a list of links to the parent pages of the current page in hierarchical order. It helps users find their place within a website or web application. Breadcrumbs are often placed horizontally before a page's main content.
+
+```js script
+import { html } from '@mdjs/mdjs-preview';
+import '@lion/breadcrumb/define';
+```
+
+```js preview-story
+export const main = () => html`
+  <lion-breadcrumb>
+    <a href="../../../../">Home</a>
+    <a href="../../../">Components</a>
+    <a href="../../">Navigation</a>
+    <a href="../">Breadcrumb</a>
+    <span>Overview</span>
+  </lion-breadcrumb>
+`;
+```
+
+## Features
+
+- Handles accessibility
+- Custom separators via CSS
+
+## Installation
+
+```bash
+npm i --save @lion/breadcrumb
+```
+
+```js
+import { LionBreadcrumb } from '@lion/breadcrumb';
+// or
+import '@lion/breadcrumb';
+```

--- a/packages/breadcrumb/README.md
+++ b/packages/breadcrumb/README.md
@@ -1,0 +1,37 @@
+# Navigation >> Breadcrumb >> Overview ||20
+
+A breadcrumb trail consists of a list of links to the parent pages of the current page in hierarchical order. It helps users find their place within a website or web application. Breadcrumbs are often placed horizontally before a page's main content.
+
+```js script
+import { html } from '@mdjs/mdjs-preview';
+import '@lion/breadcrumb/define';
+```
+
+```js preview-story
+export const main = () => html`
+  <lion-breadcrumb>
+    <a href="../../../../">Home</a>
+    <a href="../../../">Components</a>
+    <a href="../../">Navigation</a>
+    <a href="../">Breadcrumb</a>
+    <span>Overview</span>
+  </lion-breadcrumb>
+`;
+```
+
+## Features
+
+- Handles accessibility
+- Custom separators via CSS
+
+## Installation
+
+```bash
+npm i --save @lion/breadcrumb
+```
+
+```js
+import { LionBreadcrumb } from '@lion/breadcrumb';
+// or
+import '@lion/breadcrumb';
+```

--- a/packages/breadcrumb/docs/overview.md
+++ b/packages/breadcrumb/docs/overview.md
@@ -1,0 +1,3 @@
+# Lion Breadcrumb Overview
+
+[=> See Source <=](../../../docs/components/navigation/breadcrumb/overview.md)

--- a/packages/breadcrumb/index.js
+++ b/packages/breadcrumb/index.js
@@ -1,0 +1,1 @@
+export { LionBreadcrumb } from './src/LionBreadcrumb.js';

--- a/packages/breadcrumb/lion-breadcrumb.js
+++ b/packages/breadcrumb/lion-breadcrumb.js
@@ -1,0 +1,3 @@
+import { LionBreadcrumb } from './src/LionBreadcrumb.js';
+
+customElements.define('lion-breadcrumb', LionBreadcrumb);

--- a/packages/breadcrumb/package.json
+++ b/packages/breadcrumb/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@lion/breadcrumb",
+  "version": "0.8.0",
+  "description": "A breadcrumb trail consists of a list of links to the parent pages of the current page in hierarchical order.",
+  "license": "MIT",
+  "author": "ing-bank",
+  "homepage": "https://github.com/ing-bank/lion/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ing-bank/lion.git",
+    "directory": "packages/breadcrumb"
+  },
+  "main": "index.js",
+  "module": "index.js",
+  "files": [
+    "*.d.ts",
+    "*.js",
+    "custom-elements.json",
+    "docs",
+    "src",
+    "test",
+    "test-helpers",
+    "translations",
+    "types"
+  ],
+  "scripts": {
+    "custom-elements-manifest": "custom-elements-manifest analyze --litelement --exclude \"docs/**/*\" \"test-helpers/**/*\"",
+    "debug": "cd ../../ && npm run debug -- --group breadcrumb",
+    "debug:firefox": "cd ../../ && npm run debug:firefox -- --group breadcrumb",
+    "debug:webkit": "cd ../../ && npm run debug:webkit -- --group breadcrumb",
+    "publish-docs": "node ../../packages-node/publish-docs/src/cli.js --github-url https://github.com/ing-bank/lion/ --git-root-dir ../../",
+    "prepublishOnly": "npm run publish-docs && npm run custom-elements-manifest",
+    "test": "cd ../../ && npm run test:browser -- --group breadcrumb"
+  },
+  "sideEffects": [
+    "lion-breadcrumb.js"
+  ],
+  "dependencies": {
+    "@lion/core": "^0.21.0"
+  },
+  "keywords": [
+    "breadcrumb",
+    "lion",
+    "web-components"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "customElements": "custom-elements.json",
+  "exports": {
+    ".": "./index.js",
+    "./define": "./lion-breadcrumb.js",
+    "./docs/*": "./docs/*"
+  }
+}

--- a/packages/breadcrumb/src/LionBreadcrumb.js
+++ b/packages/breadcrumb/src/LionBreadcrumb.js
@@ -1,0 +1,50 @@
+import { LitElement, css, html } from '@lion/core';
+
+export class LionBreadcrumb extends LitElement {
+  static get styles() {
+    return [
+      css`
+        :host {
+          display: block;
+          --lion-breadcrumb-separator: '/';
+        }
+
+        nav.breadcrumb ol {
+          margin: 0;
+          padding-left: 0;
+          list-style: none;
+        }
+
+        nav.breadcrumb li {
+          display: inline;
+        }
+
+        nav.breadcrumb li + li::before {
+          display: inline-block;
+          margin: 0 0.25em;
+          height: 0.8em;
+          content: var(--lion-breadcrumb-separator);
+        }
+
+        nav.breadcrumb [aria-current='page'] {
+          text-decoration: none;
+        }
+      `,
+    ];
+  }
+
+  render() {
+    return html`
+      <nav aria-label="Breadcrumb" class="breadcrumb">
+        <ol>
+          ${Array.from(this.children).map((children, i, row) => {
+            if (i + 1 === row.length && children.getAttribute('href')) {
+              children.setAttribute('aria-current', 'page');
+            }
+            return html`<li>${children}</li>`;
+          })}
+        </ol>
+      </nav>
+    `;
+  }
+}

--- a/packages/breadcrumb/src/LionBreadcrumb.js
+++ b/packages/breadcrumb/src/LionBreadcrumb.js
@@ -37,11 +37,11 @@ export class LionBreadcrumb extends LitElement {
     return html`
       <nav aria-label="Breadcrumb" class="breadcrumb">
         <ol>
-          ${Array.from(this.children).map((children, i, row) => {
-            if (i + 1 === row.length && children.getAttribute('href')) {
-              children.setAttribute('aria-current', 'page');
+          ${Array.from(this.children).map((child, i, row) => {
+            if (i + 1 === row.length && child.getAttribute('href')) {
+              child.setAttribute('aria-current', 'page');
             }
-            return html`<li>${children}</li>`;
+            return html`<li>${child}</li>`;
           })}
         </ol>
       </nav>

--- a/packages/breadcrumb/test/lion-breadcrumb.test.js
+++ b/packages/breadcrumb/test/lion-breadcrumb.test.js
@@ -1,0 +1,90 @@
+import { html, css } from 'lit';
+import { fixture, expect } from '@open-wc/testing';
+
+import '../lion-breadcrumb.js';
+import { LionBreadcrumb } from '../src/LionBreadcrumb.js';
+
+const basicBreadcrumb = html`
+  <lion-breadcrumb>
+    <a href="../../">Home</a>
+    <a href="../../">Menu</a>
+    <a href="../">Current</a>
+  </lion-breadcrumb>
+`;
+
+if (!customElements.get('custom-breadcrumb')) {
+  customElements.define(
+    'custom-breadcrumb',
+    // @ts-ignore
+    class extends LionBreadcrumb {
+      static get styles() {
+        return [
+          ...super.styles,
+          // @ts-ignore
+          css`
+            :host {
+              --lion-breadcrumb-separator: '→';
+            }
+          `,
+        ];
+      }
+    },
+  );
+}
+
+const customSeparatorBreadcrumb = html`
+  <custom-breadcrumb>
+    <a href="../../../">Home</a>
+    <a href="../../">Category</a>
+    <a href="../">Sub Category</a>
+    <span>Product</span>
+  </custom-breadcrumb>
+`;
+
+describe('LionBreadcrumb', () => {
+  it('should not render a separator for the first item', async () => {
+    const el = await fixture(basicBreadcrumb);
+    // @ts-ignore
+    const { firstElementChild } = el.shadowRoot.querySelector('ol');
+
+    expect(
+      window.getComputedStyle(firstElementChild, '::before').getPropertyValue('content'),
+    ).to.be.equal('none');
+  });
+
+  it('should be able to override the separator', async () => {
+    const el = await fixture(customSeparatorBreadcrumb);
+    // @ts-ignore
+    const { lastElementChild } = el.shadowRoot.querySelector('ol');
+
+    expect(
+      window.getComputedStyle(lastElementChild, '::before').getPropertyValue('content'),
+    ).to.be.equal('"→"');
+  });
+
+  it('should set the `aria-current="page"` to the last node anchor when `href` is passed', async () => {
+    const el = await fixture(basicBreadcrumb);
+
+    const lastChildAnchorElement =
+      // @ts-ignore
+      el.shadowRoot.querySelector('ol').lastElementChild.firstElementChild;
+
+    expect(lastChildAnchorElement).to.have.attribute('aria-current', 'page');
+  });
+
+  it('should not set the `aria-current="page"` to the last node does not have href', async () => {
+    const el = await fixture(customSeparatorBreadcrumb);
+
+    const lastChildAnchorElement =
+      // @ts-ignore
+      el.shadowRoot.querySelector('ol').lastElementChild.firstElementChild;
+
+    expect(lastChildAnchorElement).to.not.have.attribute('aria-current', 'page');
+  });
+
+  it('passes the a11y audit', async () => {
+    const el = await fixture(basicBreadcrumb);
+
+    await expect(el).shadowDom.to.be.accessible();
+  });
+});

--- a/packages/breadcrumb/test/lion-breadcrumb.test.js
+++ b/packages/breadcrumb/test/lion-breadcrumb.test.js
@@ -42,6 +42,17 @@ const customSeparatorBreadcrumb = html`
 `;
 
 describe('LionBreadcrumb', () => {
+  it('should render the children', async () => {
+    const el = await fixture(basicBreadcrumb);
+    // @ts-ignore
+    const { children } = el.shadowRoot.querySelector('ol');
+
+    expect(children.length).to.be.equal(3);
+    expect(children[0].innerText).to.be.equal('Home');
+    expect(children[1].innerText).to.be.equal('Menu');
+    expect(children[2].innerText).to.be.equal('Current');
+  });
+
   it('should not render a separator for the first item', async () => {
     const el = await fixture(basicBreadcrumb);
     // @ts-ignore


### PR DESCRIPTION
## What I did

New Breadcrumb component based on https://www.w3.org/TR/wai-aria-practices/#breadcrumb

<img width="451" alt="image" src="https://user-images.githubusercontent.com/6368863/157189342-dd16c492-87b1-4ce1-b790-eb7c047b7207.png">

1. Custom separator override via css.
2. Would set `aria-current="page"` to the last element if there is an `href` attribute.

Feedback is cool.