### PR TITLE
fix: Allow elements with display:contents to be focusable in keyboard event trapping

### DIFF
--- a/.changeset/eight-years-pump.md
+++ b/.changeset/eight-years-pump.md
@@ -1,0 +1,5 @@
+---
+"@lion/overlays": patch
+---
+
+fix: isVisible check on elements with display:contents

--- a/packages/overlays/src/utils/is-visible.js
+++ b/packages/overlays/src/utils/is-visible.js
@@ -5,6 +5,11 @@ const hasStyleVisibility = ({ visibility, display }) =>
   visibility !== 'hidden' && display !== 'none';
 
 /**
+ * @param {CSSStyleDeclaration} styles
+ */
+const isDisplayContents = ({ display }) => display === 'contents';
+
+/**
  * @param {HTMLElement} element
  * @returns {boolean} Whether the element is visible
  */
@@ -24,10 +29,18 @@ export function isVisible(element) {
     return false;
   }
 
+  const computedStyle = window.getComputedStyle(element);
+
   // Check computed styles
-  // matches display: none, visbility: hidden on element and visibility: hidden from parent
-  if (!hasStyleVisibility(window.getComputedStyle(element))) {
+  // matches display: none, visibility: hidden on element and visibility: hidden from parent
+  if (!hasStyleVisibility(computedStyle)) {
     return false;
+  }
+
+  // Allow element that delegates layout (i.e. display: contents)
+  // matches display: contents
+  if (isDisplayContents(computedStyle)) {
+    return true;
   }
 
   // display: none is not inherited, so finally check if element has calculated width or height

--- a/packages/overlays/test/utils-tests/get-focusable-elements.test.js
+++ b/packages/overlays/test/utils-tests/get-focusable-elements.test.js
@@ -53,12 +53,16 @@ describe('getFocusableElements()', () => {
             <input id='el4'>
           </div>
         </div>
+
+        <div style='display: contents;'>
+          <button id='el5'></button>
+        </div>
       </div>
     `);
     const nodes = getFocusableElements(element);
     const ids = nodes.map(n => n.id);
 
-    expect(ids).eql(['el1', 'el2', 'el3', 'el4']);
+    expect(ids).eql(['el1', 'el2', 'el3', 'el4', 'el5']);
   });
 
   it('skips elements that should not receive focus', async () => {

--- a/packages/overlays/test/utils-tests/visibility.test.js
+++ b/packages/overlays/test/utils-tests/visibility.test.js
@@ -142,4 +142,16 @@ describe('isVisible()', () => {
     const target = /** @type {HTMLElement} */ (element.querySelector('#target'));
     expect(isVisible(target)).to.equal(false);
   });
+
+  it('returns true when display contents', async () => {
+    const element = /** @type {HTMLElement} */ (
+      await fixture(`
+      <div style="display: contents;">
+        <div style="width:10px; height:10px;"></div>
+      </div>
+      `)
+    );
+
+    expect(isVisible(element)).to.equal(true);
+  });
 });


### PR DESCRIPTION
I noticed an issue in overlays, where keyboard event trapping would skip certain focusable elements. After debugging for a while, I discovered that certain elements were deemed 'not visible' and would be skipped from the traversal if `display: contents` had been set. This is because of the check that is in place to explicitly query the box model as a last check, which would give a false negative.

This is problematic for when `display: contents` is important, and definitely has visible focusable elements within it!

## What I did

1. Added a check to see if `display: contents` is in the computed styles, and resolve `true`.

If anyone can think of a smarter check then I'm happy to change this. Perhaps querying the box model is not the right approach here anyway?
