### PR TITLE
fix: add type module to pkg jsons of ESM packages

### DIFF
--- a/.changeset/dull-cats-dress.md
+++ b/.changeset/dull-cats-dress.md
@@ -1,0 +1,44 @@
+---
+'@lion/accordion': minor
+'@lion/ajax': minor
+'@lion/button': minor
+'@lion/calendar': minor
+'@lion/checkbox-group': minor
+'@lion/collapsible': minor
+'@lion/combobox': minor
+'@lion/core': minor
+'@lion/dialog': minor
+'@lion/fieldset': minor
+'@lion/form': minor
+'@lion/form-core': minor
+'@lion/form-integrations': minor
+'@lion/helpers': minor
+'@lion/icon': minor
+'@lion/input': minor
+'@lion/input-amount': minor
+'@lion/input-date': minor
+'@lion/input-datepicker': minor
+'@lion/input-email': minor
+'@lion/input-iban': minor
+'@lion/input-range': minor
+'@lion/input-stepper': minor
+'@lion/input-tel': minor
+'@lion/input-tel-dropdown': minor
+'@lion/listbox': minor
+'@lion/localize': minor
+'@lion/overlays': minor
+'@lion/pagination': minor
+'@lion/progress-indicator': minor
+'@lion/radio-group': minor
+'@lion/select': minor
+'@lion/select-rich': minor
+'singleton-manager': minor
+'@lion/steps': minor
+'@lion/switch': minor
+'@lion/tabs': minor
+'@lion/textarea': minor
+'@lion/tooltip': minor
+'@lion/validate-messages': minor
+---
+
+Add "type":"module" to ESM packages so loaders like Vite will interpret the package as ESM properly.

--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/accordion"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/ajax/package.json
+++ b/packages/ajax/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/ajax"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/button"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/calendar/package.json
+++ b/packages/calendar/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/calendar"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/checkbox-group/package.json
+++ b/packages/checkbox-group/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/checkbox-group"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/collapsible"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/combobox"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/core"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/dialog"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/fieldset/package.json
+++ b/packages/fieldset/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/fieldset"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/form-core/package.json
+++ b/packages/form-core/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/field"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/form-integrations/package.json
+++ b/packages/form-integrations/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/form-integrations"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/form"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/helpers"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/icon"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-amount/package.json
+++ b/packages/input-amount/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-amount"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-date/package.json
+++ b/packages/input-date/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-date"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-datepicker/package.json
+++ b/packages/input-datepicker/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-datepicker"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-email/package.json
+++ b/packages/input-email/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-email"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-iban/package.json
+++ b/packages/input-iban/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-iban"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-range/package.json
+++ b/packages/input-range/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-range"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-stepper/package.json
+++ b/packages/input-stepper/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-stepper"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-tel-dropdown/package.json
+++ b/packages/input-tel-dropdown/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-tel-dropdown"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input-tel/package.json
+++ b/packages/input-tel/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input-tel"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/input/package.json
+++ b/packages/input/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/input"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/listbox"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/localize/package.json
+++ b/packages/localize/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/localize"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/overlays/package.json
+++ b/packages/overlays/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/overlays"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/pagination"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/progress-indicator/package.json
+++ b/packages/progress-indicator/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/progress-indicator"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/radio-group/package.json
+++ b/packages/radio-group/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/radio-group"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/select-rich/package.json
+++ b/packages/select-rich/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/select-rich"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/select"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/singleton-manager/package.json
+++ b/packages/singleton-manager/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/singleton-manager"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/steps/package.json
+++ b/packages/steps/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/steps"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/switch"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/tabs"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/textarea/package.json
+++ b/packages/textarea/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/textarea"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/tooltip"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [

--- a/packages/validate-messages/package.json
+++ b/packages/validate-messages/package.json
@@ -10,6 +10,7 @@
     "url": "https://github.com/ing-bank/lion.git",
     "directory": "packages/validate-messages"
   },
+  "type": "module",
   "main": "index.js",
   "module": "index.js",
   "files": [


### PR DESCRIPTION
Fixes issue:

```
@lion/core doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). Please contact the package author to fix.
```

Vite nowadays doesn't like the fact that we don't have "type":"module" in the pkg json of our ESM packages.

Apparently to be a "valid" ES module you need it, or have a `.mjs` extension. Not sure who came up with that but oh well, I suppose it doesn't hurt us?