### PR TITLE
Allow invokers of Accordion components to specify which content node to open and close

### DIFF
--- a/packages/accordion/test/lion-accordion.test.js
+++ b/packages/accordion/test/lion-accordion.test.js
@@ -160,13 +160,30 @@ describe('<lion-accordion>', () => {
     it('are visible when corresponding invoker is expanded', async () => {
       const el = /** @type {LionAccordion} */ (await fixture(basicAccordion));
       const contents = el.querySelectorAll('[slot=content]');
+      const invokers = el.querySelectorAll('[slot=invoker]');
+
       el.expanded = [0];
-      expect(contents[0]).to.be.visible;
-      expect(contents[1]).to.be.not.visible;
+
+      if (invokers[0].hasAttribute('data-target')) {
+        const target = invokers[0].getAttribute('data-target');
+        const targetContentNode = el.querySelector(`[data-content=${target}]`);
+        expect(targetContentNode).to.not.equal(null);
+        expect(targetContentNode).to.be.visible;
+      } else {
+        expect(contents[0]).to.be.visible;
+        expect(contents[1]).to.be.not.visible;
+      }
 
       el.expanded = [1];
-      expect(contents[0]).to.be.not.visible;
-      expect(contents[1]).to.be.visible;
+      if (invokers[1].hasAttribute('data-target')) {
+        const target = invokers[1].getAttribute('data-target');
+        const targetContentNode = el.querySelector(`[data-content=${target}]`);
+        expect(targetContentNode).to.not.equal(null);
+        expect(targetContentNode).to.be.visible;
+      } else {
+        expect(contents[0]).to.be.not.visible;
+        expect(contents[1]).to.be.visible;
+      }
     });
 
     it.skip('have a DOM structure that allows them to be animated ', async () => {});


### PR DESCRIPTION
## IMPORTANT NOTE

This is an assignment done for an interview at ING and therefore has the definite status of UNFINISHED. If there is enough interest in the PR, I will finish it, but at this time its main function is to permit a technical interview to be conducted.

## Introduction

At the moment the relationship between the Invoker and Content nodes of the Accordion components depends on the order in which the Invoker and Content nodes appear in the DOM hierarchy. So the first Invoker node will open and close the first Content node, and the second Invoker node will open and close the second Content node, and so on. This PR allows a `data-target` attribute to be specified on the Invoker node that corresponds to a `data-content` attribute on a target Content node, which allows the user to specify exactly which Content node is opened and closed when he or she clicks the Invoker button.

If no data-target is specified on an Invoker node, then the Content node with the same index as the Invoker node is opened and closed, in line with the behaviour at present.

## Example

In the following code fragment, the first Invoker targets the Content node with `data-content` "second", so it actually opens and closes the second content node. The second Invoker behaves normally, opening and closing the second content node. The third Invoker opens and closes the first content node. No invoker opens and closes the third content node.

```
     <lion-accordion>
          <h3 slot="invoker" data-target="second">
            <button>
              First invoker (expands and collapses second content node)
            </button>
          </h3>
          <div slot="content" data-content="first">
            This first content node can be opened and closed by clicking on the
            third invoker button.
          </div>
          <h3 slot="invoker">
            <button>
              Second Invoker (expands and collapses second content node)
            </button>
          </h3>
          <div slot="content" data-content="second">
            The second content slot can be opened and closed by both the first
            and second invoker buttons.
          </div>
          <h3 slot="invoker" data-target="first">
            <button>
              Third Invoker (expands and collapses first content node)
            </button>
          </h3>
          <div slot="content">
            This is a currently inaccessible third content block.
          </div>
        </lion-accordion>
```
 
 ## How to test it manually
 
 1. Scaffold an app from the open-wc github repository.
 2. Use the usual import "@lion/accordion/define"; syntac to import the tag
 3. Paste the example code above into the html block of the render function of the default generated app.
 4. When you run the app, use the accordion!
 
 ## Rules
 
 Expanding a content node will also expand any other invokers linked to the same content node.
 
 Collapsing a content node will also collapse any other invokers linked to the same content node.
 
 Invokers without data-targets should behave normally.
 
 ## Remaining issues
 
 Generally, there was not enough time to conduct thorough testing, in particular cross-browser testing and the focusing feature.
 
Although one test has been modified to reflect the change, other tests connected with the ARIA settings need to be modified.

 
 
 