### PR TITLE
chore: add a script to check latest npm dist tags

### DIFF
--- a/scripts/check-npm-dist-tag.mjs
+++ b/scripts/check-npm-dist-tag.mjs
@@ -1,0 +1,44 @@
+/* eslint-disable no-console */
+/* eslint-disable no-await-in-loop */
+import { promisify } from 'util';
+import { exec as execCallback } from 'child_process';
+import { readFile } from 'fs/promises';
+import { readdirSync } from 'fs';
+
+const exec = promisify(execCallback);
+
+const getDirectories = source =>
+  readdirSync(source, { withFileTypes: true })
+    .filter(pathMeta => pathMeta.isDirectory())
+    .map(pathMeta => pathMeta.name);
+
+async function checkNpmDistTag(folder) {
+  const actions = [];
+  console.log('| Name                     | Local Version | NPM dist tag latest | Check |');
+  console.log('| ------------------------ | ------------- | ------------------- | ----- |');
+  for (const subPackage of getDirectories(`./${folder}`)) {
+    const filePath = `./${folder}/${subPackage}/package.json`;
+    const packageJsonRaw = await readFile(filePath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonRaw.toString());
+    const { version, name } = packageJson;
+
+    const { stdout } = await exec(`npm info ${name}@latest dist-tags.latest`);
+    const latestVersion = stdout.trim();
+
+    console.log(
+      `| ${name.padEnd(24, ' ')} | ${version.padEnd(13, ' ')} | ${latestVersion.padEnd(19, ' ')} | ${version !== latestVersion ? '  ❌  ' : '  ✓  '} |`,
+    );
+
+    if (version !== latestVersion) {
+      actions.push(`npm dist-tag add ${name}@${version} latest`);
+    }
+  }
+
+  if (actions.length) {
+    console.log();
+    console.log('FIX IT by running the following commands:');
+    console.log(actions.join('\n'));
+  }
+}
+
+checkNpmDistTag('packages');


### PR DESCRIPTION
## What I did

1. Add a script to verify that the npm dist tag is the same version as in the repo

Run it via
```
node ./scripts/check-npm-dist-tag.mjs
```

Outputs info like so


```
| Name                     | Local Version | NPM dist tag latest | Check |
| ------------------------ | ------------- | ------------------- | ----- |
| @lion/accordion          | 0.9.0         | 0.9.0               |   ✓   |
| @lion/ajax               | 0.15.0        | 0.15.0              |   ✓   |
| @lion/button             | 0.17.0        | 0.17.0              |   ✓   |
| @lion/calendar           | 0.19.0        | 0.19.0              |   ✓   |
| @lion/checkbox-group     | 0.20.1        | 0.20.1              |   ✓   |
| @lion/collapsible        | 0.8.0         | 0.8.0               |   ✓   |
| @lion/combobox           | 0.10.0        | 0.10.0              |   ✓   |
| @lion/core               | 0.22.0        | 0.22.0              |   ✓   |
| @lion/dialog             | 0.15.0        | 0.15.0              |   ✓   |
| @lion/fieldset           | 0.21.0        | 0.21.0              |   ✓   |
| @lion/form               | 0.14.0        | 0.14.0              |   ✓   |
| @lion/form-core          | 0.17.1        | 0.13.2              |   ❌   |
| @lion/form-integrations  | 0.11.0        | 0.11.0              |   ✓   |
| @lion/helpers            | 0.11.0        | 0.11.0              |   ✓   |
| @lion/icon               | 0.15.0        | 0.15.0              |   ✓   |
| @lion/input              | 0.17.0        | 0.17.0              |   ✓   |
| @lion/input-amount       | 0.16.0        | 0.16.0              |   ✓   |
| @lion/input-date         | 0.14.0        | 0.14.0              |   ✓   |
| @lion/input-datepicker   | 0.25.0        | 0.25.0              |   ✓   |
| @lion/input-email        | 0.15.0        | 0.15.0              |   ✓   |
| @lion/input-iban         | 0.18.0        | 0.18.0              |   ✓   |
| @lion/input-range        | 0.12.0        | 0.12.0              |   ✓   |
| @lion/input-stepper      | 0.8.0         | 0.8.0               |   ✓   |
| @lion/input-tel          | 0.1.2         | 0.1.2               |   ✓   |
| @lion/input-tel-dropdown | 0.1.2         | 0.1.2               |   ✓   |
| @lion/listbox            | 0.13.1        | 0.13.1              |   ✓   |
| @lion/localize           | 0.24.0        | 0.24.0              |   ✓   |
| @lion/overlays           | 0.32.0        | 0.32.0              |   ✓   |
| @lion/pagination         | 0.8.0         | 0.8.0               |   ✓   |
| @lion/progress-indicator | 0.8.0         | 0.8.0               |   ✓   |
| @lion/radio-group        | 0.20.0        | 0.20.0              |   ✓   |
| @lion/select             | 0.16.0        | 0.16.0              |   ✓   |
| @lion/select-rich        | 0.30.1        | 0.30.1              |   ✓   |
| singleton-manager        | 1.4.3         | 1.4.3               |   ✓   |
| @lion/steps              | 0.11.0        | 0.11.0              |   ✓   |
| @lion/switch             | 0.20.1        | 0.20.1              |   ✓   |
| @lion/tabs               | 0.12.0        | 0.12.0              |   ✓   |
| @lion/textarea           | 0.15.0        | 0.15.0              |   ✓   |
| @lion/tooltip            | 0.23.0        | 0.23.0              |   ✓   |
| @lion/validate-messages  | 0.9.0         | 0.9.0               |   ✓   |

FIX IT by running the following commands:
npm dist-tag add @lion/form-core@0.17.1 latest
```