### PR TITLE
docs: add reset and submit button imports

### DIFF
--- a/docs/components/button/use-cases.md
+++ b/docs/components/button/use-cases.md
@@ -3,6 +3,8 @@
 ```js script
 import { html } from '@mdjs/mdjs-preview';
 import '@lion/ui/define/lion-button.js';
+import '@lion/ui/define/lion-button-reset.js';
+import '@lion/ui/define/lion-button-submit.js';
 ```
 
 ## With click handler


### PR DESCRIPTION
## What I did
- add lion-button-reset and lion-button-submit imports fixing the usage with native form demo
buttons were not imported and therefore didn't work accordingly

fixes #1874 
