### PR TITLE
Feat/localize manager override data

### DIFF
--- a/.changeset/cuddly-timers-sin.md
+++ b/.changeset/cuddly-timers-sin.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+LocalizeManager: added `allowOverridesForExistingNamespaces` parameter to `addData` method to allow for changing data in a namespace for a given locale

--- a/packages/ui/components/localize/src/LocalizeManager.js
+++ b/packages/ui/components/localize/src/LocalizeManager.js
@@ -199,17 +199,27 @@ export class LocalizeManager {
    * @param {string} locale
    * @param {string} namespace
    * @param {object} data
-   * @throws {Error} Namespace can be added only once, for a given locale
+   * @param {boolean} allowOverridesForExistingNamespaces
+   * @throws {Error} Namespace can be added only once, for a given locale unless allowOverridesForExistingNamespaces
+   * is set to `true`
    */
-  addData(locale, namespace, data) {
-    if (this._isNamespaceInCache(locale, namespace)) {
+  addData(locale, namespace, data, allowOverridesForExistingNamespaces = false) {
+    if (!allowOverridesForExistingNamespaces && this._isNamespaceInCache(locale, namespace)) {
       throw new Error(
         `Namespace "${namespace}" has been already added for the locale "${locale}".`,
       );
     }
 
     this.__storage[locale] = this.__storage[locale] || {};
-    this.__storage[locale][namespace] = data;
+
+    if (allowOverridesForExistingNamespaces) {
+      this.__storage[locale][namespace] = {
+        ...this.__storage[locale][namespace],
+        ...data,
+      };
+    } else {
+      this.__storage[locale][namespace] = data;
+    }
   }
 
   /**

--- a/packages/ui/components/localize/test/LocalizeManager.test.js
+++ b/packages/ui/components/localize/test/LocalizeManager.test.js
@@ -155,7 +155,7 @@ describe('LocalizeManager', () => {
       });
     });
 
-    it('prevents mutating existing data for the same locale & namespace', () => {
+    it('prevents mutating existing data for the same locale & namespace when "allowOverridesForExistingNamespaces" argument is not given', () => {
       manager = new LocalizeManager();
       const { storage } = getProtectedMembers(manager);
 
@@ -167,6 +167,23 @@ describe('LocalizeManager', () => {
 
       expect(storage).to.deep.equal({
         'en-GB': { 'lion-hello': { greeting: 'Hi!' } },
+      });
+    });
+
+    it('allows mutating existing data for the same locale & namespace when "allowOverridesForExistingNamespaces" argument is set to "true"', () => {
+      manager = new LocalizeManager();
+      const { storage } = getProtectedMembers(manager);
+
+      manager.addData('en-GB', 'lion-hello', { greeting: 'Hi!' });
+
+      expect(storage).to.deep.equal({
+        'en-GB': { 'lion-hello': { greeting: 'Hi!' } },
+      });
+
+      manager.addData('en-GB', 'lion-hello', { greeting: 'Hi!', alternative: 'Hello!' }, true);
+
+      expect(storage).to.deep.equal({
+        'en-GB': { 'lion-hello': { greeting: 'Hi!', alternative: 'Hello!' } },
       });
     });
   });


### PR DESCRIPTION
## What I did

1. added `allowOverridesForExistingNamespaces` parameter to `addData` method of LocalizeManager to allow for changing data in a namespace for a given locale
2. added test
3. added changeset
