### PR TITLE
Fix/input tel format options

### DIFF
--- a/.changeset/chilled-rules-explode.md
+++ b/.changeset/chilled-rules-explode.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-tel-dropdown': patch
+---
+
+substract and export getFlagSymbol function

--- a/.changeset/plenty-penguins-greet.md
+++ b/.changeset/plenty-penguins-greet.md
@@ -1,0 +1,6 @@
+---
+'@lion/input-tel': patch
+'@lion/input-tel-dropdown': patch
+---
+
+Add option to style the country-code with parentheses in the formatter

--- a/.changeset/tame-papayas-double.md
+++ b/.changeset/tame-papayas-double.md
@@ -1,0 +1,5 @@
+---
+'@lion/input-tel': patch
+---
+
+Remove unwanted characters in input-tel parser

--- a/docs/components/input-tel-dropdown/use-cases.md
+++ b/docs/components/input-tel-dropdown/use-cases.md
@@ -81,3 +81,79 @@ export const preferredRegionCodes = () => {
   `;
 };
 ```
+
+## Format
+
+### Format strategy
+
+Determines what the formatter output should look like.
+Formatting strategies as provided by awesome-phonenumber / google-libphonenumber.
+
+Possible values:
+
+| strategy      |                                output |
+| :------------ | ------------------------------------: |
+| e164          |                        `+46707123456` |
+| international |                    `+46 70 712 34 56` |
+| national      | not applicable for input-tel-dropdown |
+| significant   | not applicable for input-tel-dropdown |
+| rfc3966       |                `tel:+46-70-712-34-56` |
+
+Also see:
+
+- [awesome-phonenumber documentation](https://www.npmjs.com/package/awesome-phonenumber)
+
+```js preview-story
+export const formatStrategy = () => {
+  loadDefaultFeedbackMessages();
+  const inputTel = createRef();
+  return html`
+    <select @change="${({ target }) => (inputTel.value.formatStrategy = target.value)}">
+      <option value="e164">e164</option>
+      <option value="international">international</option>
+      <option value="rfc3966">rfc3966</option>
+    </select>
+    <lion-input-tel-dropdown
+      ${ref(inputTel)}
+      label="Format strategy"
+      help-text="Choose a strategy above"
+      format-strategy="e164"
+      name="phoneNumber"
+    ></lion-input-tel-dropdown>
+    <h-output
+      .show="${['modelValue', 'formatStrategy']}"
+      .readyPromise="${PhoneUtilManager.loadComplete}"
+    ></h-output>
+  `;
+};
+```
+
+### Format country code style
+
+You can style the country code with parentheses.
+
+```js preview-story
+export const formatCountryCodeStyle = () => {
+  loadDefaultFeedbackMessages();
+  const inputTel = createRef();
+  return html`
+    <select @change="${({ target }) => (inputTel.value.formatStrategy = target.value)}">
+      <option value="e164">e164</option>
+      <option value="international">international</option>
+      <option value="rfc3966">rfc3966</option>
+    </select>
+    <lion-input-tel-dropdown
+      ${ref(inputTel)}
+      label="Format strategy"
+      help-text="Choose a strategy above"
+      format-country-code-style="parentheses"
+      format-strategy="e164"
+      name="phoneNumber"
+    ></lion-input-tel-dropdown>
+    <h-output
+      .show="${['modelValue', 'formatStrategy']}"
+      .readyPromise="${PhoneUtilManager.loadComplete}"
+    ></h-output>
+  `;
+};
+```

--- a/docs/components/input-tel/use-cases.md
+++ b/docs/components/input-tel/use-cases.md
@@ -176,7 +176,9 @@ export const oneAllowedRegion = () => {
 };
 ```
 
-## Format strategy
+## Format
+
+### Format strategy
 
 Determines what the formatter output should look like.
 Formatting strategies as provided by awesome-phonenumber / google-libphonenumber.
@@ -223,7 +225,37 @@ export const formatStrategy = () => {
 };
 ```
 
-## Live format
+### Format country code style
+
+You can also style the country code with parentheses.
+
+```js preview-story
+export const formatCountryCodeStyle = () => {
+  loadDefaultFeedbackMessages();
+  const inputTel = createRef();
+  return html`
+    <select @change="${({ target }) => (inputTel.value.formatStrategy = target.value)}">
+      <option value="e164">e164</option>
+      <option value="international">international</option>
+      <option value="rfc3966">rfc3966</option>
+    </select>
+    <lion-input-tel
+      ${ref(inputTel)}
+      label="Format strategy"
+      help-text="Choose a strategy above"
+      .modelValue=${'+46707123456'}
+      format-country-code-style="parentheses"
+      name="phoneNumber"
+    ></lion-input-tel>
+    <h-output
+      .show="${['modelValue', 'formatStrategy']}"
+      .readyPromise="${PhoneUtilManager.loadComplete}"
+    ></h-output>
+  `;
+};
+```
+
+### Live format
 
 Type '6' in the example below to see how the phone number is formatted during typing.
 

--- a/packages/input-tel-dropdown/index.js
+++ b/packages/input-tel-dropdown/index.js
@@ -1,1 +1,2 @@
+export { getFlagSymbol } from './src/getFlagSymbol.js';
 export { LionInputTelDropdown } from './src/LionInputTelDropdown.js';

--- a/packages/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -2,6 +2,7 @@
 import { render, html, css, ref, createRef } from '@lion/core';
 import { LionInputTel } from '@lion/input-tel';
 import { localize } from '@lion/localize';
+import { getFlagSymbol } from './getFlagSymbol.js';
 
 /**
  * Note: one could consider to implement LionInputTelDropdown as a
@@ -30,14 +31,6 @@ import { localize } from '@lion/localize';
  * @typedef {import('@lion/overlays').OverlayController} OverlayController
  * @typedef {TemplateDataForDropdownInputTel & {data: {regionMetaList:RegionMeta[]}}} TemplateDataForIntlInputTel
  */
-
-// eslint-disable-next-line prefer-destructuring
-/**
- * @param {string} char
- */
-function getRegionalIndicatorSymbol(char) {
-  return String.fromCodePoint(0x1f1e6 - 65 + char.toUpperCase().charCodeAt(0));
-}
 
 /**
  * LionInputTelDropdown renders a dropdown like element next to the text field, inside the
@@ -419,8 +412,7 @@ export class LionInputTelDropdown extends LionInputTel {
       const countryCode =
         this._phoneUtil && this._phoneUtil.getCountryCodeForRegionCode(regionCode);
 
-      const flagSymbol =
-        getRegionalIndicatorSymbol(regionCode[0]) + getRegionalIndicatorSymbol(regionCode[1]);
+      const flagSymbol = getFlagSymbol(regionCode);
 
       const destinationList = this.preferredRegions.includes(regionCode)
         ? this.__regionMetaListPreferred

--- a/packages/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -281,7 +281,11 @@ export class LionInputTelDropdown extends LionInputTel {
   _initModelValueBasedOnDropdown() {
     if (!this._initialModelValue && !this.dirty && this._phoneUtil) {
       const countryCode = this._phoneUtil.getCountryCodeForRegionCode(this.activeRegion);
-      this.__initializedRegionCode = `+${countryCode}`;
+      if (this.formatCountryCodeStyle === 'parentheses') {
+        this.__initializedRegionCode = `(+${countryCode})`;
+      } else {
+        this.__initializedRegionCode = `+${countryCode}`;
+      }
       this.modelValue = this.__initializedRegionCode;
       this._initialModelValue = this.__initializedRegionCode;
       this.initInteractionState();
@@ -328,7 +332,11 @@ export class LionInputTelDropdown extends LionInputTel {
       } else {
         // In case of dropdown has +31, and input has only +3
         const valueObj = this.value.split(' ');
-        this.modelValue = this._callParser(this.value.replace(valueObj[0], `+${countryCode}`));
+        if (this.formatCountryCodeStyle === 'parentheses' && !this.value.includes('(')) {
+          this.modelValue = this._callParser(this.value.replace(valueObj[0], `(+${countryCode})`));
+        } else {
+          this.modelValue = this._callParser(this.value.replace(valueObj[0], `+${countryCode}`));
+        }
       }
     }
 

--- a/packages/input-tel-dropdown/src/getFlagSymbol.js
+++ b/packages/input-tel-dropdown/src/getFlagSymbol.js
@@ -1,0 +1,13 @@
+/**
+ * @param {string} char
+ */
+function getRegionalIndicatorSymbol(char) {
+  return String.fromCodePoint(0x1f1e6 - 65 + char.toUpperCase().charCodeAt(0));
+}
+
+/**
+ * @param {string} regionCode
+ */
+export function getFlagSymbol(regionCode) {
+  return getRegionalIndicatorSymbol(regionCode[0]) + getRegionalIndicatorSymbol(regionCode[1]);
+}

--- a/packages/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
+++ b/packages/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
@@ -1,17 +1,17 @@
-import {
-  expect,
-  fixture as _fixture,
-  fixtureSync as _fixtureSync,
-  html,
-  defineCE,
-  unsafeStatic,
-  aTimeout,
-} from '@open-wc/testing';
-import sinon from 'sinon';
 // @ts-ignore
 import { PhoneUtilManager } from '@lion/input-tel';
 // @ts-ignore
 import { mockPhoneUtilManager, restorePhoneUtilManager } from '@lion/input-tel/test-helpers';
+import {
+  aTimeout,
+  defineCE,
+  expect,
+  fixture as _fixture,
+  fixtureSync as _fixtureSync,
+  html,
+  unsafeStatic,
+} from '@open-wc/testing';
+import sinon from 'sinon';
 import { LionInputTelDropdown } from '../src/LionInputTelDropdown.js';
 
 /**
@@ -252,17 +252,18 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
         await aTimeout(0);
         expect(spy).to.have.been.calledOnce;
         restorePhoneUtilManager();
+        spy.restore();
       });
     });
 
     describe('On dropdown value change', () => {
       it('changes the currently active country code in the textbox', async () => {
-        const el = await fixture(
-          html` <${tag} .allowedRegions="${[
-            'NL',
-            'BE',
-          ]}" .modelValue="${'+31612345678'}"></${tag}> `,
-        );
+        const el = await fixture(html`
+          <${tag}
+            .allowedRegions="${['NL', 'BE']}"
+            .modelValue="${'+31612345678'}"
+          ></${tag}>
+        `);
         // @ts-ignore
         mimicUserChangingDropdown(el.refs.dropdown.value, 'BE');
         await el.updateComplete;
@@ -280,6 +281,21 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
         await el.updateComplete;
         await el.updateComplete;
         expect(el.value).to.equal('+32');
+      });
+
+      it('changes the currently active country code in the textbox when empty with parentheses', async () => {
+        const el = await fixture(
+          html` <${tag} format-country-code-style="parentheses" .allowedRegions="${[
+            'NL',
+            'BE',
+          ]}"></${tag}> `,
+        );
+        el.value = '';
+        // @ts-ignore
+        mimicUserChangingDropdown(el.refs.dropdown.value, 'BE');
+        await el.updateComplete;
+        await el.updateComplete;
+        expect(el.value).to.equal('(+32)');
       });
 
       it('changes the currently active country code in the textbox when invalid', async () => {
@@ -379,6 +395,20 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
         expect(getDropdownValue(/** @type {DropdownElement} */ (el.refs.dropdown.value))).to.equal(
           'US',
         );
+      });
+    });
+
+    describe('is empthy', () => {
+      it('ignores initial countrycode', async () => {
+        const el = await fixture(html` <${tag}></${tag}> `);
+        // @ts-ignore
+        expect(el._isEmpty()).to.be.true;
+      });
+
+      it('ignores initial countrycode with parentheses', async () => {
+        const el = await fixture(html` <${tag} format-country-code-style="parentheses"></${tag}> `);
+        // @ts-ignore
+        expect(el._isEmpty()).to.be.true;
       });
     });
   });

--- a/packages/input-tel/src/formatters.js
+++ b/packages/input-tel/src/formatters.js
@@ -7,13 +7,36 @@ import { PhoneUtilManager } from './PhoneUtilManager.js';
  */
 
 /**
+ * @param {string} value
+ * @param {object} options
+ * @param {RegionCode} options.regionCode
+ * @param {string} options.formatCountryCodeStyle
+ */
+export function getFormatCountryCodeStyle(value, { regionCode, formatCountryCodeStyle }) {
+  const countryCode = PhoneUtilManager?.PhoneUtil?.getCountryCodeForRegionCode(regionCode);
+  if (
+    formatCountryCodeStyle === 'parentheses' &&
+    countryCode &&
+    value.includes(`+${countryCode}`) &&
+    !value.includes(`(`)
+  ) {
+    return value.replace(`+${countryCode}`, `(+${countryCode})`);
+  }
+  return value;
+}
+
+/**
  * @param {string} modelValue
  * @param {object} options
  * @param {RegionCode} options.regionCode
  * @param {PhoneNumberFormat} [options.formatStrategy='international']
+ * @param {string} [options.formatCountryCodeStyle='default']
  * @returns {string}
  */
