### PR TITLE
chore: update dependency to fix "node16" module resolution

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
   "sideEffects": false,
   "dependencies": {
     "@open-wc/dedupe-mixin": "^1.3.0",
-    "@open-wc/scoped-elements": "^2.1.1",
+    "@open-wc/scoped-elements": "^2.1.3",
     "lit": "^2.0.2"
   },
   "keywords": [


### PR DESCRIPTION
Importing lion components when the module resolution of a project to "node16" (ESM) crashes node. 

Node can't find the exports of @open-wc/scoped-elements. The issue has been fixed in @open-wc/scoped-elements 2.0.2, see https://github.com/open-wc/open-wc/pull/2454

## What I did

1. Update the @open-wc/scoped-elements dependency in core to 2.0.3.
