### PR TITLE
fix: checked-changed event is no longer fired on element initializati…

### DIFF
--- a/.changeset/mean-plants-rush.md
+++ b/.changeset/mean-plants-rush.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+lion-switch: checked-changed event is no longer fired on element initialization when checked is set through attribute

--- a/packages/ui/components/switch/src/LionSwitchButton.js
+++ b/packages/ui/components/switch/src/LionSwitchButton.js
@@ -12,10 +12,6 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
         type: Boolean,
         reflect: true,
       },
-      __initialized: {
-        type: Boolean,
-        state: true,
-      },
     };
   }
 

--- a/packages/ui/components/switch/src/LionSwitchButton.js
+++ b/packages/ui/components/switch/src/LionSwitchButton.js
@@ -14,6 +14,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
       },
       __initialized: {
         type: Boolean,
+        state: true,
       },
     };
   }

--- a/packages/ui/components/switch/src/LionSwitchButton.js
+++ b/packages/ui/components/switch/src/LionSwitchButton.js
@@ -12,6 +12,9 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
         type: Boolean,
         reflect: true,
       },
+      __initialized: {
+        type: Boolean,
+      },
     };
   }
 
@@ -78,6 +81,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
 
     this.role = 'switch';
     this.checked = false;
+    this.__initialized = false;
     /** @protected */
     this._toggleChecked = this._toggleChecked.bind(this);
     /** @private */
@@ -158,8 +162,18 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
    */
   requestUpdate(name, oldValue, options) {
     super.requestUpdate(name, oldValue, options);
-    if (this.isConnected && name === 'checked' && this.checked !== oldValue && !this.disabled) {
+    if (
+      this.__initialized &&
+      this.isConnected &&
+      name === 'checked' &&
+      this.checked !== oldValue &&
+      !this.disabled
+    ) {
       this.__checkedStateChange();
     }
+  }
+
+  firstUpdated() {
+    this.__initialized = true;
   }
 }

--- a/packages/ui/components/switch/src/LionSwitchButton.js
+++ b/packages/ui/components/switch/src/LionSwitchButton.js
@@ -170,7 +170,9 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
     }
   }
 
-  firstUpdated() {
+  /** @param {import('lit').PropertyValues } changedProperties */
+  firstUpdated(changedProperties) {
+    super.firstUpdated(changedProperties);
     this.__initialized = true;
   }
 }

--- a/packages/ui/components/switch/test/lion-switch-button.test.js
+++ b/packages/ui/components/switch/test/lion-switch-button.test.js
@@ -1,4 +1,4 @@
-import { expect, fixture as _fixture } from '@open-wc/testing';
+import { expect, fixture as _fixture, fixtureSync, elementUpdated } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
 import sinon from 'sinon';
 import '@lion/ui/define/lion-switch-button.js';
@@ -124,6 +124,20 @@ describe('lion-switch-button', () => {
     el.addEventListener('checked-changed', handlerSpy);
     el.checked = !el.checked;
     expect(handlerSpy.called).to.be.false;
+  });
+
+  it('should not dispatch "checked-changed" event if not initialized on update', async () => {
+    const handlerSpy = sinon.spy();
+    const elSync = /** @type {LionSwitchButton} */ (
+      fixtureSync(html`<lion-switch-button @checked-changed="${handlerSpy}" .checked=${true} />`)
+    );
+    expect(elSync.__initialized).to.be.false;
+    await elementUpdated(elSync);
+    expect(elSync.__initialized).to.be.true;
+    expect(handlerSpy.called).to.be.false;
+    elSync.checked = !elSync.checked;
+    await elementUpdated(elSync);
+    expect(handlerSpy.called).to.be.true;
   });
 
   describe('a11y', () => {


### PR DESCRIPTION
…on when checked is set through attribute

## What I did

1. checked-changed event is no longer fired on element initialization when checked is set through attribute
2. added test
3. added changes
