### PR TITLE
feat(ajax): add an option to initialize the cache interceptors...

### DIFF
--- a/.changeset/silent-ravens-smell.md
+++ b/.changeset/silent-ravens-smell.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': minor
+---
+
+Add an option "addCaching" to the Ajax config, in order to add cache interceptors when useCache is turned off. In this situation, all requests are cached proactively.

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -23,11 +23,12 @@ export class Ajax {
    */
   constructor(config = {}) {
     /**
-     * @type {Partial<AjaxConfig>}
+     * @type {AjaxConfig}
      * @private
      */
     this.__config = {
       addAcceptLanguage: true,
+      addCaching: false,
       xsrfCookieName: 'XSRF-TOKEN',
       xsrfHeaderName: 'X-XSRF-TOKEN',
       jsonPrefix: '',
@@ -53,7 +54,7 @@ export class Ajax {
     }
 
     const { cacheOptions } = this.__config;
-    if (cacheOptions?.useCache) {
+    if (cacheOptions.useCache || this.__config.addCaching) {
       const { cacheRequestInterceptor, cacheResponseInterceptor } = createCacheInterceptors(
         cacheOptions.getCacheIdentifier,
         cacheOptions,
@@ -65,7 +66,7 @@ export class Ajax {
 
   /**
    * Configures the Ajax instance
-   * @param {Partial<AjaxConfig>} config configuration for the Ajax instance
+   * @param {AjaxConfig} config configuration for the Ajax instance
    */
   set options(config) {
     this.__config = config;

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -43,6 +43,7 @@ describe('Ajax', () => {
       };
       const expected = {
         addAcceptLanguage: true,
+        addCaching: false,
         xsrfCookieName: 'XSRF-TOKEN',
         xsrfHeaderName: 'X-XSRF-TOKEN',
         jsonPrefix: ")]}',",
@@ -301,6 +302,44 @@ describe('Ajax', () => {
 
     beforeEach(() => {
       getCacheIdentifier = () => String(cacheId);
+    });
+
+    it('does not add cache interceptors when useCache is turned off', () => {
+      const customAjax = new Ajax({
+        cacheOptions: {
+          maxAge: 100,
+          getCacheIdentifier,
+        },
+      });
+
+      expect(customAjax._requestInterceptors.length).to.equal(2);
+      expect(customAjax._responseInterceptors.length).to.equal(0);
+    });
+
+    it('adds cache interceptors when useCache is turned on', () => {
+      const customAjax = new Ajax({
+        cacheOptions: {
+          useCache: true,
+          maxAge: 100,
+          getCacheIdentifier,
+        },
+      });
+
+      expect(customAjax._requestInterceptors.length).to.equal(3);
+      expect(customAjax._responseInterceptors.length).to.equal(1);
+    });
+
+    it('adds cache interceptors when addCaching is turned on', () => {
+      const customAjax = new Ajax({
+        addCaching: true,
+        cacheOptions: {
+          maxAge: 100,
+          getCacheIdentifier,
+        },
+      });
+
+      expect(customAjax._requestInterceptors.length).to.equal(3);
+      expect(customAjax._responseInterceptors.length).to.equal(1);
     });
 
     describe('caching interceptors', async () => {

--- a/packages/ajax/test/interceptors/cacheInterceptors.test.js
+++ b/packages/ajax/test/interceptors/cacheInterceptors.test.js
@@ -150,14 +150,12 @@ describe('cache interceptors', () => {
       expect(fetchStub.callCount).to.equal(1);
     });
 
-    // TODO: Check if this is the behaviour we want
-    it('all calls with non-default `maxAge` are cached proactively', async () => {
+    it('all calls are cached proactively', async () => {
       // Given
       newCacheId();
 
       addCacheInterceptors(ajax, {
         useCache: false,
-        maxAge: 100,
       });
 
       // When
@@ -169,11 +167,7 @@ describe('cache interceptors', () => {
       expect(fetchStub.callCount).to.equal(1);
 
       // When
-      await ajax.fetch('/test', {
-        cacheOptions: {
-          useCache: true,
-        },
-      });
+      await ajax.fetch('/test');
 
       // Then
       expect(fetchStub.callCount).to.equal(2);

--- a/packages/ajax/types/types.d.ts
+++ b/packages/ajax/types/types.d.ts
@@ -12,6 +12,7 @@ export interface LionRequestInit extends Omit<RequestInit, 'body'> {
 
 export interface AjaxConfig {
   addAcceptLanguage: boolean;
+  addCaching: boolean;
   xsrfCookieName: string | null;
   xsrfHeaderName: string | null;
   cacheOptions: CacheOptionsWithIdentifier;


### PR DESCRIPTION
Add an option to initialize the cache interceptors even when useCache is turned off in the global options

## What I did

1. Add an option `addCaching` to the regular options of the Ajax library, which causes the cache interceptors to be added even when the global `useCache` option is turned off
2. Remove the `useCache` check from the tests when storing things in the cache, effectively storing everything proactively. It could be argued that this should be configurable as well, in which case we could change the `addCaching` option to a `cacheOptions.proactive` option, or something.
