### PR TITLE
fix(form-core) sync autofocus to focusable node (fixes #1775)

### DIFF
--- a/.changeset/silly-shirts-promise.md
+++ b/.changeset/silly-shirts-promise.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[FocusMixin] now syncs autofocus between host and the focusable node.

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable lit-a11y/no-autofocus */
 import { expect, fixture as _fixture, html, unsafeStatic } from '@open-wc/testing';
 import { runOverlayMixinSuite } from '../../overlays/test-suites/OverlayMixin.suite.js';
 import '@lion/ui/define/lion-dialog.js';
@@ -70,6 +71,61 @@ describe('lion-dialog', () => {
       // @ts-expect-error [allow-protected-in-tests]
       await nestedDialogEl._overlayCtrl._showComplete;
       expect(nestedDialogEl.opened).to.be.true;
+    });
+  });
+
+  describe('focus', () => {
+    it('sets focus on contentSlot by default', async () => {
+      const el = await fixture(html`
+        <lion-dialog>
+          <button slot="invoker">invoker button</button>
+          <div slot="content">
+            <label for="myInput">Label</label>
+            <input id="myInput" />
+          </div>
+        </lion-dialog>
+      `);
+      // @ts-expect-error [allow-protected-in-tests]
+      const invokerNode = el._overlayInvokerNode;
+      invokerNode.focus();
+      invokerNode.click();
+      const contentNode = el.querySelector('[slot="content"]');
+      expect(document.activeElement).to.equal(contentNode);
+    });
+
+    it('sets focus on autofocused element', async () => {
+      const el = await fixture(html`
+        <lion-dialog>
+          <button slot="invoker">invoker button</button>
+          <div slot="content">
+            <label for="myInput">Label</label>
+            <input id="myInput" autofocus />
+          </div>
+        </lion-dialog>
+      `);
+      // @ts-expect-error [allow-protected-in-tests]
+      const invokerNode = el._overlayInvokerNode;
+      invokerNode.focus();
+      invokerNode.click();
+      const input = el.querySelector('input');
+      expect(document.activeElement).to.equal(input);
+    });
+
+    it('with trapsKeyboardFocus set to false the focus stays on the invoker', async () => {
+      const el = /** @type {LionDialog} */ await fixture(html`
+        <lion-dialog .config=${{ trapsKeyboardFocus: false }}>
+          <button slot="invoker">invoker button</button>
+          <div slot="content">
+            <label for="myInput">Label</label>
+            <input id="myInput" autofocus />
+          </div>
+        </lion-dialog>
+      `);
+      // @ts-expect-error [allow-protected-in-tests]
+      const invokerNode = el._overlayInvokerNode;
+      invokerNode.focus();
+      invokerNode.click();
+      expect(document.activeElement).to.equal(invokerNode);
     });
   });
 });

--- a/packages/ui/components/form-core/src/FocusMixin.js
+++ b/packages/ui/components/form-core/src/FocusMixin.js
@@ -27,6 +27,7 @@ const FocusMixinImplementation = superclass =>
       return {
         focused: { type: Boolean, reflect: true },
         focusedVisible: { type: Boolean, reflect: true, attribute: 'focused-visible' },
+        autofocus: { type: Boolean, reflect: true }, // Required in Lit to observe autofocus
       };
     }
 
@@ -52,11 +53,41 @@ const FocusMixinImplementation = superclass =>
     connectedCallback() {
       super.connectedCallback();
       this.__registerEventsForFocusMixin();
+      this.__syncAutofocusToFocusableElement();
     }
 
     disconnectedCallback() {
       super.disconnectedCallback();
       this.__teardownEventsForFocusMixin();
+    }
+
+    /**
+     * Gets called when an attribute is changed.
+     * @param {String} name
+     * @param {String | null} _old
+     * @param {String | null} value
+     * @protected
+     */
+    attributeChangedCallback(name, _old, value) {
+      super.attributeChangedCallback(name, _old, value);
+      if (name === 'autofocus') {
+        this.__syncAutofocusToFocusableElement();
+      }
+    }
+
+    /**
+     * @private
+     */
+    __syncAutofocusToFocusableElement() {
+      if (!this._focusableNode) {
+        return;
+      }
+
+      if (this.hasAttribute('autofocus')) {
+        this._focusableNode.setAttribute('autofocus', '');
+      } else {
+        this._focusableNode.removeAttribute('autofocus');
+      }
     }
 
     /**

--- a/packages/ui/components/form-core/src/FocusMixin.js
+++ b/packages/ui/components/form-core/src/FocusMixin.js
@@ -48,6 +48,7 @@ const FocusMixinImplementation = superclass =>
        * @type {boolean}
        */
       this.focusedVisible = false;