-export function formatPhoneNumber(modelValue, { regionCode, formatStrategy = 'international' }) {
+export function formatPhoneNumber(
+  modelValue,
+  { regionCode, formatStrategy = 'international', formatCountryCodeStyle = 'default' },
+) {
   // Do not format when not loaded
   if (!PhoneUtilManager.isLoaded) {
     return modelValue;
@@ -50,8 +73,15 @@ export function formatPhoneNumber(modelValue, { regionCode, formatStrategy = 'in
       default:
         break;
     }
+
+    if (formatCountryCodeStyle !== 'default') {
+      return getFormatCountryCodeStyle(formattedValue, { regionCode, formatCountryCodeStyle });
+    }
     return formattedValue;
   }
 
+  if (formatCountryCodeStyle !== 'default') {
+    return getFormatCountryCodeStyle(modelValue, { regionCode, formatCountryCodeStyle });
+  }
   return modelValue;
 }

--- a/packages/input-tel/src/parsers.js
+++ b/packages/input-tel/src/parsers.js
@@ -18,10 +18,11 @@ export function parsePhoneNumber(viewValue, { regionCode }) {
 
   // eslint-disable-next-line prefer-destructuring
   const PhoneNumber = /** @type {AwesomePhoneNumber} */ (PhoneUtilManager.PhoneUtil);
-
+  const regex = /[+0-9]+/gi;
+  const strippedViewValue = viewValue.match(regex)?.join('');
   let pn;
   try {
-    pn = PhoneNumber(viewValue, regionCode);
+    pn = PhoneNumber(strippedViewValue, regionCode);
     // eslint-disable-next-line no-empty
   } catch (_) {}
 

--- a/packages/input-tel/test-suites/LionInputTel.suite.js
+++ b/packages/input-tel/test-suites/LionInputTel.suite.js
@@ -10,6 +10,7 @@ import {
 import sinon from 'sinon';
 import { mimicUserInput } from '@lion/form-core/test-helpers';
 import { localize } from '@lion/localize';
+import { Unparseable } from '@lion/form-core';
 import { LionInputTel } from '../src/LionInputTel.js';
 import { PhoneNumber } from '../src/validators.js';
 import { PhoneUtilManager } from '../src/PhoneUtilManager.js';
@@ -100,6 +101,28 @@ function runActiveRegionTests({ tag, phoneUtilLoadedAfterInit }) {
         resolvePhoneUtilLoaded(undefined);
         await el.updateComplete;
       }
+      expect(el.activeRegion).to.equal('NL');
+    });
+
+    it('deducts it from value when modelValue is unparseable', async () => {
+      const modelValue = new Unparseable('+316');
+      const el = await fixture(html` <${tag} .modelValue=${modelValue}></${tag}> `);
+      if (resolvePhoneUtilLoaded) {
+        resolvePhoneUtilLoaded(undefined);
+        await el.updateComplete;
+      }
+      // Region code for country code '31' is 'NL'
+      expect(el.activeRegion).to.equal('NL');
+    });
+
+    it('deducts it from value when modelValue is unparseable and contains parentheses', async () => {
+      const modelValue = new Unparseable('(+31)6');
+      const el = await fixture(html` <${tag} .modelValue=${modelValue}></${tag}> `);
+      if (resolvePhoneUtilLoaded) {
+        resolvePhoneUtilLoaded(undefined);
+        await el.updateComplete;
+      }
+      // Region code for country code '31' is 'NL'
       expect(el.activeRegion).to.equal('NL');
     });
 
@@ -269,6 +292,16 @@ export function runInputTelSuite({ klass = LionInputTel } = {}) {
           mimicUserInput(el, '612345678');
           await aTimeout(0);
           expect(el.formattedValue).to.equal('612345678');
+        });
+
+        it('formats according to formatCountryCodeStyle', async () => {
+          const el = await fixture(
+            html` <${tag} format-country-code-style="parentheses" .modelValue="${'+31612345678'}" .allowedRegions="${[
+              'NL',
+            ]}"></${tag}> `,
+          );
+          await aTimeout(0);
+          expect(el.formattedValue).to.equal('(+31) 6 12345678');
         });
       });
 

