### PR TITLE
fix(lion-accordion): Navigating with tab confuses the arrow key navigation

### DIFF
--- a/.changeset/stale-tips-begin.md
+++ b/.changeset/stale-tips-begin.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Handle focusin event in invokers in LionAccordion. Fix tabbing issues.

--- a/packages/ui/components/accordion/src/LionAccordion.js
+++ b/packages/ui/components/accordion/src/LionAccordion.js
@@ -256,6 +256,9 @@ export class LionAccordion extends LitElement {
    */
   __createInvokerFocusHandler(index) {
     return () => {
+      if (index === this.focusedIndex) {
+        return;
+      }
       this.focusedIndex = index;
     };
   }

--- a/packages/ui/components/accordion/src/LionAccordion.js
+++ b/packages/ui/components/accordion/src/LionAccordion.js
@@ -10,6 +10,7 @@ import { uuid } from '@lion/ui/core.js';
  * @property {HTMLElement} content content node
  * @property {(event: Event) => unknown} clickHandler executed on click event
  * @property {(event: Event) => unknown} keydownHandler executed on keydown event
+ * @property {(event: Event) => unknown} focusHandler executed on focusin event
  */
 
 /**
@@ -197,6 +198,7 @@ export class LionAccordion extends LitElement {
         content,
         clickHandler: this.__createInvokerClickHandler(index),
         keydownHandler: this.__handleInvokerKeydown.bind(this),
+        focusHandler: this.__createInvokerFocusHandler(index),
       };
       this._setupContent(entry);
       this._setupInvoker(entry);
@@ -245,6 +247,16 @@ export class LionAccordion extends LitElement {
     return () => {
       this.focusedIndex = index;
       this.__toggleExpanded(index);
+    };
+  }
+
+  /**
+   * @param {number} index
+   * @private
+   */
+  __createInvokerFocusHandler(index) {
+    return () => {
+      this.focusedIndex = index;
     };
   }
 
@@ -304,7 +316,7 @@ export class LionAccordion extends LitElement {
    * @protected
    */
   _setupInvoker(entry) {
-    const { invoker, uid, index, clickHandler, keydownHandler } = entry;
+    const { invoker, uid, index, clickHandler, keydownHandler, focusHandler } = entry;
     invoker.style.setProperty('order', `${index + 1}`);
     const firstChild = invoker.firstElementChild;
     if (firstChild) {
@@ -312,6 +324,7 @@ export class LionAccordion extends LitElement {
       firstChild.setAttribute('aria-controls', `content-${uid}`);
       firstChild.addEventListener('click', clickHandler);
       firstChild.addEventListener('keydown', keydownHandler);
+      firstChild.addEventListener('focusin', focusHandler);
     }
   }
 
@@ -320,13 +333,14 @@ export class LionAccordion extends LitElement {
    * @protected
    */
   _cleanInvoker(entry) {
-    const { invoker, clickHandler, keydownHandler } = entry;
+    const { invoker, clickHandler, keydownHandler, focusHandler } = entry;
     const firstChild = invoker.firstElementChild;
     if (firstChild) {
       firstChild.removeAttribute('id');
       firstChild.removeAttribute('aria-controls');
       firstChild.removeEventListener('click', clickHandler);
       firstChild.removeEventListener('keydown', keydownHandler);
+      firstChild.removeEventListener('focusin', focusHandler);
     }
   }
 

--- a/packages/ui/components/accordion/test/lion-accordion.test.js
+++ b/packages/ui/components/accordion/test/lion-accordion.test.js
@@ -213,6 +213,17 @@ describe('<lion-accordion>', () => {
       el.focusedIndex = 1;
       expect(spy).to.have.been.calledOnce;
     });
+
+    it('tabbing sets the focusedIndex correctly', async () => {
+      const el = /** @type {LionAccordion} */ (await fixture(basicAccordion));
+      const invokers = getInvokers(el);
+      el.focusedIndex = 0;
+      expect(el.focusedIndex).to.equal(0);
+      invokers[2].firstElementChild?.dispatchEvent(new Event('focusin'));
+      expect(el.focusedIndex).to.equal(2);
+      invokers[1].firstElementChild?.dispatchEvent(new Event('focusin'));
+      expect(el.focusedIndex).to.equal(1);
+    });
   });
 
   describe('Accordion Contents (slot=content)', () => {


### PR DESCRIPTION
## What I did

Modifying the LionAccordion component to handle the focusin event in the invokers. The focusedIndex is always changed to the focused element and now navigating with the tab key does not confuse the arrow key navigation.

Corresponding issue and the problem explanation: fixes https://github.com/ing-bank/lion/issues/2055
