### PR TITLE
[draft] incorporate hasChanged in sync updates

### DIFF
--- a/packages/ui/components/form-core/test-suites/form-group/FormGroupMixin.suite.js
+++ b/packages/ui/components/form-core/test-suites/form-group/FormGroupMixin.suite.js
@@ -1086,7 +1086,7 @@ export function runFormGroupMixinSuite(cfg = {}) {
         expect(input.modelValue).to.equal('Foo');
       });
 
-      it('clears interaction state', async () => {
+      it.only('clears interaction state', async () => {
         const el = /**  @type {FormGroup} */ (
           await fixture(html`<${tag} touched dirty>${inputSlots}</${tag}>`)
         );

--- a/packages/ui/components/form-core/test/lion-field.test.js
+++ b/packages/ui/components/form-core/test/lion-field.test.js
@@ -357,40 +357,32 @@ describe('<lion-field>', () => {
       expect(el.validationStates.error.Required).to.not.exist;
     });
 
-    it('will only update formattedValue when valid on `user-input-changed`', async () => {
+    it('for best DX, on `user-input-changed` (during typing/interacting): will only update formattedValue when no errors', async () => {
       const formatterSpy = sinon.spy(value => `foo: ${value}`);
-      const Bar = class extends Validator {
-        static get validatorName() {
-          return 'Bar';
-        }
+      const EqualsBar = class extends Validator {
+        static validatorName = 'EqualsBar';
 
-        /**
-         * @param {string} value
-         */
-        execute(value) {
-          const hasError = value !== 'bar';
-          return hasError;
-        }
+        execute = (/** @type {string} */ value) => value !== 'bar';
       };
       const el = /** @type {LionField} */ (
         await fixture(html`
         <${tag}
           .modelValue=${'init-string'}
           .formatter=${formatterSpy}
-          .validators=${[new Bar()]}
+          .validators=${[new EqualsBar()]}
         >${inputSlot}</${tag}>
       `)
       );
 
-      expect(formatterSpy.callCount).to.equal(0);
-      expect(el.formattedValue).to.equal('init-string');
+      expect(formatterSpy.callCount).to.equal(1);
+      expect(el.formattedValue).to.equal('foo: init-string');
 
       el.modelValue = 'bar';
-      expect(formatterSpy.callCount).to.equal(1);
+      expect(formatterSpy.callCount).to.equal(2);
       expect(el.formattedValue).to.equal('foo: bar');
 
       mimicUserInput(el, 'foo');
-      expect(formatterSpy.callCount).to.equal(1);
+      expect(formatterSpy.callCount).to.equal(2);
       expect(el.value).to.equal('foo');
     });
   });

--- a/packages/ui/components/input-date/src/LionInputDate.js
+++ b/packages/ui/components/input-date/src/LionInputDate.js
@@ -3,6 +3,32 @@ import { LionInput } from '@lion/ui/input.js';
 import { formatDate, LocalizeMixin, parseDate } from '@lion/ui/localize-no-side-effects.js';
 
 /**
+ *
+ * @param {Date | undefined} newV
+ * @param {Date | undefined} oldV
+ */
+function hasDateChanged(newV, oldV) {
+  return !(
+    (
+      Object.prototype.toString.call(newV) === '[object Date]' && // is Date Object
+      newV &&
+      newV.getDate() === oldV?.getDate?.() && // day
+      newV.getMonth() === oldV.getMonth?.() && // month
+      newV.getFullYear() === oldV.getFullYear?.()
+    ) // year
+  );
+}
+
+/**
+ * Change function that returns true if `value` is different from `oldValue`.
+ * This method is used as the default for a property's `hasChanged` function.
+ */
+export const notEqual = (value, old) => {
+  // This ensures (old==NaN, value==NaN) always returns false
+  return old !== value && (old === old || value === value);
+};
+
+/**
  * @param {Date|number} date
  */
 function isValidDate(date) {
@@ -22,7 +48,10 @@ export class LionInputDate extends LocalizeMixin(LionInput) {
   /** @type {any} */
   static get properties() {
     return {
-      modelValue: Date,
+      modelValue: {
+        type: Date,
+        hasChanged: hasDateChanged,
+      },
     };
   }
 


### PR DESCRIPTION
- considers hasChanged function of `static get properties` for all sync updates in FormatMixin
- fixes dirty check of dates, so that `new Date('2020/10/10')` equals `new Date('2020/10/10')`
- fixes some behaviors with fomatting erroneous values wrt initial user-input-changed handling
 
TODO:
- make all tests run again


closes https://github.com/ing-bank/lion/issues/1910