### PR TITLE
fix(icon): non-fatal console error for missing icons

### DIFF
--- a/.changeset/cuddly-hats-beg.md
+++ b/.changeset/cuddly-hats-beg.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Unresolved icons to not cause a fatal error, but console.error instead. Missing assets shouldn't prevent the rest of the application from rendering.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22630,7 +22630,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.0.4",

--- a/packages/ui/components/icon/src/LionIcon.js
+++ b/packages/ui/components/icon/src/LionIcon.js
@@ -194,11 +194,17 @@ export class LionIcon extends LitElement {
       }
     } else {
       const iconIdBeforeResolve = this.iconId;
-      const svg = await this._iconManager.resolveIconForId(iconIdBeforeResolve);
 
-      // update SVG if it did not change in the meantime to avoid race conditions
-      if (this.iconId === iconIdBeforeResolve) {
-        this.svg = svg;
+      // Wrap in try-catch so error is non-fatal.
+      // Failure to load an icon (asset) should not crash the entire app.
+      try {
+        const svg = await this._iconManager.resolveIconForId(iconIdBeforeResolve);
+        // update SVG if it did not change in the meantime to avoid race conditions
+        if (this.iconId === iconIdBeforeResolve) {
+          this.svg = svg;
+        }
+      } catch (e) {
+        console.error(e);
       }
     }
   }

--- a/packages/ui/components/icon/src/LionIcon.js
+++ b/packages/ui/components/icon/src/LionIcon.js
@@ -204,6 +204,7 @@ export class LionIcon extends LitElement {
           this.svg = svg;
         }
       } catch (e) {
+        // eslint-disable-next-line no-console
         console.error(e);
       }
     }


### PR DESCRIPTION
## What I did

1. Wrap icon manager resolve icon in try-catch to catch fatal error, then console.error it (non-fatal)


## Rationale

In short, missing assets like images, svgs, etc. should not cause fatal errors and cause your entire program (app) to break. 
With lion, icon assets are JS files (SVG-in-JS if you will), so we should take this extra precaution in my opinion.

Another argument can be that apps might choose to create a robots.txt file where they exclude icon files. This is necessary so that crawlers (like Googlebot for Google SEO), do not hit their [crawl request limits](https://support.google.com/webmasters/thread/173793044?hl=en&msgid=173822151) due to many icons. Icons, in the end, are not necessary to render the app for indexing it. When not bundling, e.g. loading Lion (or a Lion extension) from a CDN, this also becomes important as you get many requests due to not doing any bundling.