### PR TITLE
fix(singleton-manager): keep "main" in package.json for older tools

### DIFF
--- a/.changeset/curly-tools-sin.md
+++ b/.changeset/curly-tools-sin.md
@@ -1,0 +1,5 @@
+---
+'singleton-manager': patch
+---
+
+Keep the `main` entry in package.json for now, as it is still used by some tools.

--- a/packages/singleton-manager/package.json
+++ b/packages/singleton-manager/package.json
@@ -18,6 +18,7 @@
     },
     "./docs/*": "./docs/*"
   },
+  "main": "./src/index.js",
   "files": [
     "dist-types",
     "docs",


### PR DESCRIPTION
## What I did

1.
