### PR TITLE
fix(switch): remove one of the two nested role="switch"

### DIFF
--- a/.changeset/afraid-nails-tap.md
+++ b/.changeset/afraid-nails-tap.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[switch] remove one of the two role="switch" (nested-interactive). Only leave it on the switch-button.

--- a/packages/ui/components/switch/src/LionSwitch.js
+++ b/packages/ui/components/switch/src/LionSwitch.js
@@ -80,9 +80,6 @@ export class LionSwitch extends ScopedElementsMixin(ChoiceInputMixin(LionField))
 
   connectedCallback() {
     super.connectedCallback();
-    if (!this.role) {
-      this.role = 'switch';
-    }
     this.addEventListener('checked-changed', this.__handleButtonSwitchCheckedChanged);
     if (this._labelNode) {
       this._labelNode.addEventListener('click', this._toggleChecked);

--- a/packages/ui/components/switch/test/lion-switch.test.js
+++ b/packages/ui/components/switch/test/lion-switch.test.js
@@ -10,7 +10,7 @@ import '@lion/ui/define/lion-switch.js';
 /**
  * @typedef {import('../src/LionSwitchButton.js').LionSwitchButton} LionSwitchButton
  * @typedef {import('lit').TemplateResult} TemplateResult
- * @typedef {import('../../form-core/types/FormControlMixinTypes.js').FormControlHost} FormControlHost
+ * @typedef {import('@lion/ui/types/form-core.js').FormControlHost} FormControlHost
  */
 
 const IsTrue = class extends Validator {
@@ -215,10 +215,25 @@ describe('lion-switch', () => {
     expect(el.showsFeedbackFor).to.eql(['info']);
   });
 
-  it('should not cause error by setting an attribute in the constructor', async () => {
-    const div = await fixture(html`<div></div>`);
-    const el = /** @type {LionSwitch} */ (document.createElement('lion-switch'));
-    div.appendChild(el);
-    expect(el.role).to.equal('switch');
+  describe('Accessibility', () => {
+    it('passes axe a11y audit', async () => {
+      const el = await fixture(html`<lion-switch name="hi" label="My label"></lion-switch>`);
+      await expect(el).to.be.accessible();
+
+      el.checked = true;
+      await el.updateComplete;
+      await expect(el).to.be.accessible();
+    });
+
+    it('passes axe a11y audit when disabled', async () => {
+      const el = await fixture(
+        html`<lion-switch name="hi" label="My label" disabled></lion-switch>`,
+      );
+      await expect(el).to.be.accessible();
+
+      el.checked = true;
+      await el.updateComplete;
+      await expect(el).to.be.accessible();
+    });
   });
 });


### PR DESCRIPTION
## What I did

1. remove one of the two role="switch" (nested-interactive). Only leave it on the switch-button.

Fix: https://github.com/ing-bank/lion/issues/1772
Fix: https://github.com/ing-bank/lion/issues/1517
