### PR TITLE
chore(ajax): bump to major version 1.0.0

### DIFF
--- a/.changeset/sweet-bags-listen.md
+++ b/.changeset/sweet-bags-listen.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': major
+---
+
+First major release (no difference with 0.16.0)

--- a/README.md
+++ b/README.md
@@ -91,9 +91,12 @@ There's a couple of "systems" in lion which have a JavaScript API. Examples are 
 <script type="module">
   import { ajax } from '@lion/ajax';
 
-  ajax.get('data.json').then(response => {
-    // most likely you will use response.data
-  });
+  ajax
+    .fetch('data.json')
+    .then(response => response.json())
+    .then(data => {
+      // do something with the data
+    });
 </script>
 ```
 

--- a/docs/guides/how-to/get-started.md
+++ b/docs/guides/how-to/get-started.md
@@ -55,9 +55,12 @@ There's a couple of "systems" in lion which have a JavaScript API. Examples are 
 <script type="module">
   import { ajax } from '@lion/ajax';
 
-  ajax.get('data.json').then(response => {
-    // most likely you will use response.data
-  });
+  ajax
+    .fetch('data.json')
+    .then(response => response.json())
+    .then(data => {
+      // do something with the data
+    });
 </script>
 ```
 


### PR DESCRIPTION
## What I did

1. As discussed with @daKmoR and @narzac, let's release version 1 of the ajax library
2. Fixed a few references in the docs to the old `ajax.get` syntax
