### PR TITLE
fix(LionSwitchButton): do not dispatch checked-change event 

### DIFF
--- a/packages/switch/src/LionSwitchButton.js
+++ b/packages/switch/src/LionSwitchButton.js
@@ -158,7 +158,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
    */
   requestUpdate(name, oldValue) {
     super.requestUpdate(name, oldValue);
-    if (this.isConnected && name === 'checked' && this.checked !== oldValue) {
+    if (this.isConnected && name === 'checked' && this.checked !== oldValue && !this.disabled) {
       this.__checkedStateChange();
     }
   }

--- a/packages/switch/test/lion-switch-button.test.js
+++ b/packages/switch/test/lion-switch-button.test.js
@@ -118,6 +118,14 @@ describe('lion-switch-button', () => {
     expect(handlerSpy.called).to.be.false;
   });
 
+  it('should not dispatch "checked-changed" event if disabled on update', () => {
+    const handlerSpy = sinon.spy();
+    el.disabled = true;
+    el.addEventListener('checked-changed', handlerSpy);
+    el.checked = !el.checked;
+    expect(handlerSpy.called).to.be.false;
+  });
+
   describe('a11y', () => {
     it('should manage "aria-checked"', async () => {
       expect(el.hasAttribute('aria-checked')).to.be.true;


### PR DESCRIPTION
I have a use case where I need to set the initial value for the switch and the event should not be triggered. As the behavior to not trigger the event is bounded to the disabled attribute, I've used the same approach on the requestUpdate method.
Not sure if there is another better approach to set the initial checked value without triggering the event.

Cheers.
