### PR TITLE
fix(select): sync values with async option contents

### DIFF
--- a/.changeset/violet-ducks-suffer.md
+++ b/.changeset/violet-ducks-suffer.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+lion-select: added test to assert that modelValue of lion-select is updated when the value or text of one or more options are changed

--- a/packages/ui/components/select/src/LionSelect.js
+++ b/packages/ui/components/select/src/LionSelect.js
@@ -60,6 +60,19 @@ export class LionSelect extends LionFieldWithSelect {
   connectedCallback() {
     super.connectedCallback();
     this._inputNode.addEventListener('change', this._proxyChangeEvent);
+
+    this.__selectObserver = new MutationObserver(() => {
+      this._syncValueUpwards();
+      // We need to force computation of other values in case model didn't change
+      // TODO: consider bringing this generically in FormatMixin._syncValueUpwards
+      this._calculateValues({ source: 'model' });
+    });
+
+    this.__selectObserver.observe(this._inputNode, {
+      attributes: true,
+      childList: true,
+      subtree: true,
+    });
   }
 
   /** @param {import('lit').PropertyValues } changedProperties */
@@ -82,6 +95,7 @@ export class LionSelect extends LionFieldWithSelect {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._inputNode.removeEventListener('change', this._proxyChangeEvent);
+    this.__selectObserver?.disconnect();
   }
 
   /**

--- a/packages/ui/components/select/src/LionSelect.js
+++ b/packages/ui/components/select/src/LionSelect.js
@@ -64,7 +64,8 @@ export class LionSelect extends LionFieldWithSelect {
     this.__selectObserver = new MutationObserver(() => {
       this._syncValueUpwards();
       // We need to force computation of other values in case model didn't change
-      // TODO: consider bringing this generically in FormatMixin._syncValueUpwards
+      // This can happen when options are loaded asynchronously so the modelValue doesn't change
+      // The MutationObserver detects this and makes sure the modelValue is updated
       this._calculateValues({ source: 'model' });
     });
 

--- a/packages/ui/components/select/test/lion-select.test.js
+++ b/packages/ui/components/select/test/lion-select.test.js
@@ -44,6 +44,31 @@ describe('lion-select', () => {
     expect(lionSelect.formattedValue).to.equal('');
   });
 
+  it('updates the formattedValue correctly when the value for the selected option is updated', async () => {
+    const lionSelect = /** @type {LionSelect} */ (
+      await fixture(html`
+        <lion-select label="Foo item" .modelValue="${'nr2'}">
+          <select slot="input">
+            <option value="nr1">Item 1</option>
+            <option value="nr2"></option>
+            <option value="nr3"></option>
+          </select>
+        </lion-select>
+      `)
+    );
+    expect(lionSelect.serializedValue).to.equal('nr2');
+    expect(lionSelect.formattedValue).to.equal('');
+
+    const select = /** @type {HTMLSlotElement} */ (
+      lionSelect.shadowRoot?.querySelector('slot[name=input]')
+    ).assignedElements()[0];
+    const options = select.querySelectorAll('option');
+    options[1].textContent = 'Item 2';
+
+    await aTimeout;
+    expect(lionSelect.formattedValue).to.equal('Item 2');
+  });
+
   it('is accessible', async () => {
     const lionSelect = await fixture(html`
       <lion-select .modelValue="${'nr2'}">


### PR DESCRIPTION
closes https://github.com/ing-bank/lion/issues/1580

TODO:
- [x] write tests
- [x] explain the edge case we solved here: https://github.com/ing-bank/lion/pull/1743/files#diff-7865f08c1843c058f0e3d42527103e04a8195755f0919c458438aae0bcd32647R64
- [x] see if `_calculateValues({source: 'model'})` can/should be called in `FormatMixin._syncValueUpwards` for other edge cases
- [x] add changeset