### PR TITLE
fix(ajax): align intercepted and non-intercepted response behavior

### DIFF
--- a/.changeset/eight-years-pump.md
+++ b/.changeset/eight-years-pump.md
@@ -1,5 +1,5 @@
 ---
-"@lion/overlays": patch
+'@lion/overlays': patch
 ---
 
 fix: isVisible check on elements with display:contents

--- a/.changeset/soft-trains-brush.md
+++ b/.changeset/soft-trains-brush.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+Align intercepted and non-intercepted response behavior


### PR DESCRIPTION
## What I did

- When an interceptor returns a Response, the original request object was missing.
- When an interceptor returns a 4xx or 5xx Response, the response was returned as is instead of throwing a fetch error.
