### PR TITLE
feat(switch): fix error caused by setting role in constructor (fixes #1740)

### DIFF
--- a/.changeset/wise-carrots-mix.md
+++ b/.changeset/wise-carrots-mix.md
@@ -1,0 +1,5 @@
+---
+'@lion/switch': patch
+---
+
+Fix switch to set role in connectedCallback instead of constructor (throws error).

--- a/packages/switch/src/LionSwitch.js
+++ b/packages/switch/src/LionSwitch.js
@@ -72,7 +72,6 @@ export class LionSwitch extends ScopedElementsMixin(ChoiceInputMixin(LionField))
 
   constructor() {
     super();
-    this.role = 'switch';
     this.checked = false;
     /** @private */
     this.__handleButtonSwitchCheckedChanged = this.__handleButtonSwitchCheckedChanged.bind(this);
@@ -80,6 +79,9 @@ export class LionSwitch extends ScopedElementsMixin(ChoiceInputMixin(LionField))
 
   connectedCallback() {
     super.connectedCallback();
+    if (!this.role) {
+      this.role = 'switch';
+    }
     this.addEventListener('checked-changed', this.__handleButtonSwitchCheckedChanged);
     if (this._labelNode) {
       this._labelNode.addEventListener('click', this._toggleChecked);

--- a/packages/switch/test/lion-switch.test.js
+++ b/packages/switch/test/lion-switch.test.js
@@ -213,4 +213,11 @@ describe('lion-switch', () => {
     );
     expect(el.showsFeedbackFor).to.eql(['info']);
   });
+
+  it('should not cause error by setting an attribute in the constructor', async () => {
+    const div = await fixture(html`<div></div>`);
+    const el = /** @type {LionSwitch} */ (document.createElement('lion-switch'));
+    div.appendChild(el);
+    expect(el.role).to.equal('switch');
+  });
 });


### PR DESCRIPTION
## What I did
Intending to fix the LionSwitch throwing an error in non-lit environments:

1. Relocated setting the `role` to `'switch'` from the `constructor` to the `connectedCallback`.
2. Considering that someone else may also want to set it differently, so it only happens if it had a falsy value
3. Added a test intentionally using basic `document.createElement` instead of relaying on lit in order to trigger the bug.
