### PR TITLE
feat: content-type filter for ajax cache

### DIFF
--- a/.changeset/pretty-mice-beam.md
+++ b/.changeset/pretty-mice-beam.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': minor
+---
+
+Add cache filter for content types

--- a/packages/ajax/src/cacheManager.js
+++ b/packages/ajax/src/cacheManager.js
@@ -82,6 +82,7 @@ export const extendCacheOptions = ({
   requestIdFunction = DEFAULT_GET_REQUEST_ID,
   invalidateUrls,
   invalidateUrlsRegex,
+  contentTypes,
 }) => ({
   useCache,
   methods,
@@ -89,6 +90,7 @@ export const extendCacheOptions = ({
   requestIdFunction,
   invalidateUrls,
   invalidateUrlsRegex,
+  contentTypes,
 });
 
 /**
@@ -101,6 +103,7 @@ export const validateCacheOptions = ({
   requestIdFunction,
   invalidateUrls,
   invalidateUrlsRegex,
+  contentTypes,
 } = {}) => {
   if (useCache !== undefined && typeof useCache !== 'boolean') {
     throw new Error('Property `useCache` must be a `boolean`');
@@ -112,13 +115,16 @@ export const validateCacheOptions = ({
     throw new Error('Property `maxAge` must be a finite `number`');
   }
   if (invalidateUrls !== undefined && !Array.isArray(invalidateUrls)) {
-    throw new Error('Property `invalidateUrls` must be an `Array` or `falsy`');
+    throw new Error('Property `invalidateUrls` must be an `Array` or `undefined`');
   }
   if (invalidateUrlsRegex !== undefined && !(invalidateUrlsRegex instanceof RegExp)) {
-    throw new Error('Property `invalidateUrlsRegex` must be a `RegExp` or `falsy`');
+    throw new Error('Property `invalidateUrlsRegex` must be a `RegExp` or `undefined`');
   }
   if (requestIdFunction !== undefined && typeof requestIdFunction !== 'function') {
     throw new Error('Property `requestIdFunction` must be a `function`');
+  }
+  if (contentTypes !== undefined && !Array.isArray(contentTypes)) {
+    throw new Error('Property `contentTypes` must be an `Array` or `undefined`');
   }
 };
 

--- a/packages/ajax/test/cacheManager.test.js
+++ b/packages/ajax/test/cacheManager.test.js
@@ -74,6 +74,7 @@ describe('cacheManager', () => {
         requestIdFunction,
         invalidateUrls: invalidateUrlsResult,
         invalidateUrlsRegex: invalidateUrlsRegexResult,
+        contentTypes,
       } = extendCacheOptions({ invalidateUrls, invalidateUrlsRegex });
       // Assert
       expect(useCache).to.be.false;
@@ -82,6 +83,7 @@ describe('cacheManager', () => {
       expect(typeof requestIdFunction).to.eql('function');
       expect(invalidateUrlsResult).to.equal(invalidateUrls);
       expect(invalidateUrlsRegexResult).to.equal(invalidateUrlsRegex);
+      expect(contentTypes).to.be.undefined;
     });
 
     it('the DEFAULT_GET_REQUEST_ID function throws when called with no arguments', () => {
@@ -197,7 +199,7 @@ describe('cacheManager', () => {
       it('does not accept anything else', () => {
         // @ts-ignore
         expect(() => validateCacheOptions({ invalidateUrls: 'not-an-array' })).to.throw(
-          'Property `invalidateUrls` must be an `Array` or `falsy`',
+          'Property `invalidateUrls` must be an `Array` or `undefined`',
         );
       });
     });
@@ -213,7 +215,7 @@ describe('cacheManager', () => {
         // @ts-ignore
         expect(() =>
           validateCacheOptions({ invalidateUrlsRegex: 'a string is not a regex' }),
-        ).to.throw('Property `invalidateUrlsRegex` must be a `RegExp` or `falsy`');
+        ).to.throw('Property `invalidateUrlsRegex` must be a `RegExp` or `undefined`');
       });
     });
     describe('the requestIdFunction property', () => {
@@ -230,6 +232,22 @@ describe('cacheManager', () => {
         // @ts-ignore
         expect(() => validateCacheOptions({ requestIdFunction: 'not a function' })).to.throw(
           'Property `requestIdFunction` must be a `function`',
+        );
+      });
+    });
+    describe('the contentTypes property', () => {
+      it('accepts an array', () => {
+        // @ts-ignore Typescript requires this to be an array of string, but this is not checked by validateCacheOptions
+        expect(() => validateCacheOptions({ contentTypes: [6, 'elements', 'in', 1, true, Array] }))
+          .not.to.throw;
+      });
+      it('accepts undefined', () => {
+        expect(() => validateCacheOptions({ contentTypes: undefined })).not.to.throw;
+      });
+      it('does not accept anything else', () => {
+        // @ts-ignore
+        expect(() => validateCacheOptions({ contentTypes: 'not-an-array' })).to.throw(
+          'Property `contentTypes` must be an `Array` or `undefined`',
         );
       });
     });

--- a/packages/ajax/types/types.d.ts
+++ b/packages/ajax/types/types.d.ts
@@ -40,6 +40,7 @@ export interface CacheOptions {
   invalidateUrls?: string[];
   invalidateUrlsRegex?: RegExp;
   requestIdFunction?: RequestIdFunction;
+  contentTypes?: string[];
 }
 
 export interface CacheOptionsWithIdentifier extends CacheOptions {


### PR DESCRIPTION
## What I did

1. Added "contentTypes" parameter to CacheOptions
2. Disabled cache writing / reading based on said parameter
3. Moved some things around in the cacheInterceptors test
