### PR TITLE
fix: clone response when reading the response for error

### DIFF
--- a/.changeset/old-camels-deliver.md
+++ b/.changeset/old-camels-deliver.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+Clone response before reading and parsing the body.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22384,7 +22384,7 @@
     },
     "packages/ajax": {
       "name": "@lion/ajax",
-      "version": "1.1.4",
+      "version": "1.2.0",
       "license": "MIT"
     },
     "packages/singleton-manager": {
@@ -22393,7 +22393,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.0.4",

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -203,7 +203,8 @@ export class Ajax {
    * @returns {Promise<string|Object>}
    */
   async __parseBody(response) {
-    let responseText = await response.text();
+    // clone the response, so the consumer can also read it out manually as well
+    let responseText = await response.clone().text();
 
     const { jsonPrefix } = this.__config;
     if (typeof jsonPrefix === 'string' && responseText.startsWith(jsonPrefix)) {

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -215,6 +215,8 @@ describe('Ajax', () => {
         expect(_e.request).to.be.an.instanceOf(Request);
         expect(_e.response).to.be.an.instanceOf(Response);
         expect(_e.body).to.equal('my response');
+        const bodyFromResponse = await _e.response.text();
+        expect(bodyFromResponse).to.equal('my response');
         thrown = true;
       }
       expect(thrown).to.be.true;


### PR DESCRIPTION
## What I did

1. Fix a regression that I introduced by reading out the response. People were doing error.response.text() themselves, and now they get an error that the body stream has already been read, because in fetchJson I added the feature that it reads out the body for you and puts it on error.body already.
