### PR TITLE
chore: keep prod dependencies limited and simple

### DIFF
--- a/.changeset/little-melons-lay.md
+++ b/.changeset/little-melons-lay.md
@@ -2,4 +2,4 @@
 '@lion/input-tel': patch
 ---
 
-Make use of awsome-phonenumber, remove local copy
+Make use of awesome-phonenumber, remove local copy

--- a/.changeset/nervous-cobras-know.md
+++ b/.changeset/nervous-cobras-know.md
@@ -1,5 +1,5 @@
 ---
-'@lion/helpers': minor
+'@lion/core': patch
 '@lion/accordion': patch
 '@lion/collapsible': patch
 '@lion/form-core': patch

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -36,8 +36,7 @@
     "lion-accordion.js"
   ],
   "dependencies": {
-    "@lion/core": "^0.22.0",
-    "@lion/helpers": "^0.11.0"
+    "@lion/core": "^0.22.0"
   },
   "keywords": [
     "accordion",

--- a/packages/accordion/src/LionAccordion.js
+++ b/packages/accordion/src/LionAccordion.js
@@ -1,6 +1,6 @@
 /* eslint-disable class-methods-use-this */
-import { LitElement, css, html } from '@lion/core';
-import { uuid } from '@lion/helpers';
+import { LitElement, css, html, uuid } from '@lion/core';
+
 /**
  * @typedef {Object} StoreEntry
  * @property {string} uid Unique ID for the entry

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -38,8 +38,7 @@
     "demo/custom-collapsible.js"
   ],
   "dependencies": {
-    "@lion/core": "^0.22.0",
-    "@lion/helpers": "^0.11.0"
+    "@lion/core": "^0.22.0"
   },
   "keywords": [
     "collapsible",

--- a/packages/collapsible/src/LionCollapsible.js
+++ b/packages/collapsible/src/LionCollapsible.js
@@ -1,5 +1,4 @@
-import { LitElement, html, css } from '@lion/core';
-import { uuid } from '@lion/helpers';
+import { LitElement, html, css, uuid } from '@lion/core';
 /**
  * `LionCollapsible` is a class for custom collapsible element (`<lion-collapsible>` web component).
  *

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -85,3 +85,4 @@ export { SlotMixin } from './src/SlotMixin.js';
 export { UpdateStylesMixin } from './src/UpdateStylesMixin.js';
 export { browserDetection } from './src/browserDetection.js';
 export { EventTargetShim } from './src/EventTargetShim.js';
+export { uuid } from './src/uuid.js';

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -76,3 +76,4 @@ export { SlotMixin } from './src/SlotMixin.js';
 export { UpdateStylesMixin } from './src/UpdateStylesMixin.js';
 export { browserDetection } from './src/browserDetection.js';
 export { EventTargetShim } from './src/EventTargetShim.js';
+export { uuid } from './src/uuid.js';

--- a/packages/core/src/uuid.js
+++ b/packages/core/src/uuid.js
@@ -4,6 +4,6 @@
  * @return {string} unique id
  */
 export function uuid(prefix = '') {
-  const elementName = prefix.length > 1 ? `${prefix}-` : '';
+  const elementName = prefix.length > 0 ? `${prefix}-` : '';
   return `${elementName}${Math.random().toString(36).substr(2, 10)}`;
 }

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -40,7 +40,6 @@
   ],
   "dependencies": {
     "@lion/core": "^0.22.0",
-    "@lion/helpers": "^0.11.0",
     "@lion/localize": "^0.24.0"
   },
   "keywords": [

--- a/packages/form-core/src/FormControlMixin.js
+++ b/packages/form-core/src/FormControlMixin.js
@@ -1,5 +1,4 @@
-import { css, dedupeMixin, html, nothing, SlotMixin, DisabledMixin } from '@lion/core';
-import { uuid } from '@lion/helpers';
+import { css, dedupeMixin, html, nothing, SlotMixin, DisabledMixin, uuid } from '@lion/core';
 import { getAriaElementsInRightDomOrder } from './utils/getAriaElementsInRightDomOrder.js';
 import { Unparseable } from './validate/Unparseable.js';
 import { FormRegisteringMixin } from './registration/FormRegisteringMixin.js';

--- a/packages/helpers/index.js
+++ b/packages/helpers/index.js
@@ -1,7 +1,6 @@
 // Utilities
 export { renderLitAsNode } from './renderLitAsNode/src/renderLitAsNode.js';
 export { sortEachDepth } from './sortEachDepth/src/sortEachDepth.js';
-export { uuid } from './uuid/uuid.js';
 
 // Components
 export { SbActionLogger } from './sb-action-logger/src/SbActionLogger.js';

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -40,8 +40,7 @@
   ],
   "dependencies": {
     "@lion/core": "^0.22.0",
-    "@lion/form-core": "^0.17.1",
-    "@lion/helpers": "^0.11.0"
+    "@lion/form-core": "^0.17.1"
   },
   "keywords": [
     "form",

--- a/packages/listbox/src/ListboxMixin.js
+++ b/packages/listbox/src/ListboxMixin.js
@@ -1,6 +1,5 @@
-import { css, dedupeMixin, html, ScopedElementsMixin, SlotMixin } from '@lion/core';
+import { css, dedupeMixin, html, ScopedElementsMixin, SlotMixin, uuid } from '@lion/core';
 import { ChoiceGroupMixin, FormControlMixin, FormRegistrarMixin } from '@lion/form-core';
-import { uuid } from '@lion/helpers';
 import { LionOptions } from './LionOptions.js';
 
 // TODO: extract ListNavigationWithActiveDescendantMixin that can be reused in [role="menu"]

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -39,8 +39,7 @@
   ],
   "dependencies": {
     "@lion/core": "^0.22.0",
-    "@lion/form-core": "^0.17.1",
-    "@lion/helpers": "^0.11.0"
+    "@lion/form-core": "^0.17.1"
   },
   "keywords": [
     "lion",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -36,8 +36,7 @@
     "lion-tabs.js"
   ],
   "dependencies": {
-    "@lion/core": "^0.22.0",
-    "@lion/helpers": "^0.11.0"
+    "@lion/core": "^0.22.0"
   },
   "keywords": [
     "lion",

--- a/packages/tabs/src/LionTabs.js
+++ b/packages/tabs/src/LionTabs.js
@@ -1,5 +1,4 @@
-import { css, html, LitElement } from '@lion/core';
-import { uuid } from '@lion/helpers';
+import { css, html, LitElement, uuid } from '@lion/core';
 
 /**
  * @typedef {Object} StoreEntry


### PR DESCRIPTION
## What I did

- Keep number of production deps as limited as possible
- Use @lion/helpers only for devDeps
- Clean up unused occurrences of @lion/helpers