### PR TITLE
fix(overlay-manager): disable transition when reduced motion enabled

### DIFF
--- a/.changeset/five-dolls-begin.md
+++ b/.changeset/five-dolls-begin.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+adds support for reduced motion capabilities in overlay manager by disabling the opacity transition when a modal is opened/closed

--- a/packages/ui/components/overlays/src/globalOverlaysStyle.js
+++ b/packages/ui/components/overlays/src/globalOverlaysStyle.js
@@ -126,4 +126,14 @@ export const globalOverlaysStyle = css`
   html.global-overlays-scroll-lock-ios-fix {
     height: 100vh;
   }
+
+  @media screen and (prefers-reduced-motion: reduce) {
+    .global-overlays .global-overlays__backdrop--animation-in {
+      animation: global-overlays-backdrop-fade-in 1ms;
+    }
+
+    .global-overlays .global-overlays__backdrop--animation-out {
+      animation: global-overlays-backdrop-fade-out 1ms;
+    }
+  }
 `;


### PR DESCRIPTION
## What I did

1. Disables (actually reduces to 1ms) the 300ms opacity transition in the overlay manager when the customer has the reduced motion capability enabled on its browser.

The animation is not removed, but reduced to 1ms, so everything is working as expected, but the customer won't see the transition. Also, this helps the use of visual testing (screenshot testing) when opening an element from the overlay manager suite.