### PR TITLE
Feat/localize no side effects in repo

### DIFF
--- a/.changeset/four-wolves-do.md
+++ b/.changeset/four-wolves-do.md
@@ -1,0 +1,61 @@
+---
+'@lion/ui': minor
+---
+
+Side-effect-free alternative for `localize` (the globally shared instance of LocalizeManager).
+When this function is imported, no side-effect happened yet, i.e. no global instance was registered yet.
+The side effect-free approach generates:
+
+- smaller, optimized bundles
+- a predictable loading order, that allows for:
+  - deduping strategies when multiple instances of the localizeManager are on a page
+  - providing a customized extension of LocalizeManager
+
+Also see: https://github.com/ing-bank/lion/discussions/1861
+
+Use it like this:
+
+```js
+function myFunction() {
+  // note that 'localizeManager' is the same as former 'localize'
+  const localizeManager = getLocalizeManger();
+  // ...
+}
+```
+
+In a class, we advise a shared instance:
+
+```js
+class MyClass {
+  constructor() {
+    this._localizeManager = getLocalizeManger();
+  }
+  // ...
+}
+```
+
+Make sure to always call this method inside a function or class (otherwise side effects are created)
+
+Do you want to register your own LocalizeManager?
+Make sure it's registered before anyone called `getLocalizeManager()`
+
+```js
+import { singletonManager } from 'singleton-manager';
+import { getLocalizeManger } from '@lion/ui/localize-no-side-effects.js';
+
+// First register your own LocalizeManager (for deduping or other reasons)
+singletonManager.set('lion/ui::localize::0.x', class MyLocalizeManager extends LocalizeManager {});
+
+// Now, all your code gets the right instance
+export function myFn() {
+  const localizeManager = getLocalizeManager();
+  // ...
+}
+
+export class myClass() {
+  constructor() {
+    this._localizeManager = getLocalizeManager();
+    // ...
+  }
+}
+```

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -3,10 +3,9 @@ import { html, LitElement } from 'lit';
 import {
   getMonthNames,
   getWeekdayNames,
-  localize,
   LocalizeMixin,
   normalizeDateTime,
-} from '@lion/ui/localize.js';
+} from '@lion/ui/localize-no-side-effects.js';
 
 import { calendarStyle } from './calendarStyle.js';
 import { createDay } from './utils/createDay.js';
@@ -862,6 +861,6 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
    * @private
    */
   __getLocale() {
-    return this.locale || localize.locale;
+    return this.locale || this._localizeManager.locale;
   }
 }

--- a/packages/ui/components/calendar/test/lion-calendar.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar.test.js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 import { expect, fixture as _fixture } from '@open-wc/testing';
 import sinon from 'sinon';
@@ -15,6 +15,8 @@ import { CalendarObject, DayObject } from '@lion/ui/calendar-test-helpers.js';
 const fixture = /** @type {(arg: TemplateResult) => Promise<LionCalendar>} */ (_fixture);
 
 describe('<lion-calendar>', () => {
+  const localizeManager = getLocalizeManager();
+
   beforeEach(() => {
     localizeTearDown();
   });
@@ -1348,7 +1350,7 @@ describe('<lion-calendar>', () => {
       await el.updateComplete;
       expect(elObj.activeMonth).to.equal('décembre');
 
-      localize.locale = 'cs-CZ';
+      localizeManager.locale = 'cs-CZ';
       await el.updateComplete;
       expect(elObj.activeMonth).to.equal('décembre');
 
@@ -1391,7 +1393,7 @@ describe('<lion-calendar>', () => {
         'Sat',
       ]);
 
-      localize.locale = 'nl-NL';
+      localizeManager.locale = 'nl-NL';
       await el.localizeNamespacesLoaded;
       await el.updateComplete;
       expect(elObj.nextMonthButtonEl?.getAttribute('aria-label')).to.equal(

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -3,7 +3,7 @@ import { SlotMixin, DisabledMixin } from '@lion/ui/core.js';
 import { ScopedElementsMixin } from '@open-wc/scoped-elements';
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
 // TODO: make form-core independent from localize
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { AsyncQueue } from '../utils/AsyncQueue.js';
 import { pascalCase } from '../utils/pascalCase.js';
 import { SyncUpdatableMixin } from '../utils/SyncUpdatableMixin.js';
@@ -262,12 +262,16 @@ export const ValidateMixinImplementation = superclass =>
 
     connectedCallback() {
       super.connectedCallback();
-      localize.addEventListener('localeChanged', this._updateFeedbackComponent);
+
+      const localizeManager = getLocalizeManager();
+      localizeManager.addEventListener('localeChanged', this._updateFeedbackComponent);
     }
 
     disconnectedCallback() {
       super.disconnectedCallback();
-      localize.removeEventListener('localeChanged', this._updateFeedbackComponent);
+
+      const localizeManager = getLocalizeManager();
+      localizeManager.removeEventListener('localeChanged', this._updateFeedbackComponent);
     }
 
     /**

--- a/packages/ui/components/form-core/src/validate/validators/DateValidators.js
+++ b/packages/ui/components/form-core/src/validate/validators/DateValidators.js
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 // TODO: move to input-datepicker?
-import { normalizeDateTime } from '@lion/ui/localize.js';
+import { normalizeDateTime } from '@lion/ui/localize-no-side-effects.js';
 import { Validator } from '../Validator.js';
 
 /**

--- a/packages/ui/components/form-core/test-suites/FormatMixin.suite.js
+++ b/packages/ui/components/form-core/test-suites/FormatMixin.suite.js
@@ -1,5 +1,5 @@
 import { LitElement } from 'lit';
-import { parseDate } from '@lion/ui/localize.js';
+import { parseDate } from '@lion/ui/localize-no-side-effects.js';
 import { aTimeout, defineCE, expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
 import { Unparseable, Validator, FormatMixin } from '@lion/ui/form-core.js';

--- a/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -1,5 +1,5 @@
 import { LitElement } from 'lit';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 import { defineCE, expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import { getFormControlMembers, AlwaysInvalid } from '@lion/ui/form-core-test-helpers.js';
@@ -18,6 +18,8 @@ import {
  */
 
 export function runValidateMixinFeedbackPart() {
+  const localizeManager = getLocalizeManager();
+
   describe('Validity Feedback', () => {
     beforeEach(() => {
       localizeTearDown();
@@ -65,7 +67,7 @@ export function runValidateMixinFeedbackPart() {
 
     AlwaysInvalid.getMessage = async () => 'Message for AlwaysInvalid';
     MinLength.getMessage = async () =>
-      localize.locale === 'de-DE' ? 'Nachricht für MinLength' : 'Message for MinLength';
+      localizeManager.locale === 'de-DE' ? 'Nachricht für MinLength' : 'Message for MinLength';
     ContainsLowercaseA.getMessage = async () => 'Message for ContainsLowercaseA';
     ContainsCat.getMessage = async () => 'Message for ContainsCat';
 
@@ -341,8 +343,8 @@ export function runValidateMixinFeedbackPart() {
       expect(_feedbackNode.feedbackData?.length).to.equal(1);
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Message for MinLength');
 
-      localize.locale = 'de-DE';
-      await localize.loadingComplete;
+      localizeManager.locale = 'de-DE';
+      await localizeManager.loadingComplete;
       await el.feedbackComplete;
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Nachricht für MinLength');
     });

--- a/packages/ui/components/form-core/test/lion-field.test.js
+++ b/packages/ui/components/form-core/test/lion-field.test.js
@@ -2,7 +2,7 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { Required, Validator } from '@lion/ui/form-core.js';
 import '@lion/ui/define/lion-field.js';
 import { getFormControlMembers } from '@lion/ui/form-core-test-helpers.js';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 import {
   expect,
@@ -52,6 +52,8 @@ function getSlot(el, slot) {
 }
 
 describe('<lion-field>', () => {
+  const localizeManager = getLocalizeManager();
+
   it(`puts a unique id "${tagString}-[hash]" on the native input`, async () => {
     const el = /** @type {LionField} */ (await fixture(html`<${tag}>${inputSlot}</${tag}>`));
     // @ts-ignore allow protected accessors in tests
@@ -219,7 +221,7 @@ describe('<lion-field>', () => {
     beforeEach(() => {
       // Reset and preload validation translations
       localizeTearDown();
-      localize.addData('en-GB', 'lion-validate', {
+      localizeManager.addData('en-GB', 'lion-validate', {
         error: {
           hasX: 'This is error message for hasX',
         },

--- a/packages/ui/components/form-core/test/validate/DateValidators.test.js
+++ b/packages/ui/components/form-core/test/validate/DateValidators.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@open-wc/testing';
 
-import { normalizeDateTime } from '@lion/ui/localize.js';
+import { normalizeDateTime } from '@lion/ui/localize-no-side-effects.js';
 import { IsDate, MinDate, MaxDate, MinMaxDate, IsDateDisabled } from '@lion/ui/form-core.js';
 
 describe('Date Validation', () => {

--- a/packages/ui/components/form-integrations/test/form-validation-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/form-validation-integrations.test.js
@@ -1,12 +1,13 @@
 import { DefaultSuccess, Required, Validator } from '@lion/ui/form-core.js';
 import { getFormControlMembers } from '@lion/ui/form-core-test-helpers.js';
 import { LionInput } from '@lion/ui/input.js';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { loadDefaultFeedbackMessages } from '@lion/ui/validate-messages.js';
 import { defineCE, expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import sinon from 'sinon';
 
 describe('Form Validation Integrations', () => {
+  const localizeManager = getLocalizeManager();
   const lightDom = '';
   before(() => {
     loadDefaultFeedbackMessages();
@@ -126,11 +127,11 @@ describe('Form Validation Integrations', () => {
         }
 
         async updateLabel() {
-          this.label = localize.msg('test-default-label:label');
+          this.label = localizeManager.msg('test-default-label:label');
         }
 
         async setDefaultLabel() {
-          localize.loadNamespace({
+          localizeManager.loadNamespace({
             'test-default-label': /** @param {string} locale */ async locale => {
               switch (locale) {
                 case 'nl-NL':
@@ -143,11 +144,11 @@ describe('Form Validation Integrations', () => {
           this.boundUpdateLabel = this.updateLabel.bind(this);
 
           // localeChanged is fired AFTER localize has finished loading missing translations
-          // so no need to await localize.loadingComplete
-          localize.addEventListener('localeChanged', this.boundUpdateLabel);
+          // so no need to await localizeManager.loadingComplete
+          localizeManager.addEventListener('localeChanged', this.boundUpdateLabel);
 
           // Wait for it to complete when updating the label for the first time
-          await localize.loadingComplete;
+          await localizeManager.loadingComplete;
           this.boundUpdateLabel();
         }
       }
@@ -167,15 +168,15 @@ describe('Form Validation Integrations', () => {
       const { _feedbackNode } = getFormControlMembers(el);
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Please enter a(n) Text.');
 
-      localize.locale = 'nl-NL';
-      await localize.loadingComplete;
+      localizeManager.locale = 'nl-NL';
+      await localizeManager.loadingComplete;
       await el.updateComplete;
       await el.feedbackComplete;
       expect(el.label).to.equal('Tekst');
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Vul een Tekst in.');
 
-      localize.locale = 'en-GB';
-      await localize.loadingComplete;
+      localizeManager.locale = 'en-GB';
+      await localizeManager.loadingComplete;
       await el.updateComplete;
       await el.feedbackComplete;
       expect(el.label).to.equal('Text');

--- a/packages/ui/components/input-amount/src/LionInputAmount.js
+++ b/packages/ui/components/input-amount/src/LionInputAmount.js
@@ -1,6 +1,6 @@
 import { css } from 'lit';
 import { LionInput } from '@lion/ui/input.js';
-import { getCurrencyName, localize, LocalizeMixin } from '@lion/ui/localize.js';
+import { getCurrencyName, LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { IsNumber } from '@lion/ui/form-core.js';
 import { formatAmount, formatCurrencyLabel } from './formatters.js';
 import { parseAmount } from './parsers.js';
@@ -201,7 +201,7 @@ export class LionInputAmount extends LocalizeMixin(LionInput) {
   }
 
   get __currencyLabel() {
-    return this.currency ? formatCurrencyLabel(this.currency, localize.locale) : '';
+    return this.currency ? formatCurrencyLabel(this.currency, this._localizeManager.locale) : '';
   }
 
   __reformat() {

--- a/packages/ui/components/input-amount/src/formatters.js
+++ b/packages/ui/components/input-amount/src/formatters.js
@@ -1,4 +1,8 @@
-import { formatNumber, getFractionDigits, normalizeCurrencyLabel } from '@lion/ui/localize.js';
+import {
+  formatNumber,
+  getFractionDigits,
+  normalizeCurrencyLabel,
+} from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @typedef {import('../../localize/types/LocalizeMixinTypes.js').FormatNumberOptions} FormatOptions

--- a/packages/ui/components/input-amount/src/parsers.js
+++ b/packages/ui/components/input-amount/src/parsers.js
@@ -1,4 +1,4 @@
-import { parseNumber, getFractionDigits } from '@lion/ui/localize.js';
+import { parseNumber, getFractionDigits } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @typedef {import('../../localize/types/LocalizeMixinTypes.js').FormatNumberOptions} FormatOptions

--- a/packages/ui/components/input-date/src/LionInputDate.js
+++ b/packages/ui/components/input-date/src/LionInputDate.js
@@ -1,6 +1,6 @@
 import { IsDate } from '@lion/ui/form-core.js';
 import { LionInput } from '@lion/ui/input.js';
-import { formatDate, LocalizeMixin, parseDate } from '@lion/ui/localize.js';
+import { formatDate, LocalizeMixin, parseDate } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @param {Date|number} date

--- a/packages/ui/components/input-date/test/lion-input-date.test.js
+++ b/packages/ui/components/input-date/test/lion-input-date.test.js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 import { MaxDate } from '@lion/ui/form-core.js';
 import { expect, fixture as _fixture } from '@open-wc/testing';
@@ -13,6 +13,8 @@ import '@lion/ui/define/lion-input-date.js';
 const fixture = /** @type {(arg: TemplateResult) => Promise<LionInputDate>} */ (_fixture);
 
 describe('<lion-input-date>', () => {
+  const localizeManager = getLocalizeManager();
+
   beforeEach(() => {
     localizeTearDown();
   });
@@ -84,13 +86,13 @@ describe('<lion-input-date>', () => {
   });
 
   it('uses global locale when formatOptions.locale is not defined', async () => {
-    localize.locale = 'fr-FR';
+    localizeManager.locale = 'fr-FR';
     const el = await fixture(html`
       <lion-input-date .modelValue=${new Date('2017/06/15')}></lion-input-date>
     `);
     expect(el.formattedValue).to.equal('15/06/2017');
 
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     const el2 = await fixture(html`
       <lion-input-date .modelValue=${new Date('2017/06/15')}></lion-input-date>
     `);
@@ -105,7 +107,7 @@ describe('<lion-input-date>', () => {
       ></lion-input-date>
     `);
     expect(el.formattedValue).to.equal('15/06/2017'); // british
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     await el.updateComplete;
     expect(el.formattedValue).to.equal('15/06/2017'); // should stay british
   });

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -10,7 +10,7 @@ import {
   withModalDialogConfig,
   ArrowMixin,
 } from '@lion/ui/overlays.js';
-import { LocalizeMixin } from '@lion/ui/localize.js';
+import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { localizeNamespaceLoader } from './localizeNamespaceLoader.js';
 
 /**

--- a/packages/ui/components/input-email/src/LionInputEmail.js
+++ b/packages/ui/components/input-email/src/LionInputEmail.js
@@ -1,6 +1,6 @@
 import { IsEmail } from '@lion/ui/form-core.js';
 import { LionInput } from '@lion/ui/input.js';
-import { LocalizeMixin } from '@lion/ui/localize.js';
+import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * LionInputEmail: extension of lion-input

--- a/packages/ui/components/input-iban/src/LionInputIban.js
+++ b/packages/ui/components/input-iban/src/LionInputIban.js
@@ -1,4 +1,4 @@
-import { LocalizeMixin } from '@lion/ui/localize.js';
+import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { LionInput } from '@lion/ui/input.js';
 import { formatIBAN } from './formatters.js';
 import { parseIBAN } from './parsers.js';

--- a/packages/ui/components/input-iban/src/validators.js
+++ b/packages/ui/components/input-iban/src/validators.js
@@ -1,15 +1,16 @@
 /* eslint-disable max-classes-per-file, import/no-extraneous-dependencies */
 
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { Unparseable, Validator } from '@lion/ui/form-core.js';
 import { isValidIBAN } from 'ibantools';
 
 let loaded = false;
 const loadTranslations = async () => {
+  const localizeManager = getLocalizeManager();
   if (loaded) {
     return;
   }
-  await localize.loadNamespace(
+  await localizeManager.loadNamespace(
     {
       'lion-validate+iban': /** @param {string} locale */ locale => {
         switch (locale) {
@@ -86,7 +87,7 @@ const loadTranslations = async () => {
         }
       },
     },
-    { locale: localize.locale },
+    { locale: localizeManager.locale },
   );
   loaded = true;
 };
@@ -113,8 +114,9 @@ export class IsIBAN extends Validator {
    * @returns {Promise<string|Element>}
    */
   static async getMessage(data) {
+    const localizeManager = getLocalizeManager();
     await loadTranslations();
-    return localize.msg('lion-validate+iban:error.IsIBAN', data);
+    return localizeManager.msg('lion-validate+iban:error.IsIBAN', data);
   }
 }
 
@@ -156,11 +158,13 @@ export class IsCountryIBAN extends IsIBAN {
    * @returns {Promise<string|Element>}
    */
   static async getMessage(data) {
+    const localizeManager = getLocalizeManager();
+
     await loadTranslations();
     // If modelValue is Unparseable, the IsIBAN message is the more appropriate feedback
     return data?.modelValue instanceof Unparseable
-      ? localize.msg('lion-validate+iban:error.IsIBAN', data)
-      : localize.msg('lion-validate+iban:error.IsCountryIBAN', data);
+      ? localizeManager.msg('lion-validate+iban:error.IsIBAN', data)
+      : localizeManager.msg('lion-validate+iban:error.IsCountryIBAN', data);
   }
 }
 
@@ -203,6 +207,8 @@ export class IsNotCountryIBAN extends IsIBAN {
    * @returns {Promise<string|Element>}
    */
   static async getMessage(data) {
+    const localizeManager = getLocalizeManager();
+
     await loadTranslations();
     const _data = {
       ...data,
@@ -211,7 +217,7 @@ export class IsNotCountryIBAN extends IsIBAN {
     };
     // If modelValue is Unparseable, the IsIBAN message is the more appropriate feedback
     return data?.modelValue instanceof Unparseable
-      ? localize.msg('lion-validate+iban:error.IsIBAN', _data)
-      : localize.msg('lion-validate+iban:error.IsNotCountryIBAN', _data);
+      ? localizeManager.msg('lion-validate+iban:error.IsIBAN', _data)
+      : localizeManager.msg('lion-validate+iban:error.IsNotCountryIBAN', _data);
   }
 }

--- a/packages/ui/components/input-range/src/LionInputRange.js
+++ b/packages/ui/components/input-range/src/LionInputRange.js
@@ -2,7 +2,7 @@
 import { css, html } from 'lit';
 import { ScopedStylesController } from '@lion/ui/core.js';
 import { LionInput } from '@lion/ui/input.js';
-import { formatNumber } from '@lion/ui/localize.js';
+import { formatNumber } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @typedef {import('lit').CSSResult} CSSResult

--- a/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -2,7 +2,7 @@ import { html, css } from 'lit';
 import { ref, createRef } from 'lit/directives/ref.js';
 
 import { LionInputTel } from '@lion/ui/input-tel.js';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { getFlagSymbol } from './getFlagSymbol.js';
 
 /**
@@ -80,6 +80,7 @@ export class LionInputTelDropdown extends LionInputTel {
    * @type {TemplateDataForDropdownInputTel}
    */
   get _templateDataDropdown() {
+    const localizeManager = getLocalizeManager();
     const refs = {
       dropdown: {
         ref: this.refs.dropdown,
@@ -91,10 +92,12 @@ export class LionInputTelDropdown extends LionInputTel {
           'model-value-changed': this._onDropdownValueChange,
         },
         labels: {
-          selectCountry: localize.msg('lion-input-tel:selectCountry'),
-          allCountries: this._allCountriesLabel || localize.msg('lion-input-tel:allCountries'),
+          selectCountry: localizeManager.msg('lion-input-tel:selectCountry'),
+          allCountries:
+            this._allCountriesLabel || localizeManager.msg('lion-input-tel:allCountries'),
           preferredCountries:
-            this._preferredCountriesLabel || localize.msg('lion-input-tel:suggestedCountries'),
+            this._preferredCountriesLabel ||
+            localizeManager.msg('lion-input-tel:suggestedCountries'),
         },
       },
     };

--- a/packages/ui/components/input-tel/src/LionInputTel.js
+++ b/packages/ui/components/input-tel/src/LionInputTel.js
@@ -1,5 +1,5 @@
 import { Unparseable } from '@lion/ui/form-core.js';
-import { LocalizeMixin, localize } from '@lion/ui/localize.js';
+import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { LionInput } from '@lion/ui/input.js';
 
 import { PhoneUtilManager } from './PhoneUtilManager.js';
@@ -125,7 +125,7 @@ export class LionInputTel extends LocalizeMixin(LionInput) {
   // @ts-expect-error
   // eslint-disable-next-line class-methods-use-this
   get fieldName() {
-    return localize.msg('lion-input-tel:phoneNumber');
+    return this._localizeManager.msg('lion-input-tel:phoneNumber');
   }
 
   /**
@@ -227,7 +227,7 @@ export class LionInputTel extends LocalizeMixin(LionInput) {
   onLocaleUpdated() {
     super.onLocaleUpdated();
 
-    const localeSplitted = localize.locale.split('-');
+    const localeSplitted = this._localizeManager.locale.split('-');
     /**
      * @protected
      * @type {RegionCode}

--- a/packages/ui/components/input-tel/test-suites/LionInputTel.suite.js
+++ b/packages/ui/components/input-tel/test-suites/LionInputTel.suite.js
@@ -9,7 +9,7 @@ import {
 } from '@open-wc/testing';
 import sinon from 'sinon';
 import { mimicUserInput } from '@lion/ui/form-core-test-helpers.js';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { Unparseable } from '@lion/ui/form-core.js';
 import { LionInputTel, PhoneNumber, PhoneUtilManager } from '@lion/ui/input-tel.js';
 import { mockPhoneUtilManager, restorePhoneUtilManager } from '@lion/ui/input-tel-test-helpers.js';
@@ -23,7 +23,8 @@ const fixture = /** @type {(arg: string | TemplateResult) => Promise<LionInputTe
 const fixtureSync = /** @type {(arg: string | TemplateResult) => LionInputTel} */ (_fixtureSync);
 
 const getRegionCodeBasedOnLocale = () => {
-  const localeSplitted = localize.locale.split('-');
+  const localizeManager = getLocalizeManager();
+  const localeSplitted = localizeManager.locale.split('-');
   return /** @type {RegionCode} */ (localeSplitted[localeSplitted.length - 1]).toUpperCase();
 };
 

--- a/packages/ui/components/localize/src/date/formatDate.js
+++ b/packages/ui/components/localize/src/date/formatDate.js
@@ -1,5 +1,5 @@
 import { getLocale } from '../utils/getLocale.js';
-import { localize } from '../singleton.js';
+import { getLocalizeManager } from '../getLocalizeManager.js';
 import { normalizeIntlDate } from './utils/normalizeIntlDate.js';
 
 /** @typedef {import('../../types/LocalizeMixinTypes.js').DatePostProcessor} DatePostProcessor */
@@ -12,6 +12,7 @@ import { normalizeIntlDate } from './utils/normalizeIntlDate.js';
  * @returns {string}
  */
 export function formatDate(date, options) {
+  const localizeManager = getLocalizeManager();
   if (!(date instanceof Date)) {
     return '';
   }
@@ -36,8 +37,8 @@ export function formatDate(date, options) {
     formattedDate = '';
   }
 
-  if (localize.formatDateOptions.postProcessors.size > 0) {
-    Array.from(localize.formatDateOptions.postProcessors).forEach(([locale, fn]) => {
+  if (localizeManager.formatDateOptions.postProcessors.size > 0) {
+    Array.from(localizeManager.formatDateOptions.postProcessors).forEach(([locale, fn]) => {
       if (locale === computedLocale) {
         formattedDate = fn(formattedDate);
       }

--- a/packages/ui/components/localize/src/date/parseDate.js
+++ b/packages/ui/components/localize/src/date/parseDate.js
@@ -1,5 +1,5 @@
 import { getDateFormatBasedOnLocale } from './getDateFormatBasedOnLocale.js';
-import { localize } from '../singleton.js';
+import { getLocalizeManager } from '../getLocalizeManager.js';
 import { addLeadingZero } from './utils/addLeadingZero.js';
 
 /**
@@ -29,10 +29,12 @@ const memoizedGetDateFormatBasedOnLocale = memoize(getDateFormatBasedOnLocale);
  * @returns {Date | undefined}
  */
 export function parseDate(dateString) {
+  const localizeManager = getLocalizeManager();
+
   const stringToParse = addLeadingZero(dateString);
   let parsedString;
 
-  switch (memoizedGetDateFormatBasedOnLocale(localize.locale)) {
+  switch (memoizedGetDateFormatBasedOnLocale(localizeManager.locale)) {
     case 'day-month-year':
       parsedString = `${stringToParse.slice(6, 10)}/${stringToParse.slice(
         3,

--- a/packages/ui/components/localize/src/getLocalizeManager.js
+++ b/packages/ui/components/localize/src/getLocalizeManager.js
@@ -16,7 +16,7 @@ import { LocalizeManager } from './LocalizeManager.js';
  * ```js
  * function myFunction() {
  *   // note that 'localizeManager' is the same as former 'localize'
- *   const localize = getLocalizeManger();
+ *   const localizeManager = getLocalizeManger();
  *   // ...
  * }
  * ```

--- a/packages/ui/components/localize/src/getLocalizeManager.js
+++ b/packages/ui/components/localize/src/getLocalizeManager.js
@@ -1,0 +1,74 @@
+// @ts-ignore
+import { singletonManager } from 'singleton-manager';
+import { LocalizeManager } from './LocalizeManager.js';
+
+/**
+ * Side-effect-free alternative for `localize` (the globally shared instance of LocalizeManager).
+ * When this function is imported, no side-effect happened yet, i.e. no global instance was registered yet.
+ * The side effect-free approach generates:
+ * - smaller, optimized bundles
+ * - a predictable loading order, that allows for:
+ *   - deduping strategies when multiple instances of the localizeManager are on a page
+ *   - providing a customized extension of LocalizeManager
+ *
+ * Use it like this:
+ *
+ * ```js
+ * function myFunction() {
+ *   // note that 'localizeManager' is the same as former 'localize'
+ *   const localize = getLocalizeManger();
+ *   // ...
+ * }
+ * ```
+ *
+ * In a class, we advise a shared instance:
+ * ```js
+ * class MyClass {
+ *   constructor() {
+ *     this._localizeManager = getLocalizeManger();
+ *   }
+ *   // ...
+ * }
+ * ```
+ *
+ * Make sure to always call this method inside a function or class (otherwise side effects are created)
+ *
+ * Do you want to register your own LocalizeManager?
+ * Make sure it's registered before anyone called `getLocalizeManager()`
+ *
+ * ```js
+ * import { singletonManager } from 'singleton-manager';
+ * import { getLocalizeManger } from '@lion/ui/localize-no-side-effects.js';
+ *
+ * // First register your own LocalizeManager (for deduping or other reasons)
+ * singletonManager.set('lion/ui::localize::0.x', class MyLocalizeManager extends LocalizeManager {});
+ *
+ * // Now, all your code gets the right instance
+ * function myFuntion() {
+ *   const localizeManager = getLocalizeManager();
+ *   // ...
+ * }
+ *
+ * class myClass() {
+ *   constructor() {
+ *     this._localizeManager = getLocalizeManager();
+ *     // ...
+ *   }
+ * }
+ * ```
+ *
+ * @returns {LocalizeManager}
+ */
+export function getLocalizeManager() {
+  if (singletonManager.has('@lion/ui::localize::0.x')) {
+    return singletonManager.get('@lion/ui::localize::0.x');
+  }
+
+  const localizeManager = new LocalizeManager({
+    autoLoadOnLocaleChange: true,
+    fallbackLocale: 'en-GB',
+  });
+  singletonManager.set('@lion/ui::localize::0.x', localizeManager);
+
+  return localizeManager;
+}

--- a/packages/ui/components/localize/src/number/formatNumber.js
+++ b/packages/ui/components/localize/src/number/formatNumber.js
@@ -1,6 +1,6 @@
 /** @typedef {import('../../types/LocalizeMixinTypes.js').NumberPostProcessor} NumberPostProcessor */
 
-import { localize } from '../singleton.js';
+import { getLocalizeManager } from '../getLocalizeManager.js';
 import { getLocale } from '../utils/getLocale.js';
 import { formatNumberToParts } from './formatNumberToParts.js';
 
@@ -14,12 +14,13 @@ import { formatNumberToParts } from './formatNumberToParts.js';
  * @returns {string}
  */
 export function formatNumber(number, options = /** @type {FormatOptions} */ ({})) {
+  const localizeManager = getLocalizeManager();
   if (number === undefined || number === null) return '';
   const formattedToParts = formatNumberToParts(number, options);
   // If number is not a number
   if (
     formattedToParts === options.returnIfNaN ||
-    formattedToParts === localize.formatNumberOptions.returnIfNaN
+    formattedToParts === localizeManager.formatNumberOptions.returnIfNaN
   ) {
     return /** @type {string} */ (formattedToParts);
   }
@@ -33,8 +34,8 @@ export function formatNumber(number, options = /** @type {FormatOptions} */ ({})
 
   const computedLocale = getLocale(options && options.locale);
 
-  if (localize.formatNumberOptions.postProcessors.size > 0) {
-    Array.from(localize.formatNumberOptions.postProcessors).forEach(([locale, fn]) => {
+  if (localizeManager.formatNumberOptions.postProcessors.size > 0) {
+    Array.from(localizeManager.formatNumberOptions.postProcessors).forEach(([locale, fn]) => {
       if (locale === computedLocale) {
         printNumberOfParts = fn(printNumberOfParts);
       }

--- a/packages/ui/components/localize/src/number/getCurrencyName.js
+++ b/packages/ui/components/localize/src/number/getCurrencyName.js
@@ -1,4 +1,4 @@
-import { localize } from '../singleton.js';
+import { getLocalizeManager } from '../getLocalizeManager.js';
 import { formatNumberToParts } from './formatNumberToParts.js';
 import { forceCurrencyNameForPHPEnGB } from './utils/normalize-get-currency-name/forceCurrencyNameForPHPEnGB.js';
 
@@ -11,6 +11,7 @@ import { forceCurrencyNameForPHPEnGB } from './utils/normalize-get-currency-name
  * @returns {string} currency name like 'US dollar'
  */
 export function getCurrencyName(currencyIso, options) {
+  const localizeManager = getLocalizeManager();
   const parts = /** @type {FormatNumberPart[]} */ (
     formatNumberToParts(1, {
       ...options,
@@ -23,7 +24,7 @@ export function getCurrencyName(currencyIso, options) {
     .filter(p => p.type === 'currency')
     .map(o => o.value)
     .join(' ');
-  const locale = options?.locale || localize.locale;
+  const locale = options?.locale || localizeManager.locale;
   if (currencyIso === 'PHP' && locale === 'en-GB') {
     currencyName = forceCurrencyNameForPHPEnGB(currencyName);
   }

--- a/packages/ui/components/localize/src/number/utils/emptyStringWhenNumberNan.js
+++ b/packages/ui/components/localize/src/number/utils/emptyStringWhenNumberNan.js
@@ -1,4 +1,4 @@
-import { localize } from '../../singleton.js';
+import { getLocalizeManager } from '../../getLocalizeManager.js';
 
 /**
  * When number is NaN we should return an empty string or returnIfNaN param
@@ -7,5 +7,6 @@ import { localize } from '../../singleton.js';
  * @returns {string}
  */
 export function emptyStringWhenNumberNan(returnIfNaN) {
-  return returnIfNaN || localize.formatNumberOptions.returnIfNaN;
+  const localizeManager = getLocalizeManager();
+  return returnIfNaN || localizeManager.formatNumberOptions.returnIfNaN;
 }

--- a/packages/ui/components/localize/src/singleton.js
+++ b/packages/ui/components/localize/src/singleton.js
@@ -1,11 +1,8 @@
-import { singletonManager } from 'singleton-manager';
-import { LocalizeManager } from './LocalizeManager.js';
+import { getLocalizeManager } from './getLocalizeManager.js';
 
-/** @type {LocalizeManager} */
+/**
+ * Use the side-effect-free `const localizeManager = getLocalizeManager()` instead.
+ * @deprecated
+ */
 // eslint-disable-next-line import/no-mutable-exports
-export const localize =
-  /** @type {LocalizeManager} */ (singletonManager.get('@lion/ui::localize::0.x')) ||
-  new LocalizeManager({
-    autoLoadOnLocaleChange: true,
-    fallbackLocale: 'en-GB',
-  });
+export const localize = getLocalizeManager();

--- a/packages/ui/components/localize/src/utils/getLocale.js
+++ b/packages/ui/components/localize/src/utils/getLocale.js
@@ -1,4 +1,4 @@
-import { localize } from '../singleton.js';
+import { getLocalizeManager } from '../getLocalizeManager.js';
 
 /**
  * Gets the locale to use
@@ -7,11 +7,6 @@ import { localize } from '../singleton.js';
  * @returns {string}
  */
 export function getLocale(locale) {
-  if (locale) {
-    return locale;
-  }
-  if (localize && localize.locale) {
-    return localize.locale;
-  }
-  return 'en-GB';
+  const localizeManager = getLocalizeManager();
+  return locale || localizeManager?.locale || 'en-GB';
 }

--- a/packages/ui/components/localize/test-helpers/localizeTearDown.js
+++ b/packages/ui/components/localize/test-helpers/localizeTearDown.js
@@ -1,11 +1,12 @@
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 
 export const localizeTearDown = () => {
+  const localizeManager = getLocalizeManager();
   // makes sure that between tests the localization is reset to default state
   // @ts-ignore
-  localize._teardownHtmlLangAttributeObserver();
+  localizeManager._teardownHtmlLangAttributeObserver();
   document.documentElement.lang = 'en-GB';
   // @ts-ignore
-  localize._setupHtmlLangAttributeObserver();
-  localize.reset();
+  localizeManager._setupHtmlLangAttributeObserver();
+  localizeManager.reset();
 };

--- a/packages/ui/components/localize/test/LocalizeManager.test.js
+++ b/packages/ui/components/localize/test/LocalizeManager.test.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { fetchMock } from '@bundled-es-modules/fetch-mock';
 import { setupFakeImport, resetFakeImport, fakeImport } from '@lion/ui/localize-test-helpers.js';
 
-import { LocalizeManager } from '@lion/ui/localize.js';
+import { LocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @param {LocalizeManager} localizeManagerEl

--- a/packages/ui/components/localize/test/date/formatDate.test.js
+++ b/packages/ui/components/localize/test/date/formatDate.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { localize, formatDate, parseDate } from '@lion/ui/localize.js';
+import { getLocalizeManager, formatDate, parseDate } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 const SUPPORTED_LOCALES = {
@@ -41,6 +41,7 @@ const SUPPORTED_LOCALES = {
  */
 
 describe('formatDate', () => {
+  const localizeManager = getLocalizeManager();
   beforeEach(() => {
     localizeTearDown();
   });
@@ -50,16 +51,16 @@ describe('formatDate', () => {
 
     expect(formatDate(testDate)).to.equal('21/05/2012');
 
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     expect(formatDate(testDate)).to.equal('21-05-2012');
 
-    localize.locale = 'fr-FR';
+    localizeManager.locale = 'fr-FR';
     expect(formatDate(testDate)).to.equal('21/05/2012');
 
-    localize.locale = 'de-DE';
+    localizeManager.locale = 'de-DE';
     expect(formatDate(testDate)).to.equal('21.05.2012');
 
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     expect(formatDate(testDate)).to.equal('05/21/2012');
   });
 
@@ -74,13 +75,13 @@ describe('formatDate', () => {
     };
 
     expect(formatDate(testDate, options)).to.equal('Monday, 21 May 2012');
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     expect(formatDate(testDate, options)).to.equal('maandag 21 mei 2012');
-    localize.locale = 'fr-FR';
+    localizeManager.locale = 'fr-FR';
     expect(formatDate(testDate, options)).to.equal('lundi 21 mai 2012');
-    localize.locale = 'de-DE';
+    localizeManager.locale = 'de-DE';
     expect(formatDate(testDate, options)).to.equal('Montag, 21. Mai 2012');
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     expect(formatDate(testDate, options)).to.equal('Monday, May 21, 2012');
   });
 
@@ -93,7 +94,7 @@ describe('formatDate', () => {
       day: '2-digit',
       locale: 'en-US',
     };
-    localize.locale = 'hu-HU';
+    localizeManager.locale = 'hu-HU';
     let date = /** @type {Date} */ (parseDate('2018-5-28'));
     expect(formatDate(date)).to.equal('2018. 05. 28.');
 
@@ -110,7 +111,7 @@ describe('formatDate', () => {
       day: '2-digit',
       locale: 'en-US',
     };
-    localize.locale = 'bg-BG';
+    localizeManager.locale = 'bg-BG';
     let date = /** @type {Date} */ (parseDate('29-12-2017'));
     expect(formatDate(date)).to.equal('29.12.2017 г.');
 
@@ -130,7 +131,7 @@ describe('formatDate', () => {
       day: '2-digit',
       locale: 'en-US',
     };
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     let date = /** @type {Date} */ (parseDate('12-29-1940'));
     expect(formatDate(date)).to.equal('12/29/1940');
 
@@ -276,11 +277,11 @@ describe('formatDate', () => {
 
       // locale is en-GB
       expect(formatDate(testDate, options)).to.equal('Monday, 21 May 2012');
-      localize.locale = 'nl-NL';
+      localizeManager.locale = 'nl-NL';
       expect(formatDate(testDate, options)).to.equal('MAANDAG 21 MEI 2012');
-      localize.locale = 'de-DE';
+      localizeManager.locale = 'de-DE';
       expect(formatDate(testDate, options)).to.equal('montag, 21. mai 2012');
-      localize.locale = 'en-US';
+      localizeManager.locale = 'en-US';
       expect(formatDate(testDate, options)).to.equal('Monday, May 21, 2012');
     });
 
@@ -293,21 +294,21 @@ describe('formatDate', () => {
         month: 'long',
         day: '2-digit',
       };
-      localize.setDatePostProcessorForLocale({
+      localizeManager.setDatePostProcessorForLocale({
         locale: 'nl-NL',
         postProcessor: upperCaseProcessor,
       });
-      localize.setDatePostProcessorForLocale({
+      localizeManager.setDatePostProcessorForLocale({
         locale: 'de-DE',
         postProcessor: upperCaseProcessor,
       });
 
       expect(formatDate(testDate, options)).to.equal('Monday, 21 May 2012');
-      localize.locale = 'nl-NL';
+      localizeManager.locale = 'nl-NL';
       expect(formatDate(testDate, options)).to.equal('MAANDAG 21 MEI 2012');
-      localize.locale = 'de-DE';
+      localizeManager.locale = 'de-DE';
       expect(formatDate(testDate, options)).to.equal('MONTAG, 21. MAI 2012');
-      localize.locale = 'en-US';
+      localizeManager.locale = 'en-US';
       expect(formatDate(testDate, options)).to.equal('Monday, May 21, 2012');
     });
 
@@ -326,17 +327,17 @@ describe('formatDate', () => {
         postProcessors,
       };
 
-      localize.setDatePostProcessorForLocale({
+      localizeManager.setDatePostProcessorForLocale({
         locale: 'de-DE',
         postProcessor: lowerCaseProcessor,
       });
 
       expect(formatDate(testDate, options)).to.equal('Monday, 21 May 2012');
-      localize.locale = 'nl-NL';
+      localizeManager.locale = 'nl-NL';
       expect(formatDate(testDate, options)).to.equal('MAANDAG 21 MEI 2012');
-      localize.locale = 'de-DE';
+      localizeManager.locale = 'de-DE';
       expect(formatDate(testDate, options)).to.equal('MONTAG, 21. MAI 2012');
-      localize.locale = 'en-US';
+      localizeManager.locale = 'en-US';
       expect(formatDate(testDate, options)).to.equal('Monday, May 21, 2012');
     });
   });

--- a/packages/ui/components/localize/test/date/getDateFormatBasedOnLocale.test.js
+++ b/packages/ui/components/localize/test/date/getDateFormatBasedOnLocale.test.js
@@ -1,16 +1,21 @@
 import { expect } from '@open-wc/testing';
-import { localize, getDateFormatBasedOnLocale } from '@lion/ui/localize.js';
+import {
+  getLocalizeManager,
+  getDateFormatBasedOnLocale,
+} from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 describe('getDateFormatBasedOnLocale()', () => {
+  const localizeManager = getLocalizeManager();
+
   beforeEach(() => {
     localizeTearDown();
   });
 
   it('returns the positions of day, month and year', async () => {
-    localize.locale = 'en-GB';
+    localizeManager.locale = 'en-GB';
     expect(getDateFormatBasedOnLocale()).to.equal('day-month-year');
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     expect(getDateFormatBasedOnLocale()).to.equal('month-day-year');
   });
 });

--- a/packages/ui/components/localize/test/date/parseDate.test.js
+++ b/packages/ui/components/localize/test/date/parseDate.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { parseDate, localize } from '@lion/ui/localize.js';
+import { parseDate, getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 /**
@@ -18,6 +18,7 @@ function equalsDate(value, date) {
 }
 
 describe('parseDate()', () => {
+  const localizeManager = getLocalizeManager();
   beforeEach(() => {
     localizeTearDown();
   });
@@ -45,9 +46,9 @@ describe('parseDate()', () => {
   });
 
   it('handles different locales', () => {
-    localize.locale = 'en-GB';
+    localizeManager.locale = 'en-GB';
     expect(equalsDate(parseDate('31-12-1976'), new Date('1976/12/31'))).to.equal(true);
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     expect(equalsDate(parseDate('12-31-1976'), new Date('1976/12/31'))).to.equal(true);
   });
 
@@ -55,11 +56,11 @@ describe('parseDate()', () => {
     expect(parseDate('12.12.1976.,')).to.equal(undefined); // wrong delimiter
     expect(parseDate('foo')).to.equal(undefined); // no date
 
-    localize.locale = 'en-GB';
+    localizeManager.locale = 'en-GB';
     expect(parseDate('31.02.2020')).to.equal(undefined); // non existing date
     expect(parseDate('12.31.2020')).to.equal(undefined); // day & month switched places
 
-    localize.locale = 'en-US';
+    localizeManager.locale = 'en-US';
     expect(parseDate('02.31.2020')).to.equal(undefined); // non existing date
     expect(parseDate('31.12.2020')).to.equal(undefined); // day & month switched places
   });

--- a/packages/ui/components/localize/test/getLocalizeManager.test.js
+++ b/packages/ui/components/localize/test/getLocalizeManager.test.js
@@ -1,0 +1,30 @@
+import { expect } from '@open-wc/testing';
+// @ts-ignore
+import { singletonManager } from 'singleton-manager';
+import { LocalizeManager } from '../src/LocalizeManager.js';
+import { getLocalizeManager } from '../src/getLocalizeManager.js';
+
+describe('getLocalizeManager', () => {
+  beforeEach(() => {
+    singletonManager._map.clear();
+  });
+
+  it('gets a default instance when nothing registered on singletonManager with "@lion/ui::localize::0.x"', () => {
+    expect(singletonManager.get('@lion/ui::localize::0.x')).to.be.undefined;
+    const localizeManager = getLocalizeManager();
+    expect(localizeManager).to.equal(singletonManager.get('@lion/ui::localize::0.x'));
+  });
+
+  it('gets the same instance when called multiple times', () => {
+    const localizeManager = getLocalizeManager();
+    const localizeManagerSecondCall = getLocalizeManager();
+    expect(localizeManager).to.equal(localizeManagerSecondCall);
+  });
+
+  it('gets the instance that was registered on singletonManager with "@lion/ui::localize::0.x"', () => {
+    // Set your own for custom behavior or for deduping purposes
+    class MyLocalizeManager extends LocalizeManager {}
+    singletonManager.set('@lion/ui::localize::0.x', MyLocalizeManager);
+    expect(getLocalizeManager()).to.equal(MyLocalizeManager);
+  });
+});

--- a/packages/ui/components/localize/test/getLocalizeManager.test.js
+++ b/packages/ui/components/localize/test/getLocalizeManager.test.js
@@ -6,6 +6,7 @@ import { getLocalizeManager } from '../src/getLocalizeManager.js';
 
 describe('getLocalizeManager', () => {
   beforeEach(() => {
+    // @ts-ignore
     singletonManager._map.clear();
   });
 

--- a/packages/ui/components/localize/test/localize.test.js
+++ b/packages/ui/components/localize/test/localize.test.js
@@ -1,6 +1,6 @@
 import { expect } from '@open-wc/testing';
 
-import { localize, LocalizeManager } from '@lion/ui/localize.js';
+import { getLocalizeManager, LocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @param {LocalizeManager} localizeManagerEl
@@ -16,6 +16,7 @@ function getProtectedMembers(localizeManagerEl) {
 }
 
 describe('localize', () => {
+  const localizeManager = getLocalizeManager();
   // this is an important mindset:
   // we don't test the singleton
   // we check that it is an instance of the right class
@@ -23,16 +24,16 @@ describe('localize', () => {
   // this allows to avoid any side effects caused by changing singleton state between tests
 
   it('is an instance of LocalizeManager', () => {
-    expect(localize).to.be.an.instanceOf(LocalizeManager);
+    expect(localizeManager).to.be.an.instanceOf(LocalizeManager);
   });
 
   it('is configured to automatically load namespaces if locale is changed', () => {
-    const { autoLoadOnLocaleChange } = getProtectedMembers(localize);
+    const { autoLoadOnLocaleChange } = getProtectedMembers(localizeManager);
     expect(autoLoadOnLocaleChange).to.equal(true);
   });
 
   it('is configured to fallback to the locale "en-GB"', () => {
-    const { fallbackLocale } = getProtectedMembers(localize);
+    const { fallbackLocale } = getProtectedMembers(localizeManager);
     expect(fallbackLocale).to.equal('en-GB');
   });
 });

--- a/packages/ui/components/localize/test/number/formatNumber.test.js
+++ b/packages/ui/components/localize/test/number/formatNumber.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { localize, formatNumber } from '@lion/ui/localize.js';
+import { getLocalizeManager, formatNumber } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 // TODO: This is broken only in Safari 13.1.2 Wait till ci is on 13.1.3 and remove
@@ -20,6 +20,8 @@ const currencySymbol = /** @param {string} currency */ currency => ({
 });
 
 describe('formatNumber', () => {
+  const localizeManager = getLocalizeManager();
+
   afterEach(localizeTearDown);
 
   it('displays the appropriate amount of decimal places based on currencies spec http://www.currency-iso.org/en/home/tables/table-a1.html', () => {
@@ -74,14 +76,14 @@ describe('formatNumber', () => {
     expect(formatNumber(undefined)).to.equal('');
   });
 
-  it('uses `localize.formatNumberOptions.returnIfNaN`', () => {
-    const savedReturnIfNaN = localize.formatNumberOptions.returnIfNaN;
+  it('uses `localizeManager.formatNumberOptions.returnIfNaN`', () => {
+    const savedReturnIfNaN = localizeManager.formatNumberOptions.returnIfNaN;
 
-    localize.formatNumberOptions.returnIfNaN = '-';
+    localizeManager.formatNumberOptions.returnIfNaN = '-';
     // @ts-ignore
     expect(formatNumber('foo')).to.equal('-');
 
-    localize.formatNumberOptions.returnIfNaN = savedReturnIfNaN;
+    localizeManager.formatNumberOptions.returnIfNaN = savedReturnIfNaN;
   });
 
   it("can set what to returns when NaN via `returnIfNaN: 'foo'`", () => {
@@ -89,11 +91,11 @@ describe('formatNumber', () => {
     expect(formatNumber('foo', { returnIfNaN: '-' })).to.equal('-');
   });
 
-  it('uses `localize.locale`', () => {
+  it('uses `localizeManager.locale`', () => {
     expect(formatNumber(123456.789, { style: 'decimal', maximumFractionDigits: 2 })).to.equal(
       '123,456.79',
     );
-    localize.locale = 'de-DE';
+    localizeManager.locale = 'de-DE';
     expect(formatNumber(123456.789, { style: 'decimal', maximumFractionDigits: 2 })).to.equal(
       '123.456,79',
     );
@@ -136,7 +138,7 @@ describe('formatNumber', () => {
   });
 
   it('formats numbers correctly', () => {
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     expect(formatNumber(0, { style: 'decimal', minimumFractionDigits: 2 })).to.equal('0,00');
     expect(formatNumber(0.1, { style: 'decimal', minimumFractionDigits: 2 })).to.equal('0,10');
     expect(formatNumber(0.12, { style: 'decimal', minimumFractionDigits: 2 })).to.equal('0,12');
@@ -190,7 +192,7 @@ describe('formatNumber', () => {
   });
 
   it('throws when decimal and group separator are the same value, only when problematic', () => {
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     const fn = () =>
       formatNumber(112345678, {
         style: 'decimal',
@@ -239,7 +241,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
   });
 
   it('formats 2-digit decimals correctly', () => {
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     Array.from(new Array(100), (val, index) => index).forEach(i => {
       const iString = `${i}`;
       let number = 0.0;
@@ -253,7 +255,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
   describe('normalization', () => {
     describe('en-GB', () => {
       it('supports basics', () => {
-        localize.locale = 'en-GB';
+        localizeManager.locale = 'en-GB';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123,456.79');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123,456.79');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123,457');
@@ -265,7 +267,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
 
     describe('en-US', () => {
       it('supports basics', () => {
-        localize.locale = 'en-US';
+        localizeManager.locale = 'en-US';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123,456.79');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123,456.79');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123,457');
@@ -282,7 +284,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       }
 
       it('supports basics', () => {
-        localize.locale = 'en-AU';
+        localizeManager.locale = 'en-AU';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123,456.79');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123,456.79');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123,457');
@@ -294,7 +296,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
 
     describe('en-PH', () => {
       it('supports basics', () => {
-        localize.locale = 'en-PH';
+        localizeManager.locale = 'en-PH';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('EUR 123,456.79');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('USD 123,456.79');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('JPY 123,457');
@@ -306,7 +308,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
 
     describe('nl-NL', () => {
       it('supports basics', () => {
-        localize.locale = 'nl-NL';
+        localizeManager.locale = 'nl-NL';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123.456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123.456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123.457 JPY');
@@ -323,7 +325,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       }
 
       it('supports basics', () => {
-        localize.locale = 'nl-BE';
+        localizeManager.locale = 'nl-BE';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123.456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123.456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123.457 JPY');
@@ -335,7 +337,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
 
     describe('fr-FR', () => {
       it('supports basics', () => {
-        localize.locale = 'fr-FR';
+        localizeManager.locale = 'fr-FR';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123 456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123 456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123 457 JPY');
@@ -351,7 +353,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
         if (isSafari) {
           return;
         }
-        localize.locale = 'fr-BE';
+        localizeManager.locale = 'fr-BE';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123 456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123 456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123 457 JPY');
@@ -363,7 +365,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
 
     describe('bg-BG', () => {
       it('supports basics', () => {
-        localize.locale = 'bg-BG';
+        localizeManager.locale = 'bg-BG';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123 456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123 456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123 457 JPY');
@@ -373,7 +375,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       });
 
       it('normalizes group separator', () => {
-        localize.locale = 'bg-BG';
+        localizeManager.locale = 'bg-BG';
         expect(formatNumber(1.234, currencyCode('EUR'))).to.equal('1,23 EUR');
         expect(formatNumber(1234.567, currencyCode('EUR'))).to.equal('1 234,57 EUR');
         expect(formatNumber(-1234.567, currencyCode('EUR'))).to.equal('−1 234,57 EUR');
@@ -382,7 +384,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
 
     describe('cs-CZ', () => {
       it('supports basics', () => {
-        localize.locale = 'cs-CZ';
+        localizeManager.locale = 'cs-CZ';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123 456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123 456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123 457 JPY');
@@ -401,7 +403,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       }
 
       it('supports basics', () => {
-        localize.locale = 'tr-TR';
+        localizeManager.locale = 'tr-TR';
         expect(formatNumber(123456.789, currencyCode('EUR'))).to.equal('123.456,79 EUR');
         expect(formatNumber(123456.789, currencyCode('USD'))).to.equal('123.456,79 USD');
         expect(formatNumber(123456.789, currencyCode('JPY'))).to.equal('123.457 JPY');
@@ -413,7 +415,7 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       });
 
       it('forces turkish currency code ', () => {
-        localize.locale = 'tr-TR';
+        localizeManager.locale = 'tr-TR';
         expect(
           formatNumber(1234.56, { style: 'currency', currencyDisplay: 'code', currency: 'TRY' }),
         ).to.equal('1.234,56 TL');
@@ -428,10 +430,10 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
     /** @type {Map<string, import('../../types/LocalizeMixinTypes.js').NumberPostProcessor>} */
     let savedpostProcessors;
     beforeEach(() => {
-      savedpostProcessors = localize.formatNumberOptions.postProcessors;
+      savedpostProcessors = localizeManager.formatNumberOptions.postProcessors;
     });
     afterEach(() => {
-      localize.formatNumberOptions.postProcessors = savedpostProcessors;
+      localizeManager.formatNumberOptions.postProcessors = savedpostProcessors;
     });
 
     /**
@@ -460,8 +462,8 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       ).to.equal('112 345 678');
     });
 
-    it('uses `localize.formatNumberOptions.postProcessors`', () => {
-      localize.setNumberPostProcessorForLocale({
+    it('uses `localizeManager.formatNumberOptions.postProcessors`', () => {
+      localizeManager.setNumberPostProcessorForLocale({
         locale: 'en-GB',
         postProcessor: commaToSpaceProcessor,
       });
@@ -469,11 +471,11 @@ Please specify .groupSeparator / .decimalSeparator on the formatOptions object t
       expect(formatNumber(112345678)).to.equal('112 345 678');
     });
 
-    it('uses `options.postProcessors` and `localize.formatNumberOptions.postProcessors`', () => {
+    it('uses `options.postProcessors` and `localizeManager.formatNumberOptions.postProcessors`', () => {
       const postProcessors = new Map();
       postProcessors.set('en-GB', commaToSpaceProcessor);
 
-      localize.setNumberPostProcessorForLocale({
+      localizeManager.setNumberPostProcessorForLocale({
         locale: 'en-GB',
         postProcessor: firstSpaceToDotProcessor,
       });

--- a/packages/ui/components/localize/test/number/formatNumberToParts.test.js
+++ b/packages/ui/components/localize/test/number/formatNumberToParts.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { localize, formatNumberToParts } from '@lion/ui/localize.js';
+import { getLocalizeManager, formatNumberToParts } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 // TODO: This is broken only in Safari 13.1.2 Wait till ci is on 13.1.3 and remove
@@ -28,6 +28,8 @@ const stringifyParts =
   parts => parts.map(part => part.value).join('');
 
 describe('formatNumberToParts', () => {
+  const localizeManager = getLocalizeManager();
+
   afterEach(localizeTearDown);
 
   describe("style: 'currency symbol'", () => {
@@ -114,7 +116,7 @@ describe('formatNumberToParts', () => {
         it(`formats ${locale} ${amount} as "${stringifyParts(
           /** @type {FormatNumberPart[]} */ (expectedResult),
         )}"`, () => {
-          localize.locale = locale;
+          localizeManager.locale = locale;
           expect(
             formatNumberToParts(Number(amount), {
               style: 'decimal',
@@ -143,7 +145,7 @@ describe('formatNumberToParts', () => {
         it(`formats ${locale} ${amount} as "${stringifyParts(
           /** @type {FormatNumberPart[]} */ (expectedResult),
         )}"`, () => {
-          localize.locale = locale;
+          localizeManager.locale = locale;
           expect(
             formatNumberToParts(Number(amount), {
               style: 'decimal',

--- a/packages/ui/components/localize/test/number/getCurrencyName.test.js
+++ b/packages/ui/components/localize/test/number/getCurrencyName.test.js
@@ -1,5 +1,5 @@
 import { expect } from '@open-wc/testing';
-import { getCurrencyName } from '@lion/ui/localize.js';
+import { getCurrencyName } from '@lion/ui/localize-no-side-effects.js';
 import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
 
 describe('getCurrencyName', () => {

--- a/packages/ui/components/localize/test/number/parseNumber.test.js
+++ b/packages/ui/components/localize/test/number/parseNumber.test.js
@@ -1,7 +1,9 @@
 import { expect } from '@open-wc/testing';
-import { localize, parseNumber } from '@lion/ui/localize.js';
+import { getLocalizeManager, parseNumber } from '@lion/ui/localize-no-side-effects.js';
 
 describe('parseNumber()', () => {
+  const localizeManager = getLocalizeManager();
+
   it('parses integers', () => {
     expect(parseNumber('1')).to.equal(1);
     expect(parseNumber('12')).to.equal(12);
@@ -79,13 +81,13 @@ describe('parseNumber()', () => {
   });
 
   it('uses locale to parse amount if there is only one separator e.g. 1.234', () => {
-    localize.locale = 'en-GB';
+    localizeManager.locale = 'en-GB';
     expect(parseNumber('12.34')).to.equal(12.34);
     expect(parseNumber('12,34')).to.equal(1234);
     expect(parseNumber('1.234')).to.equal(1.234);
     expect(parseNumber('1,234')).to.equal(1234);
 
-    localize.locale = 'nl-NL';
+    localizeManager.locale = 'nl-NL';
     expect(parseNumber('12.34')).to.equal(1234);
     expect(parseNumber('12,34')).to.equal(12.34);
     expect(parseNumber('1.234')).to.equal(1234);

--- a/packages/ui/components/localize/test/side-effect-free-entrypoint.test.js
+++ b/packages/ui/components/localize/test/side-effect-free-entrypoint.test.js
@@ -1,0 +1,38 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+// @ts-ignore
+import { singletonManager } from 'singleton-manager';
+
+/**
+ * @typedef {import('../types/LocalizeMixinTypes.js').LocalizeMixin} LocalizeMixinHost
+ */
+
+describe('Entrypoints localize', () => {
+  /** @type {import('sinon').SinonSpy} */
+  let singletonManagerSetSpy;
+  beforeEach(() => {
+    singletonManagerSetSpy = sinon.spy(singletonManager, 'set');
+  });
+  afterEach(() => {
+    singletonManagerSetSpy.restore();
+  });
+
+  it('"@lion/ui/localize-no-side-effects.js" has no side effects (c.q. does not register itself on singletonManager)', async () => {
+    await import('@lion/ui/localize-no-side-effects.js');
+
+    expect(singletonManagerSetSpy).to.not.have.been.called;
+  });
+
+  it('"@lion/ui/localize.js" has side effects (c.q. registers itself on singletonManager)', async () => {
+    await import('@lion/ui/localize.js');
+
+    expect(singletonManagerSetSpy).to.have.been.calledOnce;
+
+    const { getLocalizeManager } = await import('@lion/ui/localize-no-side-effects.js');
+
+    expect(singletonManagerSetSpy).to.have.been.calledWith(
+      '@lion/ui::localize::0.x',
+      getLocalizeManager(),
+    );
+  });
+});

--- a/packages/ui/components/localize/types/LocalizeMixinTypes.ts
+++ b/packages/ui/components/localize/types/LocalizeMixinTypes.ts
@@ -1,6 +1,7 @@
 import { Constructor } from '@open-wc/dedupe-mixin';
 import { LitElement } from 'lit';
 import { DirectiveResult } from 'lit/directive.js';
+import { LocalizeManager } from '../src/LocalizeManager.js';
 
 export interface FormatNumberPart {
   type: string;
@@ -76,7 +77,13 @@ export declare class LocalizeMixinHost {
   public onLocaleUpdated(): void;
   public connectedCallback(): void;
   public disconnectedCallback(): void;
-  public msgLit(keys: string | string[], variables?: msgVariables, options?: msgOptions): string | DirectiveResult;
+  public msgLit(
+    keys: string | string[],
+    variables?: msgVariables,
+    options?: msgOptions,
+  ): string | DirectiveResult;
+
+  protected _localizeManager: LocalizeManager;
 
   private __boundLocalizeOnLocaleChanged(...args: Object[]): void;
   private __boundLocalizeOnLocaleChanging(...args: Object[]): void;

--- a/packages/ui/components/pagination/src/LionPagination.js
+++ b/packages/ui/components/pagination/src/LionPagination.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { LitElement, html, css } from 'lit';
-import { LocalizeMixin } from '@lion/ui/localize.js';
+import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @typedef {import('lit').TemplateResult} TemplateResult

--- a/packages/ui/components/progress-indicator/src/LionProgressIndicator.js
+++ b/packages/ui/components/progress-indicator/src/LionProgressIndicator.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import { LitElement, nothing } from 'lit';
-import { localize, LocalizeMixin } from '@lion/ui/localize.js';
+import { getLocalizeManager, LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 
 /**
  * @typedef {import('lit').TemplateResult} TemplateResult
@@ -195,10 +195,11 @@ export class LionProgressIndicator extends LocalizeMixin(LitElement) {
   }
 
   _setDefaultLabel() {
+    const localizeManager = getLocalizeManager();
     if (this._ariaLabelledby) {
       this.removeAttribute('aria-label');
     } else if (!this._ariaLabel) {
-      this.setAttribute('aria-label', localize.msg('lion-progress-indicator:loading'));
+      this.setAttribute('aria-label', localizeManager.msg('lion-progress-indicator:loading'));
       this.__hasDefaultLabelSet = true;
     }
   }

--- a/packages/ui/components/validate-messages/src/loadDefaultFeedbackMessages.js
+++ b/packages/ui/components/validate-messages/src/loadDefaultFeedbackMessages.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { loadDefaultFeedbackMessagesNoSideEffects } from './loadDefaultFeedbackMessagesNoSideEffects.js';
 
 /**
@@ -7,5 +7,5 @@ import { loadDefaultFeedbackMessagesNoSideEffects } from './loadDefaultFeedbackM
  */
 
 export function loadDefaultFeedbackMessages() {
-  return loadDefaultFeedbackMessagesNoSideEffects({ localize });
+  return loadDefaultFeedbackMessagesNoSideEffects({ localize: getLocalizeManager() });
 }

--- a/packages/ui/components/validate-messages/test/loadDefaultFeedbackMessagesNoSideEffects.js
+++ b/packages/ui/components/validate-messages/test/loadDefaultFeedbackMessagesNoSideEffects.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars, no-param-reassign */
 import { expect } from '@open-wc/testing';
-import { localize } from '@lion/ui/localize.js';
+import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { Required } from '@lion/ui/form-core.js';
 import { loadDefaultFeedbackMessagesNoSideEffects } from '@lion/ui/validate-messages-no-side-effects.js';
 
@@ -20,6 +20,8 @@ function getProtectedMembers(validatorEl) {
 }
 
 describe('loadDefaultFeedbackMessagesNoSideEffects', () => {
+  const localizeManager = getLocalizeManager();
+
   it('will set default feedback message for Required', async () => {
     const el = new Required();
     const { getMessage } = getProtectedMembers(el);
@@ -27,18 +29,18 @@ describe('loadDefaultFeedbackMessagesNoSideEffects', () => {
       'Please configure an error message for "Required" by overriding "static async getMessage()"',
     );
 
-    loadDefaultFeedbackMessagesNoSideEffects({ localize });
+    loadDefaultFeedbackMessagesNoSideEffects({ localize: localizeManager });
     expect(await getMessage({ fieldName: 'password' })).to.equal('Please enter a(n) password.');
   });
 
   it('will await loading of translations when switching locale', async () => {
     const el = new Required();
     const { getMessage } = getProtectedMembers(el);
-    loadDefaultFeedbackMessagesNoSideEffects({ localize });
+    loadDefaultFeedbackMessagesNoSideEffects({ localize: localizeManager });
     expect(await getMessage({ fieldName: 'password' })).to.equal('Please enter a(n) password.');
     expect(await getMessage({ fieldName: 'user name' })).to.equal('Please enter a(n) user name.');
 
-    localize.locale = 'de-DE';
+    localizeManager.locale = 'de-DE';
     expect(await getMessage({ fieldName: 'Password' })).to.equal(
       'Password muss ausgefüllt werden.',
     );

--- a/packages/ui/exports/localize-no-side-effects.js
+++ b/packages/ui/exports/localize-no-side-effects.js
@@ -1,1 +1,20 @@
 export { LocalizeManager } from '../components/localize/src/LocalizeManager.js';
+export { formatDate } from '../components/localize/src/date/formatDate.js';
+export { getDateFormatBasedOnLocale } from '../components/localize/src/date/getDateFormatBasedOnLocale.js';
+export { getMonthNames } from '../components/localize/src/date/getMonthNames.js';
+export { getWeekdayNames } from '../components/localize/src/date/getWeekdayNames.js';
+export { normalizeDateTime } from '../components/localize/src/date/normalizeDateTime.js';
+export { parseDate } from '../components/localize/src/date/parseDate.js';
+export { LocalizeMixin } from '../components/localize/src/LocalizeMixin.js';
+export { formatNumber } from '../components/localize/src/number/formatNumber.js';
+export { formatNumberToParts } from '../components/localize/src/number/formatNumberToParts.js';
+export { getCurrencyName } from '../components/localize/src/number/getCurrencyName.js';
+export { getDecimalSeparator } from '../components/localize/src/number/getDecimalSeparator.js';
+export { getFractionDigits } from '../components/localize/src/number/getFractionDigits.js';
+export { getGroupSeparator } from '../components/localize/src/number/getGroupSeparator.js';
+export { getSeparatorsFromNumber } from '../components/localize/src/number/getSeparatorsFromNumber.js';
+export { normalizeCurrencyLabel } from '../components/localize/src/number/normalizeCurrencyLabel.js';
+export { parseNumber } from '../components/localize/src/number/parseNumber.js';
+export { getLocale } from '../components/localize/src/utils/getLocale.js';
+
+export { getLocalizeManager } from '../components/localize/src/getLocalizeManager.js';


### PR DESCRIPTION
Side-effect-free alternative for `localize` (the globally shared instance of LocalizeManager).
When this function is imported, no side-effect happened yet, i.e. no global instance was registered yet.
The side effect-free approach generates:
- smaller, optimized bundles
- a predictable loading order, that allows for:
  - deduping strategies when multiple instances of the localizeManager are on a page
  - providing a customized extension of LocalizeManager

Use it like this:

```js
function myFunction() {
  // note that 'localizeManager' is the same as former 'localize'
  const localizeManager = getLocalizeManger();
  // ...
}
```

In a class, we advise a shared instance:
```js
class MyClass {
  constructor() {
    this._localizeManager = getLocalizeManger();
  }
  // ...
}
```

Make sure to always call this method inside a function or class (otherwise side effects are created)

Do you want to register your own LocalizeManager?
Make sure it's registered before anyone called `getLocalizeManager()`

```js
import { singletonManager } from 'singleton-manager';
import { getLocalizeManger } from '@lion/ui/localize-no-side-effects.js';

// First register your own LocalizeManager (for deduping or other reasons)
singletonManager.set('lion/ui::localize::0.x', class MyLocalizeManager extends LocalizeManager {});

// Now, all your code gets the right instance
export function myFn() {
  const localizeManager = getLocalizeManager();
  // ...
}

export class myClass() {
  constructor() {
    this._localizeManager = getLocalizeManager();
    // ...
  }
}
```
