### PR TITLE
fix(input-tel-dropdown): sync disabled state to dropdown

### DIFF
--- a/.changeset/rotten-birds-call.md
+++ b/.changeset/rotten-birds-call.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-tel-dropdown': patch
+---
+
+sync disable state to dropdown for a11y

--- a/packages/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -254,6 +254,14 @@ export class LionInputTelDropdown extends LionInputTel {
     if (changedProperties.has('activeRegion')) {
       this.__syncRegionWithDropdown();
     }
+
+    if (changedProperties.has('disabled') || changedProperties.has('readOnly')) {
+      if (this.disabled || this.readOnly) {
+        this.refs.dropdown?.value?.setAttribute('disabled', '');
+      } else {
+        this.refs.dropdown?.value?.removeAttribute('disabled');
+      }
+    }
   }
 
   /**

--- a/packages/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
+++ b/packages/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
@@ -134,6 +134,16 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
         );
       });
 
+      it('syncs disabled attribute to dropdown', async () => {
+        const el = await fixture(html` <${tag} disabled></${tag}> `);
+        expect(el.refs.dropdown.value?.hasAttribute('disabled')).to.be.true;
+      });
+
+      it('disables dropdown on readonly', async () => {
+        const el = await fixture(html` <${tag} readonly></${tag}> `);
+        expect(el.refs.dropdown.value?.hasAttribute('disabled')).to.be.true;
+      });
+
       it('renders to prefix slot in light dom', async () => {
         const el = await fixture(html` <${tag} .allowedRegions="${['DE']}"></${tag}> `);
         const prefixSlot = /** @type {HTMLElement} */ (

--- a/packages/input-tel-dropdown/test-suites/index.js
+++ b/packages/input-tel-dropdown/test-suites/index.js
@@ -1,0 +1,1 @@
+export { runInputTelDropdownSuite } from './LionInputTelDropdown.suite.js';


### PR DESCRIPTION
## What I did

1. Export the testSuite
2. Sync disabled state to dropdown (for a11y)
3. Set dropdown disabled if input is readonly (for a11y)

