### PR TITLE
chore: reset light dom styles in mdjs-preview

### DIFF
--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -95,24 +95,24 @@ rocket-navigation ul > li.active > ul > li.current > ul {
 }
 
 /* only apply on components list (li > 6) */
-rocket-navigation > ul > li:nth-last-child(n+6) > a,
-rocket-navigation > ul > li:nth-child(n+6) > a {
+rocket-navigation > ul > li:nth-last-child(n + 6) > a,
+rocket-navigation > ul > li:nth-child(n + 6) > a {
   font-size: 16px;
   text-transform: none;
   color: var(--primary-text-color);
 }
 
-rocket-navigation > ul > li:nth-last-child(n+6) > a:hover,
-rocket-navigation > ul > li:nth-child(n+6) > a:hover {
+rocket-navigation > ul > li:nth-last-child(n + 6) > a:hover,
+rocket-navigation > ul > li:nth-child(n + 6) > a:hover {
   color: var(--primary-color);
 }
 
-rocket-navigation > ul > li:nth-last-child(n+6) > ul,
-rocket-navigation ul > li:nth-child(n+6) > ul {
+rocket-navigation > ul > li:nth-last-child(n + 6) > ul,
+rocket-navigation ul > li:nth-child(n + 6) > ul {
   display: none;
 }
 
-rocket-navigation > ul > li:nth-last-child(n+6).active > ul,
-rocket-navigation ul > li:nth-child(n+6).active > ul {
+rocket-navigation > ul > li:nth-last-child(n + 6).active > ul,
+rocket-navigation ul > li:nth-child(n + 6).active > ul {
   display: block;
 }

--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -116,3 +116,17 @@ rocket-navigation > ul > li:nth-last-child(n + 6).active > ul,
 rocket-navigation ul > li:nth-child(n + 6).active > ul {
   display: block;
 }
+
+.markdown-body mdjs-preview > [slot='story'],
+.markdown-body mdjs-preview > [slot='story'] :where(img, button, p, h1, h2, h3, h4, h5, h6) {
+  all: initial;
+}
+
+.markdown-body mdjs-preview > [slot='story'] {
+  /** keep user-agent behaviors for browser elements */
+  display: revert;
+  /** relevant inherited props (like font styles) should be kept */
+  font-family: inherit;
+  font-size: inherit;
+  color: inherit;
+}


### PR DESCRIPTION
@gerjanvangeest in order to fix the combobox example demos (and basically all demos that inherit portal styles in light dom inside mdjs-preview), I reset all css to initial values.

Added:

```css
.markdown-body mdjs-preview > [slot='story'],
.markdown-body mdjs-preview > [slot='story'] :where(img, button) {
  all: initial;
}

.markdown-body mdjs-preview > [slot='story'] {
  /** keep user-agent behaviors for browser elements */
  display: revert;
  /** relevant inherited props (like font styles) should be kept */
  font-family: inherit;
  font-size: inherit;
  color: inherit;
}
```
