### PR TITLE
fix(core): use partial renderOptions in SlotMixin (for Safari)

### DIFF
--- a/.changeset/grumpy-donkeys-camp.md
+++ b/.changeset/grumpy-donkeys-camp.md
@@ -1,0 +1,5 @@
+---
+'@lion/core': patch
+---
+
+fix: use partial renderOptions in SlotMixin (for Safari)

--- a/packages/core/src/SlotMixin.js
+++ b/packages/core/src/SlotMixin.js
@@ -44,7 +44,9 @@ const SlotMixinImplementation = superclass =>
       const registryRoot = supportsScopedRegistry ? this.shadowRoot : document;
       // @ts-expect-error wait for browser support
       const tempRenderTarget = registryRoot.createElement('div');
-      render(template, tempRenderTarget, this.renderOptions);
+      // Providing all options breaks Safari; keep host and creationScope
+      const { creationScope, host } = this.renderOptions;
+      render(template, tempRenderTarget, { creationScope, host });
       return Array.from(tempRenderTarget.childNodes);
     }
 


### PR DESCRIPTION
Makes sure that safari doesn't throw an error when ScopedElementsMixin renderOptions are used for "offline" render of nodes.
(was not possible to test this without loading the polyfill)
