### PR TITLE
chore: fix LitElement imports in TS build output

### DIFF
--- a/.changeset/twenty-tomatoes-wash.md
+++ b/.changeset/twenty-tomatoes-wash.md
@@ -1,5 +1,5 @@
 ---
-'@lion/overlays': patch
+'@lion/ui': patch
 ---
 
-scroll issues on mac safari fixed when dialog are openend
+[overlays] scroll issues on mac safari fixed when dialog are openend

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-plugin-lit": "^1.6.1",
         "eslint-plugin-lit-a11y": "^2.2.0",
         "eslint-plugin-wc": "^1.3.2",
+        "globby": "^13.1.2",
         "husky": "^6.0.0",
         "lint-staged": "^10.0.0",
         "looks-same": "^7.2.3",
@@ -2561,6 +2562,54 @@
         "custom-elements-manifest": "index.js"
       }
     },
+<<<<<<< HEAD
+=======
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/command-line-args": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
+      "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
+      "dev": true,
+      "dependencies": {
+        "array-back": "^6.1.2",
+        "find-replace": "^3.0.0",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/globby": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+      "integrity": "sha1-LLr/d8Lypi5x6bKBOme5ejowAaU=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+>>>>>>> e266fffe (chore: fix LitElement imports in TS build output)
     "node_modules/@custom-elements-manifest/analyzer/node_modules/typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
@@ -3130,6 +3179,27 @@
       },
       "engines": {
         "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/@manypkg/get-packages/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@mdjs/core": {
@@ -5455,6 +5525,27 @@
         "node": ">= 0.6.0"
       }
     },
+    "node_modules/@web/test-runner-core/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@web/test-runner-core/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -5523,6 +5614,27 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@web/test-runner/node_modules/source-map": {
@@ -11395,7 +11507,8 @@
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -11431,20 +11544,33 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha1-KQRxBVgkJ6tuyk+QUgBmewVtpRU=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha1-JCI3IXbExsWt214q2oha+YSzlqc=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -23265,6 +23391,20 @@
         "ibantools": "^2.2.0",
         "lit": "^2.4.0",
         "singleton-manager": "^1.6.1"
+<<<<<<< HEAD
+=======
+      }
+    },
+    "packages/validate-messages": {
+      "name": "@lion/validate-messages",
+      "version": "0.10.1",
+      "extraneous": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lion/form-core": "^0.18.3",
+        "@lion/input-tel": "^0.2.3",
+        "@lion/localize": "^0.26.0"
+>>>>>>> e266fffe (chore: fix LitElement imports in TS build output)
       }
     }
   },
@@ -25105,6 +25245,41 @@
         "typescript": "~4.3.2"
       },
       "dependencies": {
+<<<<<<< HEAD
+=======
+        "array-back": {
+          "version": "6.2.2",
+          "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+          "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+          "dev": true
+        },
+        "command-line-args": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
+          "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
+          "dev": true,
+          "requires": {
+            "array-back": "^6.1.2",
+            "find-replace": "^3.0.0",
+            "lodash.camelcase": "^4.3.0",
+            "typical": "^4.0.0"
+          }
+        },
+        "globby": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha1-LLr/d8Lypi5x6bKBOme5ejowAaU=",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
+>>>>>>> e266fffe (chore: fix LitElement imports in TS build output)
         "typescript": {
           "version": "4.3.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
@@ -25620,6 +25795,20 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
             "universalify": "^0.1.0"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
           }
         }
       }
@@ -27586,6 +27775,20 @@
         "source-map": "^0.7.3"
       },
       "dependencies": {
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -27667,6 +27870,20 @@
           "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
           "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
           "dev": true
+        },
+        "globby": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+          "integrity": "sha1-vUvpi7BC+D15b344EZkfvoKg00s=",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
         },
         "source-map": {
           "version": "0.7.4",
@@ -32338,7 +32555,7 @@
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -32362,17 +32579,24 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.2.tgz",
+      "integrity": "sha1-KQRxBVgkJ6tuyk+QUgBmewVtpRU=",
       "dev": true,
       "requires": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "dependencies": {
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha1-JCI3IXbExsWt214q2oha+YSzlqc=",
+          "dev": true
+        }
       }
     },
     "gopd": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2562,32 +2562,6 @@
         "custom-elements-manifest": "index.js"
       }
     },
-<<<<<<< HEAD
-=======
-    "node_modules/@custom-elements-manifest/analyzer/node_modules/array-back": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
-    "node_modules/@custom-elements-manifest/analyzer/node_modules/command-line-args": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
-      "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^6.1.2",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/@custom-elements-manifest/analyzer/node_modules/globby": {
       "version": "11.0.4",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -2609,7 +2583,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
->>>>>>> e266fffe (chore: fix LitElement imports in TS build output)
     "node_modules/@custom-elements-manifest/analyzer/node_modules/typescript": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
@@ -11507,8 +11480,7 @@
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
-      "license": "ISC",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -23391,8 +23363,6 @@
         "ibantools": "^2.2.0",
         "lit": "^2.4.0",
         "singleton-manager": "^1.6.1"
-<<<<<<< HEAD
-=======
       }
     },
     "packages/validate-messages": {
@@ -23404,7 +23374,6 @@
         "@lion/form-core": "^0.18.3",
         "@lion/input-tel": "^0.2.3",
         "@lion/localize": "^0.26.0"
->>>>>>> e266fffe (chore: fix LitElement imports in TS build output)
       }
     }
   },
@@ -25245,26 +25214,6 @@
         "typescript": "~4.3.2"
       },
       "dependencies": {
-<<<<<<< HEAD
-=======
-        "array-back": {
-          "version": "6.2.2",
-          "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
-          "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
-          "dev": true
-        },
-        "command-line-args": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.1.2.tgz",
-          "integrity": "sha512-fytTsbndLbl+pPWtS0CxLV3BEWw9wJayB8NnU2cbQqVPsNdYezQeT+uIQv009m+GShnMNyuoBrRo8DTmuTfSCA==",
-          "dev": true,
-          "requires": {
-            "array-back": "^6.1.2",
-            "find-replace": "^3.0.0",
-            "lodash.camelcase": "^4.3.0",
-            "typical": "^4.0.0"
-          }
-        },
         "globby": {
           "version": "11.0.4",
           "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
@@ -25279,7 +25228,6 @@
             "slash": "^3.0.0"
           }
         },
->>>>>>> e266fffe (chore: fix LitElement imports in TS build output)
         "typescript": {
           "version": "4.3.5",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
@@ -32555,7 +32503,7 @@
     "glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha1-uN8PuAK7+o6JvR2Ti04WV47UTys=",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test:node": "npm run test:node --workspaces --if-present",
     "test:screenshots": "rimraf screenshots/.diff/ && rimraf screenshots/.current/ && mocha --require scripts/screenshots/bootstrap.js --exit --timeout 10000 \"packages/**/test/*.screenshots-test.js\"",
     "test:screenshots:update": "cross-env UPDATE_SCREENSHOTS=true npm run test:screenshots",
-    "types": "npm run types --workspaces --if-present && npm run types-correct-after-build",
+    "types": "npm run types --workspaces --if-present &&  npm run types-correct-after-build",
+    "types-check-only": "npm run types-check-only --workspaces --if-present",
     "types-correct-after-build": "node ./scripts/types-correct-after-build.mjs"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "test:node": "npm run test:node --workspaces --if-present",
     "test:screenshots": "rimraf screenshots/.diff/ && rimraf screenshots/.current/ && mocha --require scripts/screenshots/bootstrap.js --exit --timeout 10000 \"packages/**/test/*.screenshots-test.js\"",
     "test:screenshots:update": "cross-env UPDATE_SCREENSHOTS=true npm run test:screenshots",
-    "types": "npm run types --workspaces --if-present"
+    "types": "npm run types --workspaces --if-present && npm run types-correct-after-build",
+    "types-correct-after-build": "node ./scripts/types-correct-after-build.mjs"
   },
   "workspaces": [
     "packages/*",
@@ -78,6 +79,7 @@
     "eslint-plugin-lit": "^1.6.1",
     "eslint-plugin-lit-a11y": "^2.2.0",
     "eslint-plugin-wc": "^1.3.2",
+    "globby": "^13.1.2",
     "husky": "^6.0.0",
     "lint-staged": "^10.0.0",
     "looks-same": "^7.2.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,7 +41,8 @@
     "publish-docs": "node ../../packages-node/publish-docs/src/cli.js --github-url https://github.com/ing-bank/lion/ --git-root-dir ../../",
     "prepublishOnly": "npm run types && npm run publish-docs && npm run custom-elements-manifest",
     "test": "cd ../../ && npm run test:browser",
-    "types": "wireit"
+    "types": "wireit",
+    "types-check-only": "tsc --project tsconfig-check-only.json"
   },
   "dependencies": {
     "@bundled-es-modules/message-format": "^6.0.4",

--- a/packages/ui/tsconfig-check-only.json
+++ b/packages/ui/tsconfig-check-only.json
@@ -1,0 +1,8 @@
+{
+  "//": "this runs after 'scripts/types-correct-after-build.mjs' has been applied",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true
+  }
+}

--- a/scripts/types-correct-after-build.mjs
+++ b/scripts/types-correct-after-build.mjs
@@ -1,0 +1,33 @@
+/**
+ * TS build uses jsdoc and TS files with "import { LitElement } from 'lit'"
+ * - jsdoc compiles into "import { LitElement } from 'lit-element/lit-element.js'"
+ * - TS output remains unchanged
+ *
+ * These different imports (although they should both ultimately resolve to "{ LitElement } from 'lit-element/lit-element.js'")
+ * are incompatible (not considered the same class), which leads to errors for Subclassers.
+ *
+ * This script will make sure everything stays "import { LitElement } from 'lit'"
+ * See: https://github.com/microsoft/TypeScript/issues/51622
+ */
+
+import fs from 'fs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { globby } from 'globby';
+import { fileURLToPath } from 'url';
+
+const monorepoRootPath = fileURLToPath(new URL('../', import.meta.url));
+
+async function alignLitImports() {
+  const fileNames = await globby([`${monorepoRootPath}/packages/ui/dist-types`]);
+  for (const fileName of fileNames) {
+    // eslint-disable-next-line no-await-in-loop
+    const contents = await fs.promises.readFile(fileName, 'utf-8');
+    const replaced = contents.replace(
+      /(LitElement.*\}) from "lit-element\/lit-element\.js/g,
+      '$1 from "lit',
+    );
+    fs.promises.writeFile(fileName, replaced);
+  }
+}
+
+alignLitImports();


### PR DESCRIPTION

 TS build uses jsdoc and TS files with "import { LitElement } from 'lit'"
 - jsdoc compiles into "import { LitElement } from 'lit-element/lit-element.js'"
 - TS output remains unchanged
 
 These different imports (although they should both ultimately resolve to "{ LitElement } from 'lit-element/lit-element.js'")
 are incompatible (not considered the same class), which leads to errors for Subclassers.
 
 This script will make sure everything stays "import { LitElement } from 'lit'"
 See: https://github.com/microsoft/TypeScript/issues/51622
