### PR TITLE
chore(combobox): add clarifying test for autocomplete/check

### DIFF
--- a/packages/combobox/test/lion-combobox.test.js
+++ b/packages/combobox/test/lion-combobox.test.js
@@ -1230,6 +1230,70 @@ describe('lion-combobox', () => {
       expect(el2.checkedIndex).to.equal(-1);
     });
 
+    it('resets "checkedIndex" when going from matched to another matched textbox value', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo" autocomplete="both">
+            <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
+            <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
+            <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>
+            <lion-option .choiceValue="${'Victoria Plum'}">Victoria Plum</lion-option>
+          </lion-combobox>
+        `)
+      );
+
+      /** Goes from 2nd option Chard to 3rd option Chicory */
+      mimicUserTyping(el, 'ch');
+      await el.updateComplete;
+      expect(el.checkedIndex).to.equal(1);
+
+      mimicUserTyping(el, 'chi');
+      await el.updateComplete;
+      expect(el.checkedIndex).to.equal(2);
+
+      const el2 = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo" autocomplete="both">
+            <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
+            <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
+            <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>
+            <lion-option .choiceValue="${'Victoria Plum'}">Victoria Plum</lion-option>
+          </lion-combobox>
+        `)
+      );
+
+      mimicUserTyping(el2, 'ch');
+      await el2.updateComplete;
+      expect(el2.checkedIndex).to.equal(1);
+
+      // match-mode all ensures the user sees Artichoke option, but it's not
+      // auto-completed or auto-selected, because it doesn't start with "cho"
+      // See next test for more clarification
+      mimicUserTyping(el2, 'cho');
+      await el2.updateComplete;
+      expect(el2.checkedIndex).to.equal(-1);
+      expect(getFilteredOptionValues(el2)).to.eql(['Artichoke']);
+    });
+
+    it('sets "checkedIndex" only if the match, matches from the beginning of the word', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo" autocomplete="both">
+            <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
+            <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
+            <lion-option .choiceValue="${'Victoria Plum'}">Victoria Plum</lion-option>
+            <lion-option .choiceValue="${'Daikon'}">Daikon</lion-option>
+          </lion-combobox>
+        `)
+      );
+
+      // first match is Char'd', but better match is 'D'aikon
+      mimicUserTyping(el, 'd');
+      await el.updateComplete;
+      expect(el.checkedIndex).to.equal(3);
+      expect(getFilteredOptionValues(el)).to.eql(['Chard', 'Daikon']);
+    });
+
     it('completes chars inside textbox', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`


### PR DESCRIPTION
I was unsure why 
![image](https://user-images.githubusercontent.com/36734656/190850498-bb184186-4292-4be2-8962-8265a141245e.png)

Cabbage option isn't preselected and set to active state. I realized later it's because it goes hand in hand with autocomplete, and because the word isn't typed correct from the first letter, it's not autocompleted.

This makes more sense with the following example:
![image](https://user-images.githubusercontent.com/36734656/190850530-a448a188-695d-446a-b5fd-46d1010e6a05.png)

We type "d", first match is Chard, but Daikon is autocompleted and auto-selected because it's a better match, match from the first character.

I added some tests to clarify this behavior, as being intended.