### PR TITLE
fix(lion-calendar): Make disabled dates not selectable via keyboard navigation

### DIFF
--- a/.changeset/late-pianos-draw.md
+++ b/.changeset/late-pianos-draw.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Make disabled date buttons not selectable via keyboard navigation in LionCalendar.

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -835,7 +835,7 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
    * @private
    */
   __dayButtonSelection(el) {
-    if (isDayButton(el)) {
+    if (isDayButton(el) && !isDisabledDayButton(el)) {
       this.__dateSelectedByUser(el.date);
     }
   }

--- a/packages/ui/components/calendar/test/lion-calendar.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar.test.js
@@ -221,7 +221,7 @@ describe('<lion-calendar>', () => {
       expect(isSameDate(el.centralDate, new Date('2019/06/15'))).to.be.true;
     });
 
-    it('sends event "user-selected-date-changed" when user selects a date', async () => {
+    it('sends event "user-selected-date-changed" when user selects a date via mouse', async () => {
       const dateChangedSpy = sinon.spy();
       const el = await fixture(html`
         <lion-calendar
@@ -239,7 +239,7 @@ describe('<lion-calendar>', () => {
       ).to.equal(true);
     });
 
-    it('doesn\'t send event "user-selected-date-changed" when user selects a disabled date', async () => {
+    it('doesn\'t send event "user-selected-date-changed" when user selects a disabled date via mouse', async () => {
       const dateChangedSpy = sinon.spy();
       const disable15th = /** @param {Date} d */ d => d.getDate() === 15;
       const el = await fixture(html`
@@ -252,6 +252,57 @@ describe('<lion-calendar>', () => {
       const elObj = new CalendarObject(el);
       elObj.getDayEl(15).click();
       await el.updateComplete;
+      expect(dateChangedSpy.called).to.equal(false);
+      expect(isSameDate(/** @type {Date} */ (el.selectedDate), new Date('2000/12/12'))).to.be.true;
+    });
+
+    it.skip('sends event "user-selected-date-changed" when user selects a date via [Enter]', async () => {
+      /**
+       * TODO fix me
+       * The dispatchEvent of [Enter] should has to be on contentWrapperElement to be called
+       * But to get "selected" a check is done if the action comes from a button.
+       */
+      const dateChangedSpy = sinon.spy();
+      const el = await fixture(html`
+        <lion-calendar
+          .selectedDate="${new Date('2000/10/12')}"
+          @user-selected-date-changed="${dateChangedSpy}"
+        ></lion-calendar>
+      `);
+      const elObj = new CalendarObject(el);
+
+      el.__contentWrapperElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+      await el.updateComplete;
+      expect(elObj.activeMonth).to.equal('October');
+      expect(elObj.activeYear).to.equal('2000');
+      expect(elObj.focusedDayObj?.monthday).to.equal(11);
+
+      el.__contentWrapperElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await el.updateComplete;
+      expect(isSameDate(/** @type {Date} */ (el.selectedDate), new Date('2000/10/11'))).to.be.true;
+      expect(dateChangedSpy.called).to.equal(true);
+    });
+
+    it('doesn\'t send event "user-selected-date-changed" when user selects a disabled date via [Enter]', async () => {
+      const dateChangedSpy = sinon.spy();
+      const el = await fixture(html`
+        <lion-calendar
+          .selectedDate="${new Date('2000/10/12')}"
+          .minDate="${new Date('2000/10/12')}"
+          @user-selected-date-changed="${dateChangedSpy}"
+        ></lion-calendar>
+      `);
+      const elObj = new CalendarObject(el);
+
+      el.__contentWrapperElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft' }));
+      await el.updateComplete;
+      expect(elObj.activeMonth).to.equal('October');
+      expect(elObj.activeYear).to.equal('2000');
+      expect(elObj.focusedDayObj?.monthday).to.equal(11);
+
+      el.__contentWrapperElement?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }));
+      await el.updateComplete;
+      expect(isSameDate(/** @type {Date} */ (el.selectedDate), new Date('2000/10/12'))).to.be.true;
       expect(dateChangedSpy.called).to.equal(false);
     });
 
@@ -1191,35 +1242,6 @@ describe('<lion-calendar>', () => {
             expect(elObj.activeMonth).to.equal('December');
             expect(elObj.activeYear).to.equal('2000');
             expect(elObj.focusedDayObj?.monthday).to.equal(26);
-          });
-
-          it('disabled dates cannot be select', async () => {
-            const actSelectedDate = new Date('2000/10/12');
-
-            const el = await fixture(html`
-              <lion-calendar
-                .selectedDate="${actSelectedDate}"
-                .minDate="${new Date('2000/10/12')}"
-              >
-              </lion-calendar>
-            `);
-            const elObj = new CalendarObject(el);
-            expect(elObj.activeMonth).to.equal('October');
-            expect(elObj.activeYear).to.equal('2000');
-
-            el.__contentWrapperElement?.dispatchEvent(
-              new KeyboardEvent('keydown', { key: 'ArrowLeft' }),
-            );
-            await el.updateComplete;
-            expect(elObj.activeMonth).to.equal('October');
-            expect(elObj.activeYear).to.equal('2000');
-            expect(elObj.focusedDayObj?.monthday).to.equal(11);
-
-            el.__contentWrapperElement?.dispatchEvent(
-              new KeyboardEvent('keydown', { key: 'Enter' }),
-            );
-            await el.updateComplete;
-            expect(el.selectedDate).to.equal(actSelectedDate);
           });
         });
       });

--- a/packages/ui/components/calendar/test/lion-calendar.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar.test.js
@@ -1192,6 +1192,35 @@ describe('<lion-calendar>', () => {
             expect(elObj.activeYear).to.equal('2000');
             expect(elObj.focusedDayObj?.monthday).to.equal(26);
           });
+
+          it('disabled dates cannot be select', async () => {
+            const actSelectedDate = new Date('2000/10/12');
+
+            const el = await fixture(html`
+              <lion-calendar
+                .selectedDate="${actSelectedDate}"
+                .minDate="${new Date('2000/10/12')}"
+              >
+              </lion-calendar>
+            `);
+            const elObj = new CalendarObject(el);
+            expect(elObj.activeMonth).to.equal('October');
+            expect(elObj.activeYear).to.equal('2000');
+
+            el.__contentWrapperElement?.dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'ArrowLeft' }),
+            );
+            await el.updateComplete;
+            expect(elObj.activeMonth).to.equal('October');
+            expect(elObj.activeYear).to.equal('2000');
+            expect(elObj.focusedDayObj?.monthday).to.equal(11);
+
+            el.__contentWrapperElement?.dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'Enter' }),
+            );
+            await el.updateComplete;
+            expect(el.selectedDate).to.equal(actSelectedDate);
+          });
         });
       });
 


### PR DESCRIPTION
## What I did

After navigating with the keyboard, when pressing enter it was not checked if the day button had been disabled or not. The corresponding tests were not covering this case, so I created a test.

Corresponding issue and the problem explanation: fixes https://github.com/ing-bank/lion/issues/2057
