### PR TITLE
fix: lion-calendar Firefox

### DIFF
--- a/.changeset/tough-rivers-punch.md
+++ b/.changeset/tough-rivers-punch.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+lion-calendar: when determining if user interacted with a day button we no longer examine event.target but event.composedPath()[0] since it otherwise fails in Firefox 111+

--- a/package-lock.json
+++ b/package-lock.json
@@ -22334,7 +22334,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.0.4",

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -753,7 +753,7 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     const isDayButton = /** @param {HTMLElement} el */ el =>
       el.classList.contains('calendar__day-button');
 
-    const el = /** @type {HTMLElement & { date: Date }} */ (ev.target);
+    const el = /** @type {HTMLElement & { date: Date }} */ (ev.composedPath()[0]);
     if (isDayButton(el)) {
       this.__dateSelectedByUser(el.date);
     }


### PR DESCRIPTION
## What I did

1. lion-calendar: when determining if user interacted with a day button we no longer examine event.target but event.composedPath()[0] since it otherwise fails in Firefox 111+
(fixes #1962)
