### PR TITLE
fix(combobox): fix direct open and closing of the overlay on focus of empty input when showAllOnEmpty

### DIFF
--- a/.changeset/chilly-plants-cry.md
+++ b/.changeset/chilly-plants-cry.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[combobox] fix direct open and closing of the overlay on focus of empty input when `showAllOnEmpty`

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -856,6 +856,7 @@ export class LionCombobox extends OverlayMixin(LionListbox) {
       ...withDropdownConfig(),
       elementToFocusAfterHide: undefined,
       invokerNode: this._comboboxNode,
+      visibilityTriggerFunction: undefined,
     });
   }
 

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -670,6 +670,25 @@ describe('lion-combobox', () => {
       expect(el.checkedIndex).to.equal(-1);
     });
 
+    it('has the correct Overlay Config defined', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo" .showAllOnEmpty="${true}">
+            <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
+            <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
+            <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>
+            <lion-option .choiceValue="${'Victoria Plum'}">Victoria Plum</lion-option>
+          </lion-combobox>
+        `)
+      );
+      // @ts-ignore [allow-protected] in test
+      expect(el._defineOverlayConfig().elementToFocusAfterHide).to.equal(undefined);
+      // @ts-ignore [allow-protected] in test
+      expect(el._defineOverlayConfig().invokerNode).to.equal(el._inputNode);
+      // @ts-ignore [allow-protected] in test
+      expect(el._defineOverlayConfig().visibilityTriggerFunction).to.equal(undefined);
+    });
+
     // NB: If this becomes a suite, move to separate file
     describe('Subclassers', () => {
       it('allows to control overlay visibility via "_showOverlayCondition"', async () => {


### PR DESCRIPTION
## What I did

1.
