### PR TITLE
Fix: LionInputDatePicker enters an endless loop on InvalidDate modelValue

### DIFF
--- a/.changeset/nasty-dodos-fold.md
+++ b/.changeset/nasty-dodos-fold.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+fix: LionInputDatePicker enters an endless loop on InvalidDate modelValue

--- a/docs/components/input-datepicker/use-cases.md
+++ b/docs/components/input-datepicker/use-cases.md
@@ -76,3 +76,14 @@ export const readOnly = () => html`
   </lion-input-datepicker>
 `;
 ```
+
+## Faulty prefilled
+
+Faulty prefilled input will be cleared
+
+```js preview-story
+export const faultyPrefilled = () => html`
+  <lion-input-datepicker .modelValue="${new Date('30/01/2022')}">
+  </lion-input-datepicker>
+`;
+```

--- a/docs/components/input-datepicker/use-cases.md
+++ b/docs/components/input-datepicker/use-cases.md
@@ -83,7 +83,7 @@ Faulty prefilled input will be cleared
 
 ```js preview-story
 export const faultyPrefilled = () => html`
-  <lion-input-datepicker .modelValue="${new Date('30/01/2022')}">
+  <lion-input-datepicker label="Faulty prefiiled" .modelValue="${new Date('30/01/2022')}">
   </lion-input-datepicker>
 `;
 ```

--- a/packages/ui/components/input-date/src/LionInputDate.js
+++ b/packages/ui/components/input-date/src/LionInputDate.js
@@ -3,16 +3,6 @@ import { LionInput } from '@lion/ui/input.js';
 import { formatDate, LocalizeMixin, parseDate } from '@lion/ui/localize-no-side-effects.js';
 
 /**
- * @param {Date|number} date
- */
-function isValidDate(date) {
-  // to make sure it is a valid date we use isNaN and not Number.isNaN
-  // @ts-ignore [allow]: dirty hack, you're not supposed to pass Date instances to isNaN
-  // eslint-disable-next-line no-restricted-globals
-  return date instanceof Date && !isNaN(date);
-}
-
-/**
  * `LionInputDate` has a .modelValue of type Date. It parses, formats and validates based
  * on locale.
  *
@@ -51,7 +41,8 @@ export class LionInputDate extends LocalizeMixin(LionInput) {
    */
   // eslint-disable-next-line class-methods-use-this
   serializer(modelValue) {
-    if (!isValidDate(modelValue)) {
+    const isDate = new IsDate();
+    if (isDate.execute(modelValue)) {
       return '';
     }
     // modelValue is localized, so we take the timezone offset in milliseconds and subtract it

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -12,6 +12,7 @@ import {
 } from '@lion/ui/overlays.js';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { localizeNamespaceLoader } from './localizeNamespaceLoader.js';
+import { IsDate } from '../../../exports/form-core.js';
 
 /**
  * @typedef {import('../../form-core/src/validate/Validator.js').Validator} Validator
@@ -373,10 +374,12 @@ export class LionInputDatepicker extends ScopedElementsMixin(
    * The LionCalendar shouldn't know anything about the modelValue;
    * it can't handle Unparseable dates, but does handle 'undefined'
    * @param {?} modelValue
-   * @returns {Date|undefined} a 'guarded' modelValue
+   * @returns {Date} a 'guarded' modelValue
    */
   static __getSyncDownValue(modelValue) {
-    return modelValue instanceof Date ? modelValue : undefined;
+    const isDate = new IsDate();
+    const hasError = isDate.execute(modelValue);
+    return hasError ? undefined : modelValue;
   }
 
   /**

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -12,7 +12,7 @@ import {
 } from '@lion/ui/overlays.js';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { localizeNamespaceLoader } from './localizeNamespaceLoader.js';
-import { IsDate } from '../../../exports/form-core.js';
+import { IsDate } from '@lion/ui/form-core.js';
 
 /**
  * @typedef {import('../../form-core/src/validate/Validator.js').Validator} Validator

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -4,6 +4,7 @@ import { ScopedElementsMixin } from '@open-wc/scoped-elements';
 import { html, css } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { LionInputDate } from '@lion/ui/input-date.js';
+import { IsDate } from '@lion/ui/form-core.js';
 import {
   OverlayMixin,
   withBottomSheetConfig,
@@ -12,7 +13,6 @@ import {
 } from '@lion/ui/overlays.js';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { localizeNamespaceLoader } from './localizeNamespaceLoader.js';
-import { IsDate } from '@lion/ui/form-core.js';
 
 /**
  * @typedef {import('../../form-core/src/validate/Validator.js').Validator} Validator

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -374,7 +374,7 @@ export class LionInputDatepicker extends ScopedElementsMixin(
    * The LionCalendar shouldn't know anything about the modelValue;
    * it can't handle Unparseable dates, but does handle 'undefined'
    * @param {?} modelValue
-   * @returns {Date} a 'guarded' modelValue
+   * @returns {Date | undefined} a 'guarded' modelValue
    */
   static __getSyncDownValue(modelValue) {
     const isDate = new IsDate();

--- a/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
@@ -360,7 +360,17 @@ describe('<lion-input-datepicker>', () => {
         expect(el.__calendarMaxDate.toString()).to.equal(new Date('2019/07/15').toString());
       });
 
-      it('should validate default value', async () => {
+      it('should show error on invalid date passed to modelValue', async () => {
+        const myDate = new Date('foo');
+        const el = await fixture(html`
+          <lion-input-datepicker .modelValue="${myDate}"></lion-input-datepicker>
+        `);
+        expect(el.hasFeedbackFor).to.include('error');
+        expect(el.validationStates).to.have.property('error');
+        expect(el.validationStates.error).to.have.property('IsDate');
+      });
+
+      it('should show error on date with invalid format passed to modelValue', async () => {
         const myDate = new Date('30/01/2022');
         const el = await fixture(html`
           <lion-input-datepicker .modelValue="${myDate}"></lion-input-datepicker>

--- a/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
@@ -360,6 +360,16 @@ describe('<lion-input-datepicker>', () => {
         expect(el.__calendarMaxDate.toString()).to.equal(new Date('2019/07/15').toString());
       });
 
+      it('should validate default value', async () => {
+        const myDate = new Date('30/01/2022');
+        const el = await fixture(html`
+          <lion-input-datepicker .modelValue="${myDate}"></lion-input-datepicker>
+        `);
+        expect(el.hasFeedbackFor).to.include('error');
+        expect(el.validationStates).to.have.property('error');
+        expect(el.validationStates.error).to.have.property('IsDate');
+      });
+
       /**
        * Not in scope:
        * - min/max attr (like platform has): could be added in future if observers needed


### PR DESCRIPTION
## What I did

1. Refactored `LionInputDate` to use only one method of date validation
2. Fixed initial date validation in `LionInputDatePicker` that caused Issue: #1812 
3. Updated `LionInputDate` tests
4. Updated `LionInputDate` docs
