### PR TITLE
overlays: make sure adopted stylesheets are not adopted twice and attached to body instead of document

### DIFF
--- a/.changeset/tall-spiders-tie.md
+++ b/.changeset/tall-spiders-tie.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+overlays: add adopted stylesheets once; attach correctly to body


### PR DESCRIPTION
overlays: make sure adopted stylesheets are not adopted twice and attached to body instead of document