### PR TITLE
fix(localize): don't set modelValue to unparseable if date has a negative timezone

### DIFF
--- a/.changeset/clever-parrots-sniff.md
+++ b/.changeset/clever-parrots-sniff.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+don't set unparseable for negative timezones

--- a/packages/ui/components/input-amount/test/formatters.test.js
+++ b/packages/ui/components/input-amount/test/formatters.test.js
@@ -1,10 +1,12 @@
 import { expect } from '@open-wc/testing';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 import { formatAmount } from '@lion/ui/input-amount.js';
 
 describe('formatAmount()', () => {
+  const localizeManager = getLocalizeManager();
+
   afterEach(() => {
     localizeTearDown();
   });
@@ -67,9 +69,9 @@ describe('formatAmount()', () => {
   });
 
   it('fallbacks to global locale and EUR by default', async () => {
-    localize.locale = 'en-GB';
+    localizeManager.locale = 'en-GB';
     expect(formatAmount(12345678)).to.equal('12,345,678.00');
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     expect(formatAmount(12345678)).to.equal('12.345.678,00');
   });
 });

--- a/packages/ui/components/localize/src/date/parseDate.js
+++ b/packages/ui/components/localize/src/date/parseDate.js
@@ -58,7 +58,7 @@ export function parseDate(dateString) {
   }
 
   const [year, month, day] = parsedString.split('/').map(Number);
-  const parsedDate = new Date(Date.UTC(year, month - 1, day));
+  const parsedDate = new Date(new Date(year, month - 1, day));
 
   // Check if parsedDate is not `Invalid Date` or that the date has changed (e.g. the not existing 31.02.2020)
   if (

--- a/packages/ui/components/localize/test/date/parseDate.test.js
+++ b/packages/ui/components/localize/test/date/parseDate.test.js
@@ -5,13 +5,13 @@ import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 /**
  *
  * @param {Date | undefined} value
- * @param {Date} date
+ * @param {Date | undefined} date
  */
 function equalsDate(value, date) {
   return (
     Object.prototype.toString.call(value) === '[object Date]' && // is Date Object
     value &&
-    value.getDate() === date.getDate() && // day
+    value.getDate() === date?.getDate() && // day
     value.getMonth() === date.getMonth() && // month
     value.getFullYear() === date.getFullYear() // year
   );
@@ -50,6 +50,20 @@ describe('parseDate()', () => {
     expect(equalsDate(parseDate('31-12-1976'), new Date('1976/12/31'))).to.equal(true);
     localizeManager.locale = 'en-US';
     expect(equalsDate(parseDate('12-31-1976'), new Date('1976/12/31'))).to.equal(true);
+  });
+
+  it('handles timezones of the browser and parsed date correctly', () => {
+    const referenceDate = new Date('2020/01/30');
+    localizeManager.locale = 'nl-NL';
+    const parsedDate = parseDate('30-01-2020');
+    // time zone offset of parsed date: this value is dependent on the browser (basically where the ci or local machine it runs in is located)
+    const parseDateOffset = parsedDate?.getTimezoneOffset();
+    // The parseDate time zone should be equal to the default offset of the browser
+    const browserTimeZoneOffset = referenceDate.getTimezoneOffset();
+    // This will pass, since parseDate respects browser timezone, and not UTC format
+    expect(parseDateOffset).to.equal(browserTimeZoneOffset);
+    // Optional: verify we are dealing with the same date (this is already tested in other tests?)
+    expect(equalsDate(referenceDate, parsedDate)).to.be.true;
   });
 
   it('return undefined when no valid date provided', () => {


### PR DESCRIPTION
## What I did

fix: https://github.com/ing-bank/lion/issues/1478

I tested the suggested solution inside the input-datepicker with MinMaxDate validator. But then a day before the min date was approved. With the switch to locale DateString the min date worked as expected.
Only i had a hard time to get a working test for this. I tried `.formatOptions="${{ timeZone: "America/New_York" }}"`, but this changed the modelValue date (and others) to the day before.
