### PR TITLE
feat: parsing body for failed ajax responses

### DIFF
--- a/.changeset/quiet-insects-shake.md
+++ b/.changeset/quiet-insects-shake.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': minor
+---
+
+Parses response body automatically for fetchJson failed responses. Add test for reading out the response body in cases of a failed response in regular fetch call.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22384,7 +22384,7 @@
     },
     "packages/ajax": {
       "name": "@lion/ajax",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT"
     },
     "packages/singleton-manager": {

--- a/packages/ajax/src/AjaxFetchError.js
+++ b/packages/ajax/src/AjaxFetchError.js
@@ -2,10 +2,12 @@ export class AjaxFetchError extends Error {
   /**
    * @param {Request} request
    * @param {Response} response
+   * @param {string|Object} [body]
    */
-  constructor(request, response) {
+  constructor(request, response, body) {
     super(`Fetch request to ${request.url} failed.`);
     this.request = request;
     this.response = response;
+    this.body = body;
   }
 }


### PR DESCRIPTION
## What I did

1. Add automatic response body parsing for fetchJson failed responses
2. Add test for manually parsing body for fetch failed responses
