### PR TITLE
feat: update to @open-wc/scoped-element not needing a polyfill

### DIFF
--- a/.changeset/real-yaks-float.md
+++ b/.changeset/real-yaks-float.md
@@ -1,0 +1,98 @@
+---
+'@lion/core': minor
+'@lion/form-core': minor
+'@lion/listbox': minor
+'@lion/select-rich': minor
+'@lion/switch': minor
+'@lion/accordion': minor
+'@lion/ajax': minor
+'@lion/button': minor
+'@lion/calendar': minor
+'@lion/checkbox-group': minor
+'@lion/collapsible': minor
+'@lion/combobox': minor
+'@lion/dialog': minor
+'@lion/fieldset': minor
+'@lion/form': minor
+'@lion/form-integrations': minor
+'@lion/helpers': minor
+'@lion/icon': minor
+'@lion/input': minor
+'@lion/input-amount': minor
+'@lion/input-date': minor
+'@lion/input-datepicker': minor
+'@lion/input-email': minor
+'@lion/input-iban': minor
+'@lion/input-range': minor
+'@lion/input-stepper': minor
+'@lion/input-tel': minor
+'@lion/input-tel-dropdown': minor
+'@lion/localize': minor
+'@lion/overlays': minor
+'@lion/pagination': minor
+'@lion/progress-indicator': minor
+'@lion/radio-group': minor
+'@lion/select': minor
+'@lion/steps': minor
+'@lion/tabs': minor
+'@lion/textarea': minor
+'@lion/tooltip': minor
+'@lion/validate-messages': minor
+---
+
+BREAKING CHANGE: Work without polyfill if possible
+
+When using [component composition](https://lit.dev/docs/composition/component-composition/) in a Lion Component we always made it very explicit which sub-components are used.
+On top of that we scoped these [sub components](https://open-wc.org/docs/development/scoped-elements/) to the [current shadow root](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md) allowing multiple version to be used simultaneously.
+
+To enable this features we relied on the fact that the `ScopedElementsMixin` did loaded the needed polyfill for us.
+
+We however over time got feedback from multiple consumers that lion components "break the app as soon as you load them".
+The reasons is/was that not everyone is always using `ScopedElementsMixin` or in full control of the app (or its load order).
+
+To quote the release notes of `ScopedElementsMixin` v2.1.0:
+
+> ScopedElementsMixin 2.x tried to be as convenient as possible by automatically loading the scoped custom elements registry polyfill.
+> This however led to a fatal error whenever you registered any component before ScopedElementsMixin was used.
+
+And this was the case.
+
+With the upgrade to `@open-wc/scoped-elements` v2.1.1 Lion now no longer automatically loads the polyfill through `ScopedElementsMixin`.
+
+This essentially means the polyfill became optional which results in the following behavior
+
+1. If polyfill is not loaded it will use the global registry as a fallback
+2. Log error if actually scoping is needed and polyfill is not loaded
+3. If you manually create elements you will need to handle polyfilled and not polyfilled cases now
+
+```diff
+-  const myButton = this.shadowRoot.createElement('my-button');
++  const myButton = this.createScopedElement('my-button');
+```
+
+This also removes `@webcomponents/scoped-custom-element-registry` as a production dependency.
+
+If you need scoping be sure to load the polyfill before any other web component gets registered.
+
+It may look something like this in your HTML
+
+```html
+<script src="/node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script>
+```
+
+or if you have an SPA you can load it at the top of your app shell code
+
+```js
+import '@webcomponents/scoped-custom-element-registry';
+```
+
+You need scoping if you want to
+
+use 2 major versions of a web component (e.g. in an SPA pageA uses 1.x and pageB uses 2.x of color-picker)
+or you want to use the same tag name with different implementations (use tag color-picker from foo here and from bar here)
+
+See more details at
+
+- [Lion release blog post](https://lion-web.netlify.app/blog/lion-without-polyfills/)
+- [@open-wc/scoped-elements release blog post](https://open-wc.org/blog/scoped-elements-without-polyfill/)
+- [Change log of ScopedElementsMixin](https://github.com/open-wc/open-wc/blob/master/packages/scoped-elements/CHANGELOG.md#210)

--- a/docs/blog/lion-without-polyfills.md
+++ b/docs/blog/lion-without-polyfills.md
@@ -1,0 +1,138 @@
+---
+title: Lion without polyfills
+published: true
+description: Lion has been a long user of the scoped registry - always requiring a polyfill - but no more. Load the polyfill only if you need it.
+date: 2022-04-05
+tags: [javascript, polyfills]
+cover_image: /blog/images/introducing-lions-website-cover-image.jpg
+---
+
+The only reason Lion always loaded a polyfill was because of its usage of [@open-wc/scoped-elements](https://open-wc.org/docs/development/scoped-elements/). From today on this polyfill became optional.
+
+When using [component composition](https://lit.dev/docs/composition/component-composition/) in a Lion Component we always made it very explicit which sub-components are used.
+On top of that we scoped these [sub components](https://open-wc.org/docs/development/scoped-elements/) to the [current shadow root](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md) allowing multiple version to be used simultaneously.
+
+This means that you can use a Lion Component like `lion-listbox` (which uses component composition) and never have to worry about if the internally used components clash with others you are already using.
+
+## How does it work?
+
+1. Within Lion classes we only import other classes (e.g. in class `MyCard` we use `MyCardHeader` via composition)
+2. We define them as `scopedElements` (`my-card-header: MyCardHeader`) and let the ScopedElementsMixin handle the rest
+
+To clarify: within Lion class files we never import files that run `customElement.define`
+
+```js
+import { LitElement, html, ScopedElementsMixin } from '@lion/core';
+import { MyCardHeader } from './MyCardHeader.js';
+
+export class MyCard extends ScopedElementsMixin(LitElement) {
+  static scopedElements = {
+    'my-card-header': MyCardHeader,
+  };
+
+  render() {
+    return html`
+      <div>
+        <my-card-header></my-card-header>
+        <slot></slot>
+      </div>
+    `;
+  }
+}
+```
+
+## Known challenges in previous releases
+
+The code above totally makes sense - however we always assumed that a scoped registry will be available.
+Which was somewhat of a valid assumption as all our components are using the `ScopedElementsMixin` and it in turn loads a polyfill for the scoped registry.
+
+We however over time got feedback from multiple consumers that lion components "break the app as soon as you load them".
+The reasons is/was that not everyone is always using `ScopedElementsMixin` or in full control of the app (or its load order).
+
+To quote the release notes of the latest version of `ScopedElementsMixin`:
+
+> ScopedElementsMixin 2.x tried to be as convenient as possible by automatically loading the scoped custom elements registry polyfill.
+> This however led to a fatal error whenever you registered any component before ScopedElementsMixin was used.
+
+And this was the case.
+
+## How do we fix it?
+
+With the latest release of Lion we now updated to the latest version of `ScopedElementsMixin` which means Lion now works in all apps as long as there is no need for actual scoping.
+
+To rephrase it:
+
+> Lion works without loading any polyfills
+
+If you extend Lion components and you imperatively create scoped custom elements, you should now use a helper function that will work in scoped and unscoped cases.
+
+```diff
+-  const myButton = this.shadowRoot.createElement('my-button');
++  const myButton = this.createScopedElement('my-button');
+```
+
+## Be explicit and stay forward compatible
+
+Be sure to always define **ALL** the sub elements you are using in your template within your `scopedElements` property.
+
+```js
+import { LitElement, html, ScopedElementsMixin } from '@lion/core';
+import { MyCardHeader } from './MyCardHeader.js';
+
+export class MyCard extends ScopedElementsMixin(LitElement) {
+  static scopedElements = {
+    'my-card-header': MyCardHeader,
+  };
+
+  render() {
+    return html`
+      <div>
+        <my-card-header></my-card-header>
+        <slot></slot>
+        <my-card-footer></my-card-footer>
+      </div>
+    `;
+  }
+}
+```
+
+☝️ here we are missing a definition for `my-card-footer` in `scopedElements`.
+
+This means as soon as there is support for the scoped registry (be it native of via a polyfill) this component will not be available anymore because every new scoped registry starts off empty (there is no inheritance of a global or parent registry).
+
+Therefore **always** define all your sub elements.
+
+## How to get scoping
+
+You need scoping if you want to:
+
+- use 2 major versions of a web component (e.g. in an SPA pageA uses 1.x and pageB uses 2.x of color-picker)
+- use the same tag name with different implementations (use tag color-picker from foo here and from bar here)
+
+This usually is only needed in bigger Single Page Applications.
+In smaller applications or static sites (like 11ty, wordpress, ...) these tag name clashes are unlikely.
+
+If you need scoping and the browser you are using does not support a [scoped registry](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md) yet (which is none in April 2022) then you need to install and load a polyfill first thing in your HTML.
+
+```bash
+npm i @webcomponents/scoped-custom-element-registry
+```
+
+It could look something like this:
+
+```html
+<script src="/node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script>
+```
+
+or if you have an SPA you can load it at the top of your app shell code
+
+```js
+import '@webcomponents/scoped-custom-element-registry';
+```
+
+## Learn more
+
+If you want to learn more please check the
+
+- [Release blog post](https://open-wc.org/blog/scoped-elements-without-polyfill/)
+- [Change log of ScopedElementsMixin](https://github.com/open-wc/open-wc/blob/master/packages/scoped-elements/CHANGELOG.md#210)

--- a/packages/combobox/index.d.ts
+++ b/packages/combobox/index.d.ts
@@ -1,1 +1,0 @@
-export { LionCombobox } from "./src/LionCombobox.js";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
   "sideEffects": false,
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@open-wc/scoped-elements": "^2.0.1",
+    "@open-wc/scoped-elements": "^2.1.1",
     "lit": "^2.0.2"
   },
   "keywords": [

--- a/packages/form-core/src/validate/ValidateMixin.js
+++ b/packages/form-core/src/validate/ValidateMixin.js
@@ -107,8 +107,7 @@ export const ValidateMixinImplementation = superclass =>
       return {
         ...super.slots,
         feedback: () => {
-          // @ts-ignore we load a polyfill to support createElement on shadowRoot
-          const feedbackEl = this.shadowRoot.createElement('lion-validation-feedback');
+          const feedbackEl = this.createScopedElement('lion-validation-feedback');
           feedbackEl.setAttribute('data-tag-name', 'lion-validation-feedback');
           return feedbackEl;
         },

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -133,8 +133,9 @@ const ListboxMixinImplementation = superclass =>
       return {
         ...super.slots,
         input: () => {
-          // @ts-ignore we load a polyfill to support createElement on shadowRoot
-          const lionOptions = this.shadowRoot.createElement('lion-options');
+          const lionOptions = /** @type {import('./LionOptions.js').LionOptions} */ (
+            this.createScopedElement('lion-options')
+          );
           lionOptions.setAttribute('data-tag-name', 'lion-options');
           lionOptions.registrationTarget = this;
           return lionOptions;

--- a/packages/select-rich/src/LionSelectRich.js
+++ b/packages/select-rich/src/LionSelectRich.js
@@ -70,8 +70,7 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
     return {
       ...super.slots,
       invoker: () => {
-        // @ts-ignore we load a polyfill to support createElement on shadowRoot
-        const invokerEl = this.shadowRoot.createElement('lion-select-invoker');
+        const invokerEl = this.createScopedElement('lion-select-invoker');
         invokerEl.setAttribute('data-tag-name', 'lion-select-invoker');
         return invokerEl;
       },

--- a/packages/switch/src/LionSwitch.js
+++ b/packages/switch/src/LionSwitch.js
@@ -42,8 +42,7 @@ export class LionSwitch extends ScopedElementsMixin(ChoiceInputMixin(LionField))
     return {
       ...super.slots,
       input: () => {
-        // @ts-ignore we load a polyfill to support createElement on shadowRoot
-        const btnEl = this.shadowRoot.createElement('lion-switch-button');
+        const btnEl = this.createScopedElement('lion-switch-button');
         btnEl.setAttribute('data-tag-name', 'lion-switch-button');
         return btnEl;
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,12 +1315,12 @@
   dependencies:
     vary "^1.1.2"
 
-"@lion/accordion@^0.6.1":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@lion/accordion/-/accordion-0.6.3.tgz#93addeec077efc04d7059e7892e3e4844b4ef093"
-  integrity sha512-hk0bkCo5DbRwyHRlkoAtAnfxGIV55w7A4jHRhLRtNLN+LOLn/S/+cfN93/WuugXmNd57DoeGUvrwGbb9Wbdf1g==
+"@lion/accordion@^0.7.2":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@lion/accordion/-/accordion-0.7.3.tgz#d0e498b4efa1f79e569208798b69d17d4435705a"
+  integrity sha512-akyevk8vnTpfE0moZk+5Pt0o8uEp9sG3LpTfracSgw+GfCc6olzMm1/ENncr7h9Kf3+9zNhtw4v5qzIbDOB7tA==
   dependencies:
-    "@lion/core" "0.18.2"
+    "@lion/core" "0.20.0"
 
 "@lion/combobox@^0.8.6":
   version "0.8.7"
@@ -1341,15 +1341,6 @@
     "@open-wc/scoped-elements" "^1.3.3"
     lit-element "~2.4.0"
     lit-html "^1.3.0"
-
-"@lion/core@0.18.2":
-  version "0.18.2"
-  resolved "https://registry.yarnpkg.com/@lion/core/-/core-0.18.2.tgz#ffac7a4a4811277cf864afdc7114dbb036a2e27a"
-  integrity sha512-wlzhAZUTTBYBUNeO+/dhMmh/bkzuwKOORhl7bh5PDMeHSLpTpubs5AKjrYLhF16qxczm0k/GautyJ9wZUfq2ZA==
-  dependencies:
-    "@open-wc/dedupe-mixin" "^1.2.18"
-    "@open-wc/scoped-elements" "^2.0.0-next.3"
-    lit "^2.0.0-rc.2"
 
 "@lion/core@0.19.0", "@lion/core@^0.19.0":
   version "0.19.0"
@@ -1442,11 +1433,6 @@
   resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0.tgz#7b6e6a85709cda0370c47e425ac2f3b553696a4b"
   integrity sha512-Kpgenb8UNFsKCsFhggiVvUkCbcFQSd6N8hffYEEGjz27/4rw3cTSsmP9t3q1EHOAsdum60Wo64HvuZDFpEwexA==
 
-"@lit/reactive-element@^1.0.0-rc.1", "@lit/reactive-element@^1.0.0-rc.2":
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@lit/reactive-element/-/reactive-element-1.0.0-rc.2.tgz#f24dba16ea571a08dca70f1783bd2ca5ec8de3ee"
-  integrity sha512-cujeIl5Ei8FC7UHf4/4Q3bRJOtdTe1vpJV/JEBYCggedmQ+2P8A2oz7eE+Vxi6OJ4nc0X+KZxXnBoH4QrEbmEQ==
-
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -1493,20 +1479,20 @@
     unist-util-visit "^2.0.3"
 
 "@mdjs/mdjs-preview@^0.5.3":
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/@mdjs/mdjs-preview/-/mdjs-preview-0.5.4.tgz#843b507e5881c7060b25263863a96dc3f475fe95"
-  integrity sha512-SYXjiRJHSDLYYE4LiCD+LJLEmkUjLWo8uoLmvma5T1TGMksxvft/FNzjBEjNL9YthHeNXizUUUB85KEDlQgv0Q==
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@mdjs/mdjs-preview/-/mdjs-preview-0.5.6.tgz#837ac6274f818bfa025cecfb68e5cff8001f3ab3"
+  integrity sha512-PzHxFzKgocnziI1HHe2uMuYzgEcZlEOYS9QD33EekhW4kAo/ZjhGvxkhBXfkZldbXTZDWTPN5fvD8GTgoJmL2A==
   dependencies:
-    "@lion/accordion" "^0.6.1"
-    "@open-wc/scoped-elements" "^2.0.0-next.3"
-    lit "^2.0.0-rc.2"
+    "@lion/accordion" "^0.7.2"
+    "@open-wc/scoped-elements" "^2.0.0"
+    lit "^2.0.0"
 
 "@mdjs/mdjs-story@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@mdjs/mdjs-story/-/mdjs-story-0.3.0.tgz#dd22b472cb5159dcdf2b3f0549c4aa096cc51fae"
-  integrity sha512-wdknFF++NM3/fqCmreF1XI3n0N4XAReg5rdUuxnkjJlfDlG1fcpjd1BEhl7NvdDzLHo/UR2h1V4KHLCH9UIRqA==
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@mdjs/mdjs-story/-/mdjs-story-0.3.1.tgz#cc19891962e06c8ecf0b0e40f191bcdae19bf910"
+  integrity sha512-X7pAukoE6U4iez/uZ431nNgvjbglAmyqLymfVHa2fqqTmqvPeH34n4xzz4elTdmEq2mskx+wyKQTZHq1Abp9Fw==
   dependencies:
-    lit "^2.0.0-rc.2"
+    lit "^2.0.0"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -1638,30 +1624,28 @@
     polyfills-loader "^1.7.5"
 
 "@open-wc/scoped-elements@^1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.3.3.tgz#fe008aef4d74fb00c553c900602960638fc1c7b0"
-  integrity sha512-vFIQVYYjFw67odUE4JzZOpctnF7S/2DX+S+clrL3bQPql7HvEnV0wMFwOWUavQTuCJi0rfU8GTcNMiUybio+Yg==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-1.3.4.tgz#96e27e13c8b09668ee631e9fccd5623a05af5cc2"
+  integrity sha512-WD+ObocdzcFCpBxnc8bQa7NoATeA+tJrK0/c/yV1Nx4leV+1PmJNNu+WCcuckBEGd0Op6FP8w1TidoqmVVba6g==
   dependencies:
     "@open-wc/dedupe-mixin" "^1.3.0"
     lit-html "^1.0.0"
 
 "@open-wc/scoped-elements@^2.0.0", "@open-wc/scoped-elements@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.0.1.tgz#6b1c3535f809bd90710574db80093a81e3a1fc2d"
-  integrity sha512-JS6ozxUFwFX3+Er91v9yQzNIaFn7OnE0iESKTbFvkkKdNwvAPtp1fpckBKIvWk8Ae9ZcoI9DYZuT2DDbMPcadA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.1.0.tgz#8b52ea46b1d973017b84d76c90af61047ece7227"
+  integrity sha512-Mf91jAW0j4MYYMz8PX8Rrk86sSKdiyKYK7RT1Ww84KSElwON0mDVGNlhJCbtw9cDJbfzL+fH1zJAaLyOY7GIMA==
   dependencies:
     "@lit/reactive-element" "^1.0.0"
     "@open-wc/dedupe-mixin" "^1.3.0"
-    "@webcomponents/scoped-custom-element-registry" "^0.0.3"
 
-"@open-wc/scoped-elements@^2.0.0-next.3":
-  version "2.0.0-next.4"
-  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.0.0-next.4.tgz#d8294358e3e8ad2ba44200ab805549fde49245f6"
-  integrity sha512-BMd5n5BHLi3FBhwhPbBuN7pZdi8I1CIQn10aKLZtg9aplVhN2BG1rwr0ANebXJ6fdq8m1PE1wQAaCXYCcEBTEQ==
+"@open-wc/scoped-elements@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@open-wc/scoped-elements/-/scoped-elements-2.1.1.tgz#a43a2167d259af1f113301fcc93b1b9a6c371991"
+  integrity sha512-qQAtVIK2H1oUIM2oSrCBnf1+ZGHd2nIowt1tete+Dn9rNXIogAMJlUBY/R1NR9MuuJvQ1MeFjgQoDmb05TUdkw==
   dependencies:
-    "@lit/reactive-element" "^1.0.0-rc.1"
+    "@lit/reactive-element" "^1.0.0"
     "@open-wc/dedupe-mixin" "^1.3.0"
-    "@webcomponents/scoped-custom-element-registry" "0.0.2"
 
 "@open-wc/semantic-dom-diff@^0.13.16":
   version "0.13.21"
@@ -2471,11 +2455,6 @@
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.3.tgz#ff5e2f1902969d305225a047c8a0fd5c915cebef"
   integrity sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==
 
-"@types/trusted-types@^1.0.1":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-1.0.6.tgz#569b8a08121d3203398290d602d84d73c8dcf5da"
-  integrity sha512-230RC8sFeHoT6sSUlRO6a8cAnclO06eeiq1QDfiv2FGCLWFvvERWgwIQD4FWqD9A69BN7Lzee4OXwoMVnnsWDw==
-
 "@types/trusted-types@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
@@ -2987,16 +2966,6 @@
     nanocolors "^0.2.1"
     portfinder "^1.0.28"
     source-map "^0.7.3"
-
-"@webcomponents/scoped-custom-element-registry@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@webcomponents/scoped-custom-element-registry/-/scoped-custom-element-registry-0.0.2.tgz#c863d163cb39c60063808e5ae23e06a1766fbe5f"
-  integrity sha512-lKCoZfKoE3FHvmmj2ytaLBB8Grxp4HaxfSzaGlIZN6xXnOILfpCO0PFJkAxanefLGJWMho4kRY5PhgxWFhmSOw==
-
-"@webcomponents/scoped-custom-element-registry@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@webcomponents/scoped-custom-element-registry/-/scoped-custom-element-registry-0.0.3.tgz#774591a886b0b0e4914717273ba53fd8d5657522"
-  integrity sha512-lpSzgDCGbM99dytb3+J3Suo4+Bk1E13MPnWB42JK8GwxSAxFz+tC7TTv2hhDSIE2IirGNKNKCf3m08ecu6eAsQ==
 
 "@webcomponents/shadycss@^1.10.2":
   version "1.10.2"
@@ -8496,14 +8465,6 @@ lit-element@^3.0.0:
     "@lit/reactive-element" "^1.0.0"
     lit-html "^2.0.0"
 
-lit-element@^3.0.0-rc.2:
-  version "3.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-3.0.0-rc.2.tgz#883d0b6fd7b846226d360699d1b713da5fc7e1b7"
-  integrity sha512-2Z7DabJ3b5K+p5073vFjMODoaWqy5PIaI4y6ADKm+fCGc8OnX9fU9dMoUEBZjFpd/bEFR9PBp050tUtBnT9XTQ==
-  dependencies:
-    "@lit/reactive-element" "^1.0.0-rc.2"
-    lit-html "^2.0.0-rc.3"
-
 lit-element@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.4.0.tgz#b22607a037a8fc08f5a80736dddf7f3f5d401452"
@@ -8523,13 +8484,6 @@ lit-html@^2.0.0:
   dependencies:
     "@types/trusted-types" "^2.0.2"
 
-lit-html@^2.0.0-rc.3:
-  version "2.0.0-rc.3"
-  resolved "https://registry.yarnpkg.com/lit-html/-/lit-html-2.0.0-rc.3.tgz#1c216e548630e18d3093d97f4e29563abce659af"
-  integrity sha512-Y6P8LlAyQuqvzq6l/Nc4z5/P5M/rVLYKQIRxcNwSuGajK0g4kbcBFQqZmgvqKG+ak+dHZjfm2HUw9TF5N/pkCw==
-  dependencies:
-    "@types/trusted-types" "^1.0.1"
-
 lit@^2.0.0, lit@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.2.tgz#5e6f422924e0732258629fb379556b6d23f7179c"
@@ -8538,15 +8492,6 @@ lit@^2.0.0, lit@^2.0.2:
     "@lit/reactive-element" "^1.0.0"
     lit-element "^3.0.0"
     lit-html "^2.0.0"
-
-lit@^2.0.0-rc.2:
-  version "2.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/lit/-/lit-2.0.0-rc.2.tgz#724a2d621aa098001d73bf7106f3a72b7b5948ef"
-  integrity sha512-BOCuoJR04WaTV8UqTKk09cNcQA10Aq2LCcBOiHuF7TzWH5RNDsbCBP5QM9sLBSotGTXbDug/gFO08jq6TbyEtw==
-  dependencies:
-    "@lit/reactive-element" "^1.0.0-rc.2"
-    lit-element "^3.0.0-rc.2"
-    lit-html "^2.0.0-rc.3"
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## What I did

BREAKING CHANGE: Work without polyfill if possible

When using [component composition](https://lit.dev/docs/composition/component-composition/) in a Lion Component we always made it very explicit which sub-components are used.
On top of that we scoped these [sub components](https://open-wc.org/docs/development/scoped-elements/) to the [current shadow root](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md) allowing multiple version to be used simultaneously.

To enable this features we relied on the fact that the `ScopedElementsMixin` did loaded the needed polyfill for us.

We however over time got feedback from multiple consumers that lion components "break the app as soon as you load them".
The reasons is/was that not everyone is always using `ScopedElementsMixin` or in full control of the app (or its load order).

To quote the release notes of `ScopedElementsMixin` v2.1.0:

> ScopedElementsMixin 2.x tried to be as convenient as possible by automatically loading the scoped custom elements registry polyfill.
> This however led to a fatal error whenever you registered any component before ScopedElementsMixin was used.

And this was the case.

With the upgrade to `@open-wc/scoped-elements` v2.1.1 Lion now no longer automatically loads the polyfill through `ScopedElementsMixin`.

This essentially means the polyfill became optional which results in the following behavior

1. If polyfill is not loaded it will use the global registry as a fallback
2. Log error if actually scoping is needed and polyfill is not loaded
3. If you manually create elements you will need to handle polyfilled and not polyfilled cases now

```diff
-  const myButton = this.shadowRoot.createElement('my-button');
+  const myButton = this.createScopedElement('my-button');
```

This also removes `@webcomponents/scoped-custom-element-registry` as a production dependency.

If you need scoping be sure to load the polyfill before any other web component gets registered.

It may look something like this in your HTML

```html
<script src="/node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script>
```

or if you have an SPA you can load it at the top of your app shell code

```js
import '@webcomponents/scoped-custom-element-registry';
```

You need scoping if you want to

use 2 major versions of a web component (e.g. in an SPA pageA uses 1.x and pageB uses 2.x of color-picker)
or you want to use the same tag name with different implementations (use tag color-picker from foo here and from bar here)

See more details at

- [Lion release blog post](https://lion-web.netlify.app/blog/lion-without-polyfills/)
- [@open-wc/scoped-elements release blog post](https://open-wc.org/blog/scoped-elements-without-polyfill/)
- [Change log of ScopedElementsMixin](https://github.com/open-wc/open-wc/blob/master/packages/scoped-elements/CHANGELOG.md#210)