+      this.autofocus = false;
     }
 
     connectedCallback() {
@@ -62,15 +63,11 @@ const FocusMixinImplementation = superclass =>
     }
 
     /**
-     * Gets called when an attribute is changed.
-     * @param {String} name
-     * @param {String | null} _old
-     * @param {String | null} value
-     * @protected
+     * @param {import('lit').PropertyValues } changedProperties
      */
-    attributeChangedCallback(name, _old, value) {
-      super.attributeChangedCallback(name, _old, value);
-      if (name === 'autofocus') {
+    updated(changedProperties) {
+      super.updated(changedProperties);
+      if (changedProperties.has('autofocus')) {
         this.__syncAutofocusToFocusableElement();
       }
     }

--- a/packages/ui/components/form-core/test/FocusMixin.test.js
+++ b/packages/ui/components/form-core/test/FocusMixin.test.js
@@ -323,6 +323,39 @@ describe('FocusMixin', () => {
         spy4.restore();
         restoreMock4();
       });
+
+      it('has mirrors syncs autofocus on the focusable element when autofocus changes', async () => {
+        const el = /** @type {Focusable} */ (
+          await fixture(html`
+          <${tag}><input slot="input"></${tag}>
+        `)
+        );
+
+        // @ts-ignore [allow-protected] in test
+        const { _focusableNode } = el;
+
+        el.setAttribute('autofocus', '');
+        await el.updateComplete;
+        expect(_focusableNode.hasAttribute('autofocus')).to.be.true;
+
+        el.removeAttribute('autofocus');
+        await el.updateComplete;
+        expect(_focusableNode.hasAttribute('autofocus')).not.to.be.true;
+      });
+
+      it('has mirrors syncs autofocus on the focusable element when autofocus was set on render', async () => {
+        const el = /** @type {Focusable} */ (
+          await fixture(html`
+          <${tag} autofocus><input slot="input"></${tag}>
+        `)
+        );
+
+        // @ts-ignore [allow-protected] in test
+        const { _focusableNode } = el;
+
+        expect(el.hasAttribute('autofocus')).to.be.true;
+        expect(_focusableNode.hasAttribute('autofocus')).to.be.true;
+      });
     });
   });
 });

--- a/packages/ui/components/form-core/types/FocusMixinTypes.ts
+++ b/packages/ui/components/form-core/types/FocusMixinTypes.ts
@@ -26,6 +26,12 @@ export declare class FocusHost {
   blur(): void;
 
   /**
+  * Synchronizes property values when attributes change.
+  * @category attributes
+  */
+    attributeChangedCallback(name: string, _old: string | null, value: string | null): void;
+
+  /**
    * The focusable element:
    * could be an input, textarea, select, button or any other element with tabindex > -1
    */

--- a/packages/ui/components/form-core/types/FocusMixinTypes.ts
+++ b/packages/ui/components/form-core/types/FocusMixinTypes.ts
@@ -26,12 +26,6 @@ export declare class FocusHost {
   blur(): void;
 
   /**
-  * Synchronizes property values when attributes change.
-  * @category attributes
-  */
-    attributeChangedCallback(name: string, _old: string | null, value: string | null): void;
-
-  /**
    * The focusable element:
    * could be an input, textarea, select, button or any other element with tabindex > -1
    */

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable lit-a11y/no-autofocus */
 import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit';
 import { getAllTagNames } from './helpers/helpers.js';
@@ -69,5 +70,22 @@ describe('Form inside dialog Integrations', () => {
       'lion-input-stepper',
       'lion-textarea',
     ]);
+  });
+
+  it('sets focus on first focusable element with autofocus', async () => {
+    const el = /** @type {LionDialog} */ await fixture(html`
+      <lion-dialog>
+        <button slot="invoker">invoker button</button>
+        <div slot="content">
+          <lion-input label="label" name="input" autofocus></lion-input>
+          <lion-textarea label="label" name="textarea" autofocus></lion-textarea>
+        </div>
+      </lion-dialog>
+    `);
+    // @ts-expect-error [allow-protected-in-tests]
+    el._overlayInvokerNode.click();
+    const lionInput = el.querySelector('[name="input"]');
+    // @ts-expect-error [allow-protected-in-tests]
+    expect(document.activeElement).to.equal(lionInput._focusableNode);
   });
 });


### PR DESCRIPTION
## What I did

1. In FocusMixin synced the autofocus attribute from the host to the focusable node.
2. Added tests to ensure the sync happens if autofocus was set on the host during render or when autofocus is added or removed from the host.
