### PR TITLE
fix: getMessage return type supports string and Element

### DIFF
--- a/.changeset/mighty-frogs-wave.md
+++ b/.changeset/mighty-frogs-wave.md
@@ -1,0 +1,5 @@
+---
+'@lion/form-core': patch
+---
+
+Extend type of getMessage to allow it being implemented as a sync function.

--- a/packages/form-core/types/validate/validate.d.ts
+++ b/packages/form-core/types/validate/validate.d.ts
@@ -27,7 +27,7 @@ export type ValidatorParam = any;
  * Will be stored on Validator instance and passed to `execute` function
  */
 export type ValidatorConfig = {
-  getMessage?: (data: Partial<FeedbackMessageData>) => Promise<string | Element>;
+  getMessage?: (data: Partial<FeedbackMessageData>) => Promise<string | Element> | string | Element;
   type?: ValidationType;
   node?: FormControlHost;
   fieldName?: string | Promise<string>;


### PR DESCRIPTION
## What I did

I have extended the return type of getMessage in the validator to support string and Element types.
