### PR TITLE
fix(@lion/ui): export types necessary for type inference of core.js

### DIFF
--- a/.changeset/ten-plums-notice.md
+++ b/.changeset/ten-plums-notice.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(@lion/ui): export types necessary for type inference of core.js

--- a/packages/ui/exports/types/core.ts
+++ b/packages/ui/exports/types/core.ts
@@ -1,3 +1,5 @@
+export { DisabledHost } from '../../components/core/types/DisabledMixinTypes.js';
+export { DisabledWithTabIndexHost } from '../../components/core/types/DisabledWithTabIndexMixinTypes.js';
 export { SlotHost } from '../../components/core/types/SlotMixinTypes.js';
 export { SlotsMap } from '../../components/core/types/SlotMixinTypes.js';
 export { SlotFunctionResult } from '../../components/core/types/SlotMixinTypes.js';


### PR DESCRIPTION
Regretfully, I overlooked two Host types in the core in the https://github.com/ing-bank/lion/pull/1906 . Mea culpa. Fixes #1903 some more, this time for extenders who create a component that is tied to the `DisabledMixin`.

## What I did

1. Added the overlooked `DisabledHost` and `DisabledWithTabIndexHost` types as well.
