### PR TITLE
fix: do not show ResultValidator feedback message if input field is empty

### DIFF
--- a/.changeset/tender-otters-shake.md
+++ b/.changeset/tender-otters-shake.md
@@ -1,0 +1,5 @@
+---
+'@lion/form-core': patch
+---
+
+fix: reset the form validators after a form `reset` click or field emptied

--- a/docs/components/form/use-cases.md
+++ b/docs/components/form/use-cases.md
@@ -23,7 +23,6 @@ To fire a submit from JavaScript, select the `lion-form` element and call `.subm
 ```js preview-story
 export const formSubmit = () => {
   loadDefaultFeedbackMessages();
-
   const submitHandler = ev => {
     if (ev.target.hasFeedbackFor.includes('error')) {
       const firstFormElWithError = ev.target.formElements.find(el =>

--- a/packages/form-core/src/validate/ValidateMixin.js
+++ b/packages/form-core/src/validate/ValidateMixin.js
@@ -499,7 +499,7 @@ export const ValidateMixinImplementation = superclass =>
 
     /**
      * step b (as explained in `validate()`), called by __finishValidation
-     * @param {{validator:Validator; outcome: boolean|string;}[]} regularValidationResult result of steps 1-3
+     * @param {{validator: Validator;outcome: boolean | string;}[]} regularValidationResult result of steps 1-3
      * @private
      */
     __executeResultValidators(regularValidationResult) {
@@ -509,6 +509,16 @@ export const ValidateMixinImplementation = superclass =>
           return !vCtor.async && v instanceof ResultValidator;
         })
       );
+
+      if (!resultValidators.length) {
+        return [];
+      }
+
+      // If empty, do not show the ResulValidation message (e.g. Correct!)
+      if (this._isEmpty(this.modelValue)) {
+        this.__prevShownValidationResult = [];
+        return [];
+      }
 
       // Map everything to Validator[] for backwards compatibility
       return resultValidators
@@ -537,8 +547,9 @@ export const ValidateMixinImplementation = superclass =>
     __finishValidation({ source, hasAsync }) {
       const syncAndAsyncOutcome = [...this.__syncValidationResult, ...this.__asyncValidationResult];
       // if we have any ResultValidators left, now is the time to run them...
-      const resultOutCome = this.__executeResultValidators(syncAndAsyncOutcome);
-
+      const resultOutCome = /** @type {ValidationResultEntry[]} */ (
+        this.__executeResultValidators(syncAndAsyncOutcome)
+      );
       this.__validationResult = [...resultOutCome, ...syncAndAsyncOutcome];
 
       const ctor = /** @type {ValidateHostConstructor} */ (this.constructor);
@@ -560,7 +571,6 @@ export const ValidateMixinImplementation = superclass =>
       this.hasFeedbackFor = [
         ...new Set(this.__validationResult.map(({ validator }) => validator.type)),
       ];
-
       /** private event that should be listened to by LionFieldSet */
       this.dispatchEvent(new Event('validate-performed', { bubbles: true }));
       if (source === 'async' || !hasAsync) {


### PR DESCRIPTION
Co-authored by: Gerjan van Geest <gerjan.van.geest@ing.com>

## What I did

1. Check if the modeValue is empty to reset the validators after a form `reset` button click
2. Add test for this case
3. Refactor code to keep __isEmpty from being called more times, causing existing tests to fail
