### PR TITLE
fix: export ajax types

### DIFF
--- a/.changeset/long-actors-trade.md
+++ b/.changeset/long-actors-trade.md
@@ -1,0 +1,5 @@
+---
+"@lion/ajax": patch
+---
+
+fix: export ajax types

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -72,14 +72,19 @@ export class Ajax {
       this.addRequestInterceptor(createXsrfRequestInterceptor(xsrfCookieName, xsrfHeaderName));
     }
 
-    const { cacheOptions } = this.__config;
-    if (cacheOptions.useCache || this.__config.addCaching) {
-      const { cacheRequestInterceptor, cacheResponseInterceptor } = createCacheInterceptors(
-        cacheOptions.getCacheIdentifier,
-        cacheOptions,
-      );
-      this.addRequestInterceptor(cacheRequestInterceptor);
-      this.addResponseInterceptor(cacheResponseInterceptor);
+    // eslint-disable-next-line prefer-destructuring
+    const cacheOptions = /** @type {import('@lion/ajax').CacheOptionsWithIdentifier} */ (
+      this.__config.cacheOptions
+    );
+    if ((cacheOptions && cacheOptions.useCache) || this.__config.addCaching) {
+      if (cacheOptions.getCacheIdentifier) {
+        const { cacheRequestInterceptor, cacheResponseInterceptor } = createCacheInterceptors(
+          cacheOptions.getCacheIdentifier,
+          cacheOptions,
+        );
+        this.addRequestInterceptor(cacheRequestInterceptor);
+        this.addResponseInterceptor(cacheResponseInterceptor);
+      }
     }
   }
 

--- a/packages/ajax/src/index.js
+++ b/packages/ajax/src/index.js
@@ -10,3 +10,23 @@ export {
 
 // globally available instance
 export const ajax = new Ajax();
+
+/**
+ * @typedef {import('../types/types.js').LionRequestInit} LionRequestInit
+ * @typedef {import('../types/types.js').AjaxConfig} AjaxConfig
+ * @typedef {import('../types/types.js').RequestInterceptor} RequestInterceptor
+ * @typedef {import('../types/types.js').ResponseInterceptor} ResponseInterceptor
+ * @typedef {import('../types/types.js').CacheConfig} CacheConfig
+ * @typedef {import('../types/types.js').RequestIdFunction} RequestIdFunction
+ * @typedef {import('../types/types.js').CacheOptions} CacheOptions
+ * @typedef {import('../types/types.js').CacheOptionsWithIdentifier} CacheOptionsWithIdentifier
+ * @typedef {import('../types/types.js').ValidatedCacheOptions} ValidatedCacheOptions
+ * @typedef {import('../types/types.js').CacheRequestExtension} CacheRequestExtension
+ * @typedef {import('../types/types.js').CacheResponseRequest} CacheResponseRequest
+ * @typedef {import('../types/types.js').CacheResponseExtension} CacheResponseExtension
+ * @typedef {import('../types/types.js').CacheRequest} CacheRequest
+ * @typedef {import('../types/types.js').CacheResponse} CacheResponse
+ * @typedef {import('../types/types.js').CachedRequests} CachedRequests
+ * @typedef {import('../types/types.js').CachedRequestInterceptor} CachedRequestInterceptor
+ * @typedef {import('../types/types.js').CachedResponseInterceptor} CachedResponseInterceptor
+ */

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -72,7 +72,10 @@ describe('Ajax', () => {
       // TODO: fix AjaxConfig types => e.g. create FullAjaxConfig with everything "mandatory" and then AjaxConfig (= Partial of it) for user
       // @ts-ignore
       const ajax1 = new Ajax(config);
-      const defaultCacheIdentifierFunction = ajax1.options?.cacheOptions?.getCacheIdentifier;
+
+      const defaultCacheIdentifierFunction = /** @type {() =>  void} */ (
+        ajax1.options?.cacheOptions?.getCacheIdentifier
+      );
       // Then
       expect(defaultCacheIdentifierFunction).not.to.be.undefined;
       expect(defaultCacheIdentifierFunction).to.be.a('function');

--- a/packages/ajax/types/types.ts
+++ b/packages/ajax/types/types.ts
@@ -11,12 +11,12 @@ export interface LionRequestInit extends Omit<RequestInit, 'body'> {
 }
 
 export interface AjaxConfig {
-  addAcceptLanguage: boolean;
-  addCaching: boolean;
-  xsrfCookieName: string | null;
-  xsrfHeaderName: string | null;
-  cacheOptions: CacheOptionsWithIdentifier;
-  jsonPrefix: string;
+  addAcceptLanguage?: boolean;
+  addCaching?: boolean;
+  xsrfCookieName?: string | null;
+  xsrfHeaderName?: string | null;
+  cacheOptions?: CacheOptionsWithIdentifier;
+  jsonPrefix?: string;
 }
 
 export type RequestInterceptor = (request: Request) => Promise<Request | Response>;
@@ -46,7 +46,7 @@ export interface CacheOptions {
 }
 
 export interface CacheOptionsWithIdentifier extends CacheOptions {
-  getCacheIdentifier: () => string;
+  getCacheIdentifier?: () => string;
 }
 
 export interface ValidatedCacheOptions extends CacheOptions {


### PR DESCRIPTION
## What I did

1. The types in `packages/ajax/types/types.ts` arent reachable via the `index.d.ts`, this exports them and makes the available to import
