### PR TITLE
fix(lang): fix default en-PH date validation message

### DIFF
--- a/.changeset/tender-rockets-vanish.md
+++ b/.changeset/tender-rockets-vanish.md
@@ -1,0 +1,5 @@
+---
+'@lion/validate-messages': patch
+---
+
+Fixed en-PH default validation message

--- a/packages/validate-messages/src/loadDefaultFeedbackMessages.js
+++ b/packages/validate-messages/src/loadDefaultFeedbackMessages.js
@@ -61,6 +61,7 @@ export function loadDefaultFeedbackMessages() {
             case 'en-US':
               return import('@lion/validate-messages/translations/en-US.js');
             case 'en-PH':
+              return import('@lion/validate-messages/translations/en-PH.js');
             case 'en':
               return import('@lion/validate-messages/translations/en.js');
             case 'es-ES':

--- a/packages/validate-messages/translations/en-PH.js
+++ b/packages/validate-messages/translations/en-PH.js
@@ -1,0 +1,13 @@
+import en from './en.js';
+
+export default {
+  ...en,
+  error: {
+    ...en.error,
+    IsDate: 'Please enter a valid date (MM/DD/YYYY).',
+  },
+  warning: {
+    ...en.warning,
+    IsDate: 'Please enter a valid date (MM/DD/YYYY).',
+  },
+};


### PR DESCRIPTION
## What I did

1. Fixed default date validation message for `en-PH`.
<img width="353" alt="image" src="https://user-images.githubusercontent.com/6368863/157195395-c23b1aa5-50f8-4c07-863d-fcfbb193e463.png">


Please let me know if I missed some files.