### PR TITLE
fix(lion-calendar): Make calendar buttons selectable on firefox throu…

### DIFF
--- a/.changeset/yellow-timers-poke.md
+++ b/.changeset/yellow-timers-poke.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+lion-calendar: when determining if user interacted with a day button, use event.composedPath()[0] instead of event.target to fix Firefox 111+ issue

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -799,7 +799,7 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
    * @private
    */
   __clickDateDelegation(ev) {
-    const el = /** @type {HTMLElement & { date: Date }} */ (ev.target);
+    const el = /** @type {HTMLElement & { date: Date }} */ (ev.composedPath()[0]);
     if (isDayButton(el) && !isDisabledDayButton(el)) {
       this.__dateSelectedByUser(el.date);
     }
@@ -866,7 +866,9 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     switch (ev.key) {
       case ' ':
       case 'Enter':
-        this.__dayButtonSelection(/** @type {HTMLElement & { date: Date }} */ (ev.target));
+        this.__dayButtonSelection(
+          /** @type {HTMLElement & { date: Date }} */ (ev.composedPath()[0]),
+        );
         break;
       case 'ArrowUp':
         this.__modifyDate(-7, { dateType: '__focusedDate', type: 'Date' });


### PR DESCRIPTION
…gh datepicker

## What I did

Fix #2051 by incorporating the previously (accidentally?) overwritten fix for it (#1965), but this time additionally fixing keyboard selection as well.