### PR TITLE
chore: make default public npm registry explicit

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org


### PR DESCRIPTION
## What I did

1. Make registry=https://registry.npmjs.org/ the default by adding it in .npmrc on project level
2. Update package-lock.json
