### PR TITLE
fix(progress-indicator): accept 0 as a valid value

### DIFF
--- a/.changeset/early-bats-dance.md
+++ b/.changeset/early-bats-dance.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(progress-indicator): accept 0 as a valid value

--- a/packages/ui/components/progress-indicator/src/LionProgressIndicator.js
+++ b/packages/ui/components/progress-indicator/src/LionProgressIndicator.js
@@ -150,7 +150,7 @@ export class LionProgressIndicator extends LocalizeMixin(LitElement) {
       }
     } else {
       if (changedProperties.has('value')) {
-        if (!this.value || typeof this.value !== 'number') {
+        if ((!this.value && this.value !== 0) || typeof this.value !== 'number') {
           this.removeAttribute('value');
         } else if (this.value < this.min) {
           this.value = this.min;

--- a/packages/ui/components/progress-indicator/test/lion-progress-indicator.test.js
+++ b/packages/ui/components/progress-indicator/test/lion-progress-indicator.test.js
@@ -149,7 +149,9 @@ describe('lion-progress-indicator', () => {
       const el = await fixture(
         html`<lion-progress-indicator value="30"></lion-progress-indicator> `,
       );
-      el.setAttribute('value', '');
+      // when the attribute is defined, lit set the property to Number(attributeValue)
+      // this means, setting the value to an empty string will be valid because Number('') is 0
+      el.setAttribute('value', 'invalid-value');
       await el.updateComplete;
       expect(el.indeterminate).to.be.true;
       await el.updateComplete;
@@ -157,6 +159,21 @@ describe('lion-progress-indicator', () => {
       expect(el.hasAttribute('aria-valuemin')).to.be.false;
       expect(el.hasAttribute('aria-valuemax')).to.be.false;
       expect(el.getAttribute('aria-label')).to.equal('Loading');
+    });
+
+    it('can update value to 0', async () => {
+      const el = await fixture(
+        html`<lion-progress-indicator value="0"></lion-progress-indicator> `,
+      );
+      await el.updateComplete;
+      expect(el.indeterminate).to.be.false;
+    });
+
+    // empty string will be converted to 0 by lit because value is declared as number
+    it('can update value to 0 if the set value is empty string', async () => {
+      const el = await fixture(html`<lion-progress-indicator value=""></lion-progress-indicator> `);
+      await el.updateComplete;
+      expect(el.indeterminate).to.be.false;
     });
   });
 


### PR DESCRIPTION
## What I did

1. Updated the condition in removing the value attribute.
2. When the value is set to 0, currently, without this fix, the value is being removed because the condition is **!this.value || typeof this.value !== 'number'** => !0 is equal to true that's why the progress bar value is being removed (**this.removeAttribute('value')**)
3. I updated the condition to check if the value is 0, it will be accepted and the value attribute will not be removed.
4. I also added and updated the unit test. The current unit test on setting the value of the value attribute to an empty string will fail because according to this [documentation](https://lit.dev/docs/components/properties/), on the convertion for Number (attribute to property) **_If the element has the corresponding attribute, set the property to Number(attributeValue)_**. So, if the value is set to '', it will be Number('') which is equal to 0.
