### PR TITLE
fix: make `fetchJson` return type generic instead of `Object`

### DIFF
--- a/.changeset/early-steaks-attend.md
+++ b/.changeset/early-steaks-attend.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': minor
+---
+
+make return type for `fetchJson` generic

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -175,9 +175,10 @@ export class Ajax {
    *  - Deserializing response payload as JSON
    *  - Adding the correct Content-Type and Accept headers
    *
+   * @template T
    * @param {RequestInfo} info
    * @param {LionRequestInit} [init]
-   * @returns {Promise<{ response: Response, body: string|Object }>}
+   * @returns {Promise<{ response: Response, body: string | T }>}
    */
   async fetchJson(info, init) {
     const lionInit = {
@@ -204,8 +205,9 @@ export class Ajax {
   }
 
   /**
+   * @template T
    * @param {Response} response
-   * @returns {Promise<string|Object>}
+   * @returns {Promise<string|T>}
    */
   async __parseBody(response) {
     // clone the response, so the consumer can also read it out manually as well


### PR DESCRIPTION
## What I did

1. Makes the return type for `fetchJson` generic instead of `Object`. I did this only for `fetchJson`, and not for `fetch`, because for `fetch` we want the actual `Promise<Response>`, and we dont do any transformation there; for `fetchJson` we try to parse the response, so it makes more sense to support a generic here
