### PR TITLE
[remark-extend] failing tests for advanced js

### DIFF
--- a/packages-node/remark-extend/package.json
+++ b/packages-node/remark-extend/package.json
@@ -32,6 +32,12 @@
     "unist-util-select": "^3.0.1",
     "unist-util-visit": "^2.0.2"
   },
+  "devDependencies": {
+    "hast-util-sanitize": "^4.0.0",
+    "hast-util-to-mdast": "^8.3.1",
+    "mdast-util-to-hast": "^12.1.1",
+    "mdast-util-to-markdown": "^1.3.0"
+  },
   "keywords": [
     "remark"
   ],

--- a/packages-node/remark-extend/test-node/fixtures/js-advanced-1.md
+++ b/packages-node/remark-extend/test-node/fixtures/js-advanced-1.md
@@ -1,0 +1,11 @@
+```js
+import { sharedVar } from 'some-global-lib';
+// This path needs to be rewritten to that of the importing context
+import '../some-local-file.js';
+```
+
+## Consuming shared var
+
+```js
+export const x = sharedVar`My Example`;
+```

--- a/packages-node/remark-extend/test-node/fixtures/js-advanced-2.md
+++ b/packages-node/remark-extend/test-node/fixtures/js-advanced-2.md
@@ -1,0 +1,12 @@
+```js
+import { sharedVar } from 'some-other-global-lib';
+```
+
+The var below conflicts when someone imports blocks from both js-advanced-1.md and js-advanced-2.md in
+the same file.
+
+## Consuming conflicting shared var
+
+```js
+export const y = sharedVar`My Example`;
+```

--- a/packages-node/remark-extend/test-node/fixtures/js-simple.md
+++ b/packages-node/remark-extend/test-node/fixtures/js-simple.md
@@ -1,0 +1,5 @@
+## Simple
+
+```js
+const x = 'My Example';
+```

--- a/packages-node/remark-extend/test-node/unifiedToMarkdown.mjs
+++ b/packages-node/remark-extend/test-node/unifiedToMarkdown.mjs
@@ -1,0 +1,43 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { toMdast } from 'hast-util-to-mdast';
+import { toMarkdown } from 'mdast-util-to-markdown';
+import { sanitize } from 'hast-util-sanitize';
+import { toHast } from 'mdast-util-to-hast';
+
+/**
+ * Plugin to serialize markdown as HTML.
+ *
+ * @type {import('unified').Plugin<[Options?]|void[], Root, string>}
+ */
+export async function unifiedToMarkdown(settings = {}) {
+  const options = { ...settings };
+
+  // eslint-disable-next-line no-use-before-define
+  Object.assign(this, { Compiler: compiler });
+
+  /**
+   * @type {import('unified').CompilerFunction<Root, string>}
+   */
+  function compiler(node, file) {
+    const hast = toHast(node, {
+      allowDangerousHtml: true,
+      handlers: options.handlers,
+    });
+    const mdAst = toMdast(hast);
+    const result = toMarkdown(mdAst);
+
+    if (file.extname) {
+      // eslint-disable-next-line no-param-reassign
+      file.extname = '.md';
+    }
+
+    // Add an eof eol.
+    return node &&
+      node.type &&
+      node.type === 'root' &&
+      result &&
+      /[^\r\n]/.test(result.charAt(result.length - 1))
+      ? `${result}\n`
+      : result;
+  }
+}


### PR DESCRIPTION
Test cases that illustrate the issue addressed here: https://github.com/ing-bank/lion/issues/1578

```js
    it('supports js content', async () => {
      const result = await executeMd(
        [
          //
          "```js ::importBlockContent('./fixtures/js-simple.md', '## Simple')",
          '```',
        ].join('\n'),
      );

      expect(result).to.equal(
        [
          //
          '```js',
          "const x = 'My Example';",
          '```',
          '',
        ].join('\n'),
      );
    });

    it('considers variables outside imported block', async () => {
      const result = await executeMd(
        [
          //
          "```js ::importBlockContent('./fixtures/js-advanced-1.md', '## Consuming shared var')",
          '```',
        ].join('\n'),
      );

      expect(result).to.equal(
        [
          //
          '```js',
          "import { sharedVar } from 'some-global-lib';",
          // This file is needed for its side effect
          // Note its location changed from '../some-local-file.js' to './some-local-file.js'
          "import './some-local-file.js';",
          '```',
          '',
          '```js',
          'export const x = sharedVar`My Example`;',
          '```',
          '',
        ].join('\n'),
      );
    });

    // N.B. if the goal of remark-extend is only to extend lion docs, we can limit the
    // functionality to 1:1 mappings of page names and leave this a nice to have
    it.skip('considers name clashes in variables outside imported blocks of multiple files', async () => {
      const result = await executeMd(
        [
          //
          "```js ::importBlockContent('./fixtures/js-advanced-1.md', '## Consuming shared var')",
          '```',
          '',
          "```js ::importBlockContent('./fixtures/js-advanced-2.md', '## Consuming conflicting shared var')",
          '```',
        ].join('\n'),
      );

      expect(result).to.equal(
        [
          //
          '```js',
          "import { sharedVar } from 'some-global-lib';",
          "import { sharedVar_2 } from 'some-other-global-lib';",
          "import '../some-local-file.js';",
          '```',
          '',
          '```js',
          'export const x = sharedVar`My Example`;',
          '```',
          '',
          '```js',
          'export const y = sharedVar_2`My Example`;',
          '```',
          '',
        ].join('\n'),
      );
    });
```