### PR TITLE
chore: add eg for label-sr-only attribute on input element

### DIFF
--- a/docs/components/input/use-cases.md
+++ b/docs/components/input/use-cases.md
@@ -13,6 +13,19 @@ Can be provided via the `label` attribute or via the `slot="label"`.
 export const label = () => html` <lion-input label="Input" name="input"></lion-input> `;
 ```
 
+## Label sr-only (a11y)
+
+Can be provided via the `label-sr-only` boolean attribute.
+
+The label will be hidden, but still readable by screen readers.
+
+```js preview-story
+export const labelSrOnly = () =>
+  html` <lion-input label-sr-only label="Input" name="input"></lion-input> `;
+```
+
+> Note: Once we support the ElementInternals API, the equivalent will be `<lion-input aria-label="Input" name="input"></lion-input>`
+
 ## Help-text
 
 A helper text shown below the label to give extra clarification.


### PR DESCRIPTION
## What I did

1. Added a section under `components/input/use-cases/` that displays an example on how to use the `label-sr-only` attribute on an input element.

closes https://github.com/ing-bank/lion/issues/1630