### PR TITLE
Fix: calendar translation de.js strings corrected

### DIFF
--- a/.changeset/tiny-lamps-melt.md
+++ b/.changeset/tiny-lamps-melt.md
@@ -1,0 +1,5 @@
+---
+"@lion/calendar": patch
+---
+
+Fix: calendar translation de.js strings corrected

--- a/packages/calendar/translations/de.js
+++ b/packages/calendar/translations/de.js
@@ -1,6 +1,6 @@
 export default {
   nextMonth: 'Nächster Monat',
   previousMonth: 'Vorheriger Monat',
-  nextFullYear: 'Nächster Jahr',
-  previousFullYear: 'Vorheriger Jahr',
+  nextFullYear: 'Nächstes Jahr',
+  previousFullYear: 'Vorheriges Jahr',
 };


### PR DESCRIPTION
## What I did

1. Updated the translation strings for calendar. It should use the correct labelling of the year navigation buttons

Translation reference:
https://translate.google.de/?sl=en&tl=de&text=previous%20year%3B%0Anext%20year&op=translate
