### PR TITLE
Fixed grammar

### DIFF
--- a/.changeset/nervous-numbers-smash.md
+++ b/.changeset/nervous-numbers-smash.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Changed spelling/grammar of the german error message for an invalid IBAN.

--- a/packages/ui/components/input-iban/translations/de.js
+++ b/packages/ui/components/input-iban/translations/de.js
@@ -1,6 +1,6 @@
 export default {
   error: {
-    IsIBAN: 'Geben Sie ein gültiges {fieldName} ein.',
+    IsIBAN: 'Geben Sie eine gültige {fieldName} ein.',
     IsCountryIBAN:
       'Geben Sie eine gültige {params, select,\n' +
       'AT {Österreichisch}\n' +


### PR DESCRIPTION
IBAN is feminin in German: <https://www.duden.de/rechtschreibung/IBAN>

## What I did

1. Changed spelling/grammar of the german error message for an invalid IBAN. 
