### PR TITLE
fix(lion-accordion): make a copy when changing expanded

### DIFF
--- a/.changeset/sixty-cycles-dance.md
+++ b/.changeset/sixty-cycles-dance.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+lion-accordion now replaces expanded with a copy when it changes on click of an invoker button.

--- a/packages/ui/components/accordion/src/LionAccordion.js
+++ b/packages/ui/components/accordion/src/LionAccordion.js
@@ -424,7 +424,7 @@ export class LionAccordion extends LitElement {
    * @private
    */
   __toggleExpanded(value) {
-    const { expanded } = this;
+    const expanded = [...this.expanded];
     const index = expanded.indexOf(value);
 
     if (index === -1) {

--- a/packages/ui/components/accordion/test/lion-accordion.test.js
+++ b/packages/ui/components/accordion/test/lion-accordion.test.js
@@ -80,6 +80,14 @@ describe('<lion-accordion>', () => {
       ).to.equal('invoker 1');
     });
 
+    it('updates expanded with a new array when an invoker is clicked', async () => {
+      const el = /** @type {LionAccordion} */ (await fixture(basicAccordion));
+      const invokers = getInvokers(el);
+      const oldExpanded = el.expanded;
+      invokers[1].firstElementChild?.dispatchEvent(new Event('click'));
+      expect(el.expanded).to.not.equal(oldExpanded);
+    });
+
     it('has [expanded] on current expanded invoker which serves as styling hook', async () => {
       const el = /** @type {LionAccordion} */ (await fixture(basicAccordion));
       const invokers = getInvokers(el);


### PR DESCRIPTION
## What I did

1. When an invoker button is clicked we make a copy of the expanded array, manipulate that and replace the old expanded array with the new one. This allows for an easy comparison to verify that expanded has changed, which is required when trying to use the component in vue.
2. This fixes https://github.com/ing-bank/lion/issues/2046
