### PR TITLE
fix(ajax): don't throw on non-JSON responses in fetchJson

### DIFF
--- a/.changeset/late-donkeys-collect.md
+++ b/.changeset/late-donkeys-collect.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+don't throw on non-JSON responses in fetchJson

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -180,14 +180,19 @@ export class Ajax {
       responseText = responseText.substring(jsonPrefix.length);
     }
 
-    try {
-      return {
-        response,
-        body: JSON.parse(responseText),
-      };
-    } catch (error) {
-      throw new Error(`Failed to parse response from ${response.url} as JSON.`);
+    /** @type {any} */
+    let body = responseText;
+    if (response.headers.get('content-type')?.includes('application/json')) {
+      try {
+        body = JSON.parse(responseText);
+      } catch (error) {
+        throw new Error(`Failed to parse response from ${response.url} as JSON.`);
+      }
+    } else {
+      body = responseText;
     }
+
+    return { response, body };
   }
 
   /**

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -159,6 +159,12 @@ describe('Ajax', () => {
       expect(response.response.headers.get('X-Custom-Header')).to.equal('y-custom-value');
     });
 
+    it('handles non-json responses', async () => {
+      fetchStub.returns(Promise.resolve(new Response('!@#$')));
+      const response = await ajax.fetchJson('/foo');
+      expect(response.body).to.eql('!@#$');
+    });
+
     describe('given a request body', () => {
       it('encodes the request body as json', async () => {
         await ajax.fetchJson('/foo', { method: 'POST', body: { a: 1, b: 2 } });
@@ -176,14 +182,14 @@ describe('Ajax', () => {
     describe('given a json prefix', () => {
       it('strips json prefix from response before decoding', async () => {
         const localAjax = new Ajax({ jsonPrefix: '//.,!' });
-        fetchStub.returns(Promise.resolve(new Response('//.,!{"a":1,"b":2}')));
+        fetchStub.returns(Promise.resolve(new Response('//.,!{"a":1,"b":2}', responseInit())));
         const response = await localAjax.fetchJson('/foo');
         expect(response.body).to.eql({ a: 1, b: 2 });
       });
     });
 
     it('throws on invalid JSON responses', async () => {
-      fetchStub.returns(Promise.resolve(new Response('invalid-json')));
+      fetchStub.returns(Promise.resolve(new Response('invalid-json', responseInit())));
 
       let thrown = false;
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11637,6 +11637,11 @@ singleton-manager@1.4.2:
   resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.4.2.tgz#4649acafca3eccf987d828ab16369ee59c4a22a5"
   integrity sha512-3/K7K61TiN0+tw32HRC3AZQBacN0Ky/NmHEnhofFPEFROqZ5T6BXK45Z94OQsvuFD2euOVOU40XDNeTal63Baw==
 
+singleton-manager@1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/singleton-manager/-/singleton-manager-1.4.3.tgz#bdfd71e3b8c99ee8a0d9086496a795c84f886d0e"
+  integrity sha512-Jy1Ib9cO9xCQ6UZ/vyFOqqWMnSpfZ8/Sc2vme944aWsCLO+lMPiFG9kGZGpyiRT9maYeI0JyZH1CGgjmkSN8VA==
+
 sinon@^7.2.2:
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"


### PR DESCRIPTION
## What I did

Fixes https://github.com/ing-bank/lion/issues/1763

I added a check for the content-type of the fetch response. Only if it's JSON, `fetchJson` should try to parse the response. Otherwise it should just return the response text.
