### PR TITLE
Update namespace type for localize mixin

### DIFF
--- a/.changeset/forty-hornets-speak.md
+++ b/.changeset/forty-hornets-speak.md
@@ -1,0 +1,5 @@
+---
+"@lion/ui": patch
+---
+
+Updated the return type of `localizeNamespaces()` of the localize mixin to allow `NamespaceObject[]`

--- a/packages/ui/components/localize/src/LocalizeMixin.js
+++ b/packages/ui/components/localize/src/LocalizeMixin.js
@@ -6,6 +6,7 @@ import { localize } from './singleton.js';
 /**
  * @typedef {import('lit/directive.js').DirectiveResult} DirectiveResult
  * @typedef {import('../types/LocalizeMixinTypes.js').LocalizeMixin} LocalizeMixin
+ * @typedef {import('../types/LocalizeMixinTypes.js').NamespaceObject} NamespaceObject
  */
 
 /**
@@ -17,7 +18,7 @@ const LocalizeMixinImplementation = superclass =>
   // @ts-ignore https://github.com/microsoft/TypeScript/issues/36821#issuecomment-588375051
   class LocalizeMixin extends superclass {
     /**
-     * @returns {Object.<string,function>[]}
+     * @returns {NamespaceObject[]}
      */
     static get localizeNamespaces() {
       return [];
@@ -106,11 +107,11 @@ const LocalizeMixinImplementation = superclass =>
     }
 
     /**
-     * @returns {string[]}
+     * @returns {NamespaceObject[]}
      * @private
      */
     __getUniqueNamespaces() {
-      /** @type {string[]} */
+      /** @type {NamespaceObject[]} */
       const uniqueNamespaces = [];
 
       // IE11 does not support iterable in the constructor


### PR DESCRIPTION
## What I did

1. The type of `get localizeNamespaces()` was not matching the correct type. According to the [documentation](https://github.com/ing-bank/lion/blob/master/docs/fundamentals/systems/localize/use-cases.md?plain=1#L211) and subsequent [functions](https://github.com/ing-bank/lion/blob/master/packages/ui/components/localize/src/LocalizeManager.js#L223) is  `NamespaceObject[]` the correct type

## Potential issues

- `NamespaceObject` may not to be exported correctly from this package
