### PR TITLE
fix(@lion/ui): declare sideEffects in package.json (fixes #1915)

### DIFF
--- a/.changeset/witty-carpets-clap.md
+++ b/.changeset/witty-carpets-clap.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(@lion/ui): declare sideEffects in package.json

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,13 @@
     "types-check-only": "tsc --project tsconfig-check-only.json",
     "types-correct-after-build": "node ./scripts/types-correct-after-build.js"
   },
+  "sideEffects": [
+    "exports/define/**/*.js",
+    "exports/define-helpers/**/*.js",
+    "exports/icon.js",
+    "exports/localize.js",
+    "exports/overlays.js"
+  ],
   "dependencies": {
     "@bundled-es-modules/message-format": "^6.0.4",
     "@open-wc/dedupe-mixin": "^1.3.1",


### PR DESCRIPTION
## What I did

1. Added the following side effects (between scripts and dependencies, where I found them in older Lion packages):
```
  "sideEffects": [
    "exports/define/**/*.js",
    "exports/define-helpers/**/*.js",
    "exports/icon.js",
    "exports/localize.js",
    "exports/overlays.js"
  ],
```
2. Did the same change in the node_modules of our design system, and checked that indeed they fix the broken tree-shaking. All of our components now report bundle sizes similar to the pre-@lion/ui migration, including zero-import, single component imports and import everything tests.
3. Looked for the hint "singleton" in the `@lion/ui` source js files to see if any `singleton-manager` usages get caught that were not mentioned in the issue.

All the `define` and `define-helpers` were my take, not directly suggested by @tlouisse. It seems to make sense to mark the self-defining components as sideEffects.