### PR TITLE
chore: add missing import of lion-checkbox-indeterminate

### DIFF
--- a/docs/components/checkbox-group/use-cases.md
+++ b/docs/components/checkbox-group/use-cases.md
@@ -3,6 +3,7 @@
 ```js script
 import { html } from '@mdjs/mdjs-preview';
 import '@lion/ui/define/lion-checkbox-group.js';
+import '@lion/ui/define/lion-checkbox-indeterminate.js';
 import '@lion/ui/define/lion-checkbox.js';
 ```
 


### PR DESCRIPTION
## What I did

1. add missing import of lion-checkbox-indeterminate to the checkbox-group docs