--- a/packages/input-tel/test/formatters.test.js
+++ b/packages/input-tel/test/formatters.test.js
@@ -25,4 +25,42 @@ describe('formatPhoneNumber', () => {
       formatPhoneNumber('+46707123456', { regionCode: 'SE', formatStrategy: 'significant' }),
     ).to.equal('707123456');
   });
+
+  it('formats a phone number according to provided formatCountryCodeStyle', () => {
+    expect(
+      formatPhoneNumber('0707123456', {
+        regionCode: 'SE',
+        formatStrategy: 'e164',
+        formatCountryCodeStyle: 'parentheses',
+      }),
+    ).to.equal('(+46)707123456');
+    expect(
+      formatPhoneNumber('+46707123456', {
+        regionCode: 'SE',
+        formatStrategy: 'international',
+        formatCountryCodeStyle: 'parentheses',
+      }),
+    ).to.equal('(+46) 70 712 34 56');
+    expect(
+      formatPhoneNumber('+46707123456', {
+        regionCode: 'SE',
+        formatStrategy: 'national',
+        formatCountryCodeStyle: 'parentheses',
+      }),
+    ).to.equal('070-712 34 56');
+    expect(
+      formatPhoneNumber('+46707123456', {
+        regionCode: 'SE',
+        formatStrategy: 'rfc3966',
+        formatCountryCodeStyle: 'parentheses',
+      }),
+    ).to.equal('tel:(+46)-70-712-34-56');
+    expect(
+      formatPhoneNumber('+46707123456', {
+        regionCode: 'SE',
+        formatStrategy: 'significant',
+        formatCountryCodeStyle: 'parentheses',
+      }),
+    ).to.equal('707123456');
+  });
 });

--- a/packages/input-tel/test/parsers.test.js
+++ b/packages/input-tel/test/parsers.test.js
@@ -13,4 +13,12 @@ describe('parsePhoneNumber', () => {
     expect(parsePhoneNumber('0707123456', { regionCode: 'NL' })).to.equal('+31707123456');
     expect(parsePhoneNumber('0707123456', { regionCode: 'DE' })).to.equal('+49707123456');
   });
+
+  it('removes unwanted characters', () => {
+    expect(parsePhoneNumber('(+31)707123456', { regionCode: 'NL' })).to.equal('+31707123456');
+    expect(parsePhoneNumber('+31 70 7123456', { regionCode: 'NL' })).to.equal('+31707123456');
+    expect(parsePhoneNumber('+31-70-7123456', { regionCode: 'NL' })).to.equal('+31707123456');
+    expect(parsePhoneNumber('+31|70|7123456', { regionCode: 'NL' })).to.equal('+31707123456');
+    expect(parsePhoneNumber('tel:+31707123456', { regionCode: 'NL' })).to.equal('+31707123456');
+  });
 });

--- a/packages/input-tel/test/preprocessors.test.js
+++ b/packages/input-tel/test/preprocessors.test.js
@@ -16,7 +16,7 @@ describe('liveFormatPhoneNumber', () => {
         prevViewValue: '+36123',
         currentCaretIndex: 2,
       }),
-    ).to.eql({ viewValue: '+31 6 123', caretIndex: 4 });
+    ).to.eql({ caretIndex: 4, viewValue: '+31 6 123' });
   });
 
   it('live formats a complete view value', () => {
@@ -28,5 +28,55 @@ describe('liveFormatPhoneNumber', () => {
         currentCaretIndex: 10,
       }),
     ).to.eql({ caretIndex: 12, viewValue: '+31 6 12345678' });
+  });
+
+  describe('with formatCountryCodeStyle is set to parantheses', () => {
+    it('live formats an incomplete view value', () => {
+      expect(
+        liveFormatPhoneNumber('+316123', {
+          regionCode: 'NL',
+          formatStrategy: 'international',
+          prevViewValue: '+31613',
+          currentCaretIndex: 5,
+          formatCountryCodeStyle: 'parentheses',
+        }),
+      ).to.eql({ caretIndex: 9, viewValue: '(+31) 6 123' });
+    });
+
+    it('live formats a complete view value', () => {
+      expect(
+        liveFormatPhoneNumber('+31612345678', {
+          regionCode: 'NL',
+          formatStrategy: 'international',
+          prevViewValue: '+3161234578',
+          currentCaretIndex: 10,
+          formatCountryCodeStyle: 'parentheses',
+        }),
+      ).to.eql({ caretIndex: 14, viewValue: '(+31) 6 12345678' });
+    });
+
+    it('does not update if parentheses are already in place', () => {
+      expect(
+        liveFormatPhoneNumber('(+31)6123', {
+          regionCode: 'NL',
+          formatStrategy: 'international',
+          prevViewValue: '(+31)123',
+          currentCaretIndex: 5,
+          formatCountryCodeStyle: 'parentheses',
+        }),
+      ).to.eql({ caretIndex: 5, viewValue: '(+31)6123' });
+    });
+
+    it('sets the correct caretIndex if currentCaretIndex in between the countryCode', () => {
+      expect(
+        liveFormatPhoneNumber('+316123', {
+          regionCode: 'NL',
+          formatStrategy: 'international',
+          prevViewValue: '+36123',
+          currentCaretIndex: 2,
+          formatCountryCodeStyle: 'parentheses',
+        }),
+      ).to.eql({ caretIndex: 4, viewValue: '(+31) 6 123' });
+    });
   });
 });


### PR DESCRIPTION
## What I did

1. Substract and export getFlagSymbol function
2. Add option to style the country-code with parentheses in the formatter
3. Remove unwanted characters in input-tel parser
