### PR TITLE
Fix/correct plugin order extend docs

### DIFF
--- a/.changeset/pink-dolphins-drop.md
+++ b/.changeset/pink-dolphins-drop.md
@@ -1,0 +1,5 @@
+---
+'rocket-preset-extend-lion-docs': patch
+---
+
+fix: run plugins in correct order, allowing replace functions to access local urls and kick in after tag transforms

--- a/packages-node/rocket-preset-extend-lion-docs/preset/extendLionDocs.js
+++ b/packages-node/rocket-preset-extend-lion-docs/preset/extendLionDocs.js
@@ -55,13 +55,6 @@ export async function extendLionDocs({
     path: path.resolve(__dirname),
     setupUnifiedPlugins: [
       addPlugin(
-        remarkExtendPkg.remarkExtend,
-        { globalReplaceFunction },
-        {
-          location: markdownPkg,
-        },
-      ),
-      addPlugin(
         remarkUrlToLocal,
         // the page object gets injected globally
         // @ts-ignore
@@ -70,7 +63,7 @@ export async function extendLionDocs({
           rootDir: _rootDir,
         },
         {
-          location: remarkExtendPkg.remarkExtend,
+          location: markdownPkg,
         },
       ),
       addPlugin(
@@ -79,7 +72,14 @@ export async function extendLionDocs({
         // @ts-ignore
         { extendDocsConfig },
         {
-          location: remarkExtendPkg.remarkExtend,
+          location: remarkUrlToLocal,
+        },
+      ),
+      addPlugin(
+        remarkExtendPkg.remarkExtend,
+        { globalReplaceFunction },
+        {
+          location: remarkUrlToLocal,
         },
       ),
     ],


### PR DESCRIPTION
run plugins in correct order, allowing replace functions to access local urls and kick in after tag transforms