### PR TITLE
Fix/accordion selectors

### DIFF
--- a/.changeset/strange-dots-draw.md
+++ b/.changeset/strange-dots-draw.md
@@ -2,4 +2,4 @@
 '@lion/ui': patch
 ---
 
-narrowed the scope of the selectors that query [slot=invoker] and [slot=content] to prevent that any nested elements with [slot=invoker] and [slot=content] are moved to slot=\_accordion as well
+`accordion`: narrowed the scope of the selectors that query [slot=invoker] and [slot=content] to prevent that any nested elements with [slot=invoker] and [slot=content] are moved to slot=\_accordion as well

--- a/.changeset/strange-dots-draw.md
+++ b/.changeset/strange-dots-draw.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+narrowed the scope of the selectors that query [slot=invoker] and [slot=content] to prevent that any nested elements with [slot=invoker] and [slot=content] are moved to slot=\_accordion as well

--- a/packages/ui/components/accordion/src/LionAccordion.js
+++ b/packages/ui/components/accordion/src/LionAccordion.js
@@ -210,10 +210,10 @@ export class LionAccordion extends LitElement {
    */
   __rearrangeInvokersAndContent() {
     const invokers = /** @type {HTMLElement[]} */ (
-      Array.from(this.querySelectorAll(':scope > [slot="invoker"]'))
+      Array.from(this.children).filter(child => child.slot === 'invoker')
     );
     const contents = /** @type {HTMLElement[]} */ (
-      Array.from(this.querySelectorAll(':scope > [slot="content"]'))
+      Array.from(this.children).filter(child => child.slot === 'content')
     );
     const accordion = this.shadowRoot?.querySelector('slot[name=_accordion]');
     if (accordion) {

--- a/packages/ui/components/accordion/src/LionAccordion.js
+++ b/packages/ui/components/accordion/src/LionAccordion.js
@@ -210,10 +210,10 @@ export class LionAccordion extends LitElement {
    */
   __rearrangeInvokersAndContent() {
     const invokers = /** @type {HTMLElement[]} */ (
-      Array.from(this.querySelectorAll('[slot="invoker"]'))
+      Array.from(this.querySelectorAll(':scope > [slot="invoker"]'))
     );
     const contents = /** @type {HTMLElement[]} */ (
-      Array.from(this.querySelectorAll('[slot="content"]'))
+      Array.from(this.querySelectorAll(':scope > [slot="content"]'))
     );
     const accordion = this.shadowRoot?.querySelector('slot[name=_accordion]');
     if (accordion) {


### PR DESCRIPTION
## What I did

1. narrowed the scope of the selectors that query [slot=invoker] and [slot=content] to prevent that any nested elements with [slot=invoker] and [slot=content] are moved to slot=_accordion as well
