### PR TITLE
chore: update lit-element to latest 2.x and lit-html to latest 1.x version

### DIFF
--- a/.changeset/four-timers-sin.md
+++ b/.changeset/four-timers-sin.md
@@ -1,0 +1,5 @@
+---
+'@lion/core': patch
+---
+
+Update lit-element to latest 2.x version and lit-html to latest 1.x version

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,8 +38,8 @@
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.2.18",
     "@open-wc/scoped-elements": "^1.3.3",
-    "lit-element": "~2.4.0",
-    "lit-html": "^1.4.0"
+    "lit-element": "^2.5.1",
+    "lit-html": "^1.4.1"
   },
   "keywords": [
     "lion",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8006,7 +8006,14 @@ lit-element@^2.2.1, lit-element@^2.4.0, lit-element@~2.4.0:
   dependencies:
     lit-html "^1.1.1"
 
-lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0, lit-html@^1.4.0:
+lit-element@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/lit-element/-/lit-element-2.5.1.tgz#3fa74b121a6cd22902409ae3859b7847d01aa6b6"
+  integrity sha512-ogu7PiJTA33bEK0xGu1dmaX5vhcRjBXCFexPja0e7P7jqLhTpNKYRPmE+GmiCaRVAbiQKGkUgkh/i6+bh++dPQ==
+  dependencies:
+    lit-html "^1.1.1"
+
+lit-html@^1.0.0, lit-html@^1.1.1, lit-html@^1.3.0, lit-html@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/lit-html/-/lit-html-1.4.1.tgz"
   integrity sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA==


### PR DESCRIPTION
## What I did

1. Updated the lit-element dependency to the latest 2.x version and removed the ~, and replaced it with ^, so that we can get future minor updates as well
2. Updated the lit-html dependency to the latest 1.x version
