### PR TITLE
fix: avoid JSON.parsing empty responses

### DIFF
--- a/.changeset/chilly-bananas-talk.md
+++ b/.changeset/chilly-bananas-talk.md
@@ -1,0 +1,5 @@
+---
+"@lion/ajax": patch
+---
+
+fix: avoid JSON.parsing empty responses

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -193,9 +193,11 @@ export class Ajax {
 
     /** @type {any} */
     let body = responseText;
+
     if (
-      !response.headers.get('content-type') ||
-      response.headers.get('content-type')?.includes('json')
+      body.length &&
+      (!response.headers.get('content-type') ||
+        response.headers.get('content-type')?.includes('json'))
     ) {
       try {
         body = JSON.parse(responseText);

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -221,6 +221,13 @@ describe('Ajax', () => {
       }
       expect(thrown).to.be.true;
     });
+
+    it('doesnt throw on empty response', async () => {
+      fetchStub.returns(Promise.resolve(new Response('', responseInit())));
+
+      const { response } = await ajax.fetchJson('/foo');
+      expect(response.ok);
+    });
   });
 
   describe('request and response interceptors', () => {


### PR DESCRIPTION
We saw some errors in production environment of API calls that _did_ successfully complete, but then threw an error because `ajax` is trying to call `JSON.parse("")` on an empty string, which results in: `Uncaught SyntaxError: Unexpected end of JSON input
`.