### PR TITLE
fix: autocomplete for combobox

### DIFF
--- a/.changeset/unlucky-owls-search.md
+++ b/.changeset/unlucky-owls-search.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Fixed autocomplete feature for the lion-combobox component. It used to autoselect a wrong item

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -953,6 +953,9 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(LionListbox)) {
     if (autoselect && !hasAutoFilled && !this.multipleChoice) {
       // This means there is no match for checkedIndex
       this.setCheckedIndex(-1);
+      if (prevValue !== curValue) {
+        this.activeIndex = -1;
+      }
       this.modelValue = this.parser(inputValue);
     }
 

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1304,6 +1304,47 @@ describe('lion-combobox', () => {
       ]);
     });
 
+    it('doesnt autocomplete when there is no match for "mak"', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo">
+            <lion-option .choiceValue="${'Mango'}">Mango</lion-option>
+            <lion-option .choiceValue="${'Lemon'}">Lemon</lion-option>
+            <lion-option .choiceValue="${'Apple'}">Apple</lion-option>
+          </lion-combobox>
+        `)
+      );
+      const { _inputNode } = getComboboxMembers(el);
+      mimicUserTypingAdvanced(el, ['m', 'a', 'k']);
+      await el.updateComplete;
+      mimicKeyPress(_inputNode, 'Enter');
+      await el.updateComplete;
+      await el.updateComplete;
+      expect(_inputNode.value).to.equal('Mak');
+    });
+
+    it('doesnt autocomplete when there is no match for "mo"', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo">
+            <lion-option .choiceValue="${'Mango'}">Mango</lion-option>
+            <lion-option .choiceValue="${'Lemon'}">Lemon</lion-option>
+            <lion-option .choiceValue="${'Apple'}">Apple</lion-option>
+          </lion-combobox>
+        `)
+      );
+      const { _inputNode } = getComboboxMembers(el);
+      mimicUserTypingAdvanced(el, ['m', 'o', 'Backspace', 'Backspace', 'm', 'o']);
+      await el.updateComplete;
+      await el.updateComplete;
+      await el.updateComplete;
+      await el.updateComplete;
+      mimicKeyPress(_inputNode, 'Enter');
+      await el.updateComplete;
+      await el.updateComplete;
+      expect(_inputNode.value).to.equal('Mo');
+    });
+
     it('does not filter options when autocomplete is "inline"', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1304,7 +1304,7 @@ describe('lion-combobox', () => {
       ]);
     });
 
-    it('doesnt autocomplete when there is no match for "mak"', async () => {
+    it('does not autocomplete on [Enter] when textbox content does not match options', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`
           <lion-combobox name="foo">
@@ -1323,7 +1323,7 @@ describe('lion-combobox', () => {
       expect(_inputNode.value).to.equal('Mak');
     });
 
-    it('doesnt autocomplete when there is no match for "mo"', async () => {
+    it('does not autocomplete on [Enter] when textbox content does not match options and content was cleared via [Backspace]', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`
           <lion-combobox name="foo">


### PR DESCRIPTION
This pull request fixes a bug which I noticed in the `lion-combobox` component. First I will describe a bug and then there will be a section with explanation regarding the PR itself.

# Bug description
Autocomplete feature is not being stable in multiple cases.

## Case 1
### Steps to reproduce

* Navigate to https://lion-web.netlify.app/components/combobox/use-cases/#validation (`Validation` section)
* Type `m` and wait until `Mango` autocompletion happens
* Type one more symbol `o` and wait until autocompletion disappears
* Type backspace 2 times to erase `mo`
* Type `m` and wait until `Mango` autocompletion happens
* Type one more symbol `o` and wait until autocompletion disappears
* Hit `Enter`

#### Actual result
The autocomplete feature replaces `mo` to `Mango`
#### Expected result
Autocompletion should not happen since there are no words in the combobox list which starts from `mo`

### A gif with example
![combobox_mo](https://github.com/ing-bank/lion/assets/8991129/6f871548-3aac-4c57-b4f2-ad13cd16590e)

## Case 2
### Steps to reproduce

* Navigate to https://lion-web.netlify.app/components/combobox/use-cases/#validation (`Validation` section)
* Type `m` and wait until `Mango` autocompletion happens
* Type one more symbol `a` and wait until `Mango` autocompletion happens
* Type one more symbol `k` and wait until autocompletion disappears
* Hit `Enter`

#### Actual result
The autocomplete feature replaces `mak` to `Mango`
#### Expected result
Autocompletion should not happen since there are no words in the combobox list which starts from `mak`

### A gif with example
![combobox_mak](https://github.com/ing-bank/lion/assets/8991129/1352e6ce-d7b7-49aa-986c-39ea0b733c99)

# Pull request description
To fix the issue the `activeIndex` of the `lion-combobox` should be set to `-1` every time the unselection happens.
Note this is not the first iteration of the PR. I tried different approaches which might be more appropriate but those require more code updates and possible breaking changes which I don't want to bring without a discussion. F.e. there is [a piece of existing code](https://github.com/ing-bank/lion/blob/master/packages/ui/components/combobox/src/LionCombobox.js#L530) which sets `activeIndex` to `-1` on every popup opening which means `skip any active for all elements`, but at the same time there is a [unit test](https://github.com/ing-bank/lion/blob/master/packages/ui/components/listbox/test-suites/ListboxMixin.suite.js#L1407) which tests setting `active` property programmatically before opening the popup. It seems this test doesn't make much sense for `lion-combobox` since any the active elements become non-active as soon as a popup opens. So supporting active state with closed combobox might be not a best idea. 
If not having active elements with closed combobox is ok, then [_handleAutocompletion](https://github.com/ing-bank/lion/blob/master/packages/ui/components/combobox/src/LionCombobox.js#L1029) might not be called on initial setup. Then only thing it does before opening a combobox popup is [setting](https://github.com/ing-bank/lion/blob/master/packages/ui/components/combobox/src/LionCombobox.js#L892) `activeIndex` (this can be ditched) and [reset](https://github.com/ing-bank/lion/blob/master/packages/ui/components/combobox/src/LionCombobox.js#L956) the model (this can be moved to another function). 
Anyways we can discuss this and I can explain what I mean exactly in details.