### PR TITLE
feat(@lion/ui): add _invokerIconTemplate to LionInputDatepicker (closes #1943)

### DIFF
--- a/.changeset/stupid-emus-compete.md
+++ b/.changeset/stupid-emus-compete.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+feat(@lion/ui): add \_invokerIconTemplate to LionInputDatepicker

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -279,9 +279,17 @@ export class LionInputDatepicker extends ScopedElementsMixin(
         aria-label="${this.msgLit('lion-input-datepicker:openDatepickerLabel')}"
         title="${this.msgLit('lion-input-datepicker:openDatepickerLabel')}"
       >
-        📅
+        ${this._invokerIconTemplate()}
       </button>
     `;
+  }
+
+  /**
+   * Subclassers can replace this with their custom extension invoker icon
+   */
+  // eslint-disable-next-line class-methods-use-this
+  _invokerIconTemplate() {
+    return html`📅`;
   }
 
   _setupOverlayCtrl() {


### PR DESCRIPTION
## What I did

Extracted icon of the invoker button into an overrideable _invokerIconTemplate