### PR TITLE
fix(localize): parseNumbers as heuristic if there is only 1 separator…

### DIFF
--- a/.changeset/hot-turtles-glow.md
+++ b/.changeset/hot-turtles-glow.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[localize] parseNumbers as heuristic if there is only 1 separator and 2 or less decimals e.g. 12.34

--- a/packages/ui/components/localize/src/number/parseNumber.js
+++ b/packages/ui/components/localize/src/number/parseNumber.js
@@ -23,8 +23,14 @@ import { getDecimalSeparator } from './getDecimalSeparator.js';
 function getParseMode(value, { mode = 'auto' } = {}) {
   const separators = value.match(/[., ]/g);
 
-  if (!separators || (mode === 'auto' && separators.length === 1)) {
+  if (!separators) {
     return 'withLocale';
+  }
+  if (mode === 'auto' && separators.length === 1) {
+    const decimalLength = value.split(`${separators}`)[1].length;
+    if (decimalLength >= 3) {
+      return 'withLocale';
+    }
   }
   if (separators.length === 1 || separators[0] !== separators[separators.length - 1]) {
     return 'heuristic';

--- a/packages/ui/components/localize/test/number/parseNumber.test.js
+++ b/packages/ui/components/localize/test/number/parseNumber.test.js
@@ -80,18 +80,32 @@ describe('parseNumber()', () => {
     expect(parseNumber('1 234 56')).to.equal(123456);
   });
 
-  it('uses locale to parse amount if there is only one separator e.g. 1.234', () => {
+  it('uses heuristic to parse amount if there is only one separator e.g. 12.34 and amount of decimals is 2 or smaller', () => {
     localizeManager.locale = 'en-GB';
+    expect(parseNumber('12.3')).to.equal(12.3);
+    expect(parseNumber('12,3')).to.equal(12.3);
     expect(parseNumber('12.34')).to.equal(12.34);
-    expect(parseNumber('12,34')).to.equal(1234);
-    expect(parseNumber('1.234')).to.equal(1.234);
-    expect(parseNumber('1,234')).to.equal(1234);
+    expect(parseNumber('12,34')).to.equal(12.34);
 
     localizeManager.locale = 'nl-NL';
-    expect(parseNumber('12.34')).to.equal(1234);
+    expect(parseNumber('12.3')).to.equal(12.3);
+    expect(parseNumber('12,3')).to.equal(12.3);
+    expect(parseNumber('12.34')).to.equal(12.34);
     expect(parseNumber('12,34')).to.equal(12.34);
+  });
+
+  it('uses locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
+    localizeManager.locale = 'en-GB';
+    expect(parseNumber('1.234')).to.equal(1.234);
+    expect(parseNumber('1,234')).to.equal(1234);
+    expect(parseNumber('1.2345')).to.equal(1.2345);
+    expect(parseNumber('1,2345')).to.equal(12345);
+
+    localizeManager.locale = 'nl-NL';
     expect(parseNumber('1.234')).to.equal(1234);
     expect(parseNumber('1,234')).to.equal(1.234);
+    expect(parseNumber('1.2345')).to.equal(12345);
+    expect(parseNumber('1,2345')).to.equal(1.2345);
   });
 
   it('returns numbers only if it can not be interpreted e.g. 1.234.567', () => {


### PR DESCRIPTION
… and 2 or less decimals e.g. 12.34

## What I did

1.
