### PR TITLE
fix(lion-field): remove name property exception to align with platform

### DIFF
--- a/.changeset/hungry-mirrors-stare.md
+++ b/.changeset/hungry-mirrors-stare.md
@@ -1,5 +1,5 @@
 ---
-'@lion/form-core': patch
+'@lion/form-core': minor
 ---
 
 remove name property check on lion field for forward compatibility with Form participation api

--- a/.changeset/hungry-mirrors-stare.md
+++ b/.changeset/hungry-mirrors-stare.md
@@ -1,0 +1,5 @@
+---
+'@lion/form-core': patch
+---
+
+remove name property check on lion field for forward compatibility with Form participation api

--- a/packages/form-core/src/registration/FormRegistrarMixin.js
+++ b/packages/form-core/src/registration/FormRegistrarMixin.js
@@ -156,10 +156,6 @@ const FormRegistrarMixinImplementation = superclass =>
       // 2. Add children as object key
       if (this._isFormOrFieldset) {
         const { name } = child;
-        if (!name) {
-          console.info('Error Node:', child); // eslint-disable-line no-console
-          throw new TypeError('You need to define a name');
-        }
         if (name === this.name) {
           console.info('Error Node:', child); // eslint-disable-line no-console
           throw new TypeError(`You can not have the same name "${name}" as your parent`);

--- a/packages/form-core/test-suites/form-group/FormGroupMixin.suite.js
+++ b/packages/form-core/test-suites/form-group/FormGroupMixin.suite.js
@@ -133,27 +133,6 @@ export function runFormGroupMixinSuite(cfg = {}) {
       ]);
     });
 
-    it('throws if an element without a name tries to register', async () => {
-      const orig = console.info;
-      console.info = () => {};
-
-      let error;
-      const el = /**  @type {FormGroup} */ (await fixture(html`<${tag}></${tag}>`));
-      try {
-        // we test the api directly as errors thrown from a web component are in a
-        // different context and we can not catch them here => register fake elements
-        el.addFormElement(
-          /**  @type {HTMLElement & import('../../types/FormControlMixinTypes').FormControlHost} */ ({}),
-        );
-      } catch (err) {
-        error = err;
-      }
-      expect(error).to.be.instanceOf(TypeError);
-      expect(/** @type {TypeError} */ (error).message).to.equal('You need to define a name');
-
-      console.info = orig; // restore original console
-    });
-
     it('throws if name is the same as its parent', async () => {
       const orig = console.info;
       console.info = () => {};


### PR DESCRIPTION
## What I did

1. Remove check for name property as discussed with @tlouisse 
