### PR TITLE
Feat/workflow improvement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     steps:
       - uses: google/wireit@setup-github-actions-caching/v1
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
       - name: Setup Node.js 16.x
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 16.x
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,18 +3,23 @@ name: Verify changes
 on: pull_request
 
 jobs:
+  setup-common-steps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - uses: google/wireit@setup-github-actions-caching/v1
+
   verify:
     name: Verify changes
     runs-on: ubuntu-latest
+    needs: setup-common-steps
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-
       - name: Sanity check
         run: node ./scripts/lock-scan.js
 
       - name: Setup Node 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16.x
 
@@ -30,12 +35,10 @@ jobs:
   browser-tests:
     name: Browser tests
     runs-on: ubuntu-latest
+    needs: setup-common-steps
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-
       - name: Setup Node 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: 16.x
 
@@ -49,17 +52,15 @@ jobs:
 
   node-tests:
     name: Node tests
+    needs: setup-common-steps
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [16.x]
         os: [ubuntu-latest]
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
-
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -78,11 +79,10 @@ jobs:
         node-version: [16.x]
         os: [windows-latest]
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
-      - uses: actions/checkout@v2
+      - needs: setup-common-steps
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,7 +3,7 @@ name: Verify changes
 on: pull_request
 
 jobs:
-  setup-common-steps:
+  init:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -7,19 +7,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: google/wireit@setup-github-actions-caching/v1
 
   verify:
     name: Verify changes
     runs-on: ubuntu-latest
-    needs: setup-common-steps
+    needs: init
     steps:
       - name: Sanity check
         run: node ./scripts/lock-scan.js
 
       - name: Setup Node 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
@@ -35,10 +35,10 @@ jobs:
   browser-tests:
     name: Browser tests
     runs-on: ubuntu-latest
-    needs: setup-common-steps
+    needs: init
     steps:
       - name: Setup Node 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 
@@ -52,7 +52,7 @@ jobs:
 
   node-tests:
     name: Node tests
-    needs: setup-common-steps
+    needs: init
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -79,10 +79,10 @@ jobs:
         node-version: [16.x]
         os: [windows-latest]
     steps:
-      - needs: setup-common-steps
+      - needs: init
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## What I did

1. Updated the versions of actions/setup-node and actions/checkout in the release.yml file. 
2. Updated the `verify.yml` file to include the setup-common-steps job. The setup-common-steps job is responsible for setting up the common steps required for the verify workflow. By adding this job, we ensure that the necessary setup is performed before running the verify job.

The update includes the following changes:

Added the setup-common-steps job to the jobs section.
Added the needs keyword to the verify, browser-tests, node-tests, and node-tests-windows jobs, specifying that they depend on the setup-common-steps job.

