### PR TITLE
fix(combobox): set no typeahead to true

### DIFF
--- a/.changeset/mean-ducks-occur.md
+++ b/.changeset/mean-ducks-occur.md
@@ -1,0 +1,5 @@
+---
+'@lion/combobox': patch
+---
+
+Set noTypeAhead to true


### PR DESCRIPTION
## What I did

Forgot to add changeset for combobox.

fix: https://github.com/ing-bank/lion/issues/1704

