### PR TITLE
fix(input-tel-dropdown): do not sync regionCode if countryCode is the…

### DIFF
--- a/.changeset/old-ties-relax.md
+++ b/.changeset/old-ties-relax.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-tel-dropdown': patch
+---
+
+Do not sync regionCode from input to dropdown if the countryCode didn't change

--- a/.changeset/poor-mugs-bow.md
+++ b/.changeset/poor-mugs-bow.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-tel-dropdown': patch
+---
+
+Only focus input on dropdownValue change if dropdown was opened. Otherwise it blocks user from use type ahead on the dropdown.

--- a/docs/_data/site.cjs
+++ b/docs/_data/site.cjs
@@ -1,7 +1,7 @@
 module.exports = async function () {
   return {
     dir: 'ltr',
-    lang: 'en',
+    lang: 'en-GB',
     name: 'Lion',
     description: 'Fundamental white label web components for building your design system',
     socialLinks: [

--- a/packages/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -300,9 +300,6 @@ export class LionInputTelDropdown extends LionInputTel {
       setTimeout(() => {
         this._inputNode.focus();
       });
-    } else {
-      // For native select
-      this._inputNode.focus();
     }
   }
 
@@ -333,9 +330,23 @@ export class LionInputTelDropdown extends LionInputTel {
     if (!dropdownElement || !regionCode) {
       return;
     }
+    const inputCountryCode = this._phoneUtil?.getCountryCodeForRegionCode(regionCode);
+
     if ('modelValue' in dropdownElement) {
+      const dropdownCountryCode = this._phoneUtil?.getCountryCodeForRegionCode(
+        dropdownElement.modelValue,
+      );
+      if (dropdownCountryCode === inputCountryCode) {
+        return;
+      }
       /** @type {* & FormatHost} */ (dropdownElement).modelValue = regionCode;
     } else {
+      const dropdownCountryCode = this._phoneUtil?.getCountryCodeForRegionCode(
+        dropdownElement.value,
+      );
+      if (dropdownCountryCode === inputCountryCode) {
+        return;
+      }
       /** @type {HTMLSelectElement} */ (dropdownElement).value = regionCode;
     }
   }

--- a/rocket.config.mjs
+++ b/rocket.config.mjs
@@ -14,9 +14,9 @@ export default {
       simulationSettings: {
         simulatorUrl: '/simulator/',
         languages: [
-          { key: 'en-US', name: 'English (United States)' },
-          { key: 'en-US', name: 'English (United Kingdom)' },
           { key: 'de-DE', name: 'German' },
+          { key: 'en-GB', name: 'English (United Kingdom)' },
+          { key: 'en-US', name: 'English (United States)' },
           { key: 'nl-NL', name: 'Dutch' },
         ],
       },


### PR DESCRIPTION
## What I did

1. Do not sync regionCode from input to dropdown if the countryCode didn't change
2. Only focus input on dropdownValue change if dropdown was opened. Otherwise it blocks user from use type ahead on the dropdown.