### PR TITLE
fix(calendar): focusCentralDate function should only use buttons inside the dates table

### DIFF
--- a/.changeset/khaki-wasps-worry.md
+++ b/.changeset/khaki-wasps-worry.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[calendar] focusCentralDate function should only use buttons inside the dates table

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -250,7 +250,10 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
   }
 
   focusCentralDate() {
-    const button = /** @type {HTMLElement} */ (this.shadowRoot?.querySelector('[tabindex="0"]'));
+    const datesTable = /** @type {HTMLElement} */ (
+      this.shadowRoot?.querySelector('#js-content-wrapper')
+    );
+    const button = /** @type {HTMLElement} */ (datesTable.querySelector('[tabindex="0"]'));
     button.focus();
     this.__focusedDate = this.centralDate;
   }


### PR DESCRIPTION
## What I did

1. If other buttons outside the dataTable contains `[tabindex=0]`, then the `focusCentralDate` function may set focus to the wrong element. This fix removes that mistake.
