### PR TITLE
fix(combobox): Fix search issues when modifying the middle of the input word

### DIFF
--- a/.changeset/nine-icons-end.md
+++ b/.changeset/nine-icons-end.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Fix search issues when modifying the middle of the input word in LionCombobox.

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -850,7 +850,7 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(LionListbox)) {
    */
   _handleAutocompletion() {
     const isSelectionEmpty = this._inputNode.selectionStart === this._inputNode.selectionEnd;
-    const hasSelection = isSelectionEmpty ? false : this._inputNode.value.length !== this._inputNode.selectionStart;
+    const hasSelection = !isSelectionEmpty && this._inputNode.value.length !== this._inputNode.selectionStart;
 
     const inputValue = this._inputNode.value;
     const inputSelectionStart = this._inputNode.selectionStart;

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -849,7 +849,8 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(LionListbox)) {
    * @protected
    */
   _handleAutocompletion() {
-    const hasSelection = this._inputNode.value.length !== this._inputNode.selectionStart;
+    const isSelectionEmpty = this._inputNode.selectionStart === this._inputNode.selectionEnd;
+    const hasSelection = isSelectionEmpty ? false : this._inputNode.value.length !== this._inputNode.selectionStart;
 
     const inputValue = this._inputNode.value;
     const inputSelectionStart = this._inputNode.selectionStart;

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -850,7 +850,8 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(LionListbox)) {
    */
   _handleAutocompletion() {
     const isSelectionEmpty = this._inputNode.selectionStart === this._inputNode.selectionEnd;
-    const hasSelection = !isSelectionEmpty && this._inputNode.value.length !== this._inputNode.selectionStart;
+    const hasSelection =
+      !isSelectionEmpty && this._inputNode.value.length !== this._inputNode.selectionStart;
 
     const inputValue = this._inputNode.value;
     const inputSelectionStart = this._inputNode.selectionStart;

--- a/packages/ui/components/combobox/test-helpers/combobox-helpers.js
+++ b/packages/ui/components/combobox/test-helpers/combobox-helpers.js
@@ -75,26 +75,20 @@ export async function mimicUserTypingAdvanced(el, values) {
       if (key === 'Backspace') {
         if (hasSelection) {
           _inputNode.value =
-            _inputNode.value.slice(0, selectionStart) +
-            _inputNode.value.slice(selectionEnd);
+            _inputNode.value.slice(0, selectionStart) + _inputNode.value.slice(selectionEnd);
           cursorPosition = selectionStart;
         } else if (cursorPosition > 0) {
           _inputNode.value =
-            _inputNode.value.slice(0, cursorPosition - 1) +
-            _inputNode.value.slice(cursorPosition);
+            _inputNode.value.slice(0, cursorPosition - 1) + _inputNode.value.slice(cursorPosition);
           cursorPosition -= 1;
         }
       } else if (hasSelection) {
         _inputNode.value =
-          _inputNode.value.slice(0, selectionStart) +
-          key +
-          _inputNode.value.slice(selectionEnd);
+          _inputNode.value.slice(0, selectionStart) + key + _inputNode.value.slice(selectionEnd);
         cursorPosition = selectionStart + key.length;
       } else {
         _inputNode.value =
-          _inputNode.value.slice(0, cursorPosition) +
-          key +
-          _inputNode.value.slice(cursorPosition);
+          _inputNode.value.slice(0, cursorPosition) + key + _inputNode.value.slice(cursorPosition);
         cursorPosition += 1;
       }
 

--- a/packages/ui/components/combobox/test-helpers/combobox-helpers.js
+++ b/packages/ui/components/combobox/test-helpers/combobox-helpers.js
@@ -86,12 +86,14 @@ export async function mimicUserTypingAdvanced(el, values) {
         }
       } else if (hasSelection) {
         _inputNode.value =
-          _inputNode.value.slice(0, selectionStart) + key +
+          _inputNode.value.slice(0, selectionStart) +
+          key +
           _inputNode.value.slice(selectionEnd);
         cursorPosition = selectionStart + key.length;
       } else {
         _inputNode.value =
-          _inputNode.value.slice(0, cursorPosition) + key +
+          _inputNode.value.slice(0, cursorPosition) +
+          key +
           _inputNode.value.slice(cursorPosition);
         cursorPosition += 1;
       }

--- a/packages/ui/components/combobox/test-helpers/combobox-helpers.js
+++ b/packages/ui/components/combobox/test-helpers/combobox-helpers.js
@@ -63,39 +63,38 @@ export function mimicKeyPress(el, key) {
 export async function mimicUserTypingAdvanced(el, values) {
   const { _inputNode } = getComboboxMembers(el);
   _inputNode.dispatchEvent(new Event('focusin', { bubbles: true }));
+  let cursorPosition = _inputNode.selectionStart || 0;
 
   for (const key of values) {
     // eslint-disable-next-line no-await-in-loop, no-loop-func
     await new Promise(resolve => {
-      const hasSelection = _inputNode.selectionStart !== _inputNode.selectionEnd;
+      const selectionStart = _inputNode.selectionStart || 0;
+      const selectionEnd = _inputNode.selectionEnd || 0;
+      const hasSelection = selectionStart !== selectionEnd;
 
       if (key === 'Backspace') {
         if (hasSelection) {
-          _inputNode.value =
-            _inputNode.value.slice(
-              0,
-              _inputNode.selectionStart ? _inputNode.selectionStart : undefined,
-            ) +
-            _inputNode.value.slice(
-              _inputNode.selectionEnd ? _inputNode.selectionEnd : undefined,
-              _inputNode.value.length,
-            );
-        } else {
-          _inputNode.value = _inputNode.value.slice(0, -1);
+            _inputNode.value =
+                _inputNode.value.slice(0, selectionStart) +
+                _inputNode.value.slice(selectionEnd);
+            cursorPosition = selectionStart;
+        } else if (cursorPosition > 0) {
+            _inputNode.value =
+                _inputNode.value.slice(0, cursorPosition - 1) +
+                _inputNode.value.slice(cursorPosition);
+            cursorPosition -= 1;
         }
       } else if (hasSelection) {
         _inputNode.value =
-          _inputNode.value.slice(
-            0,
-            _inputNode.selectionStart ? _inputNode.selectionStart : undefined,
-          ) +
-          key +
-          _inputNode.value.slice(
-            _inputNode.selectionEnd ? _inputNode.selectionEnd : undefined,
-            _inputNode.value.length,
-          );
+            _inputNode.value.slice(0, selectionStart) +
+            key +
+            _inputNode.value.slice(selectionEnd);
+        cursorPosition = selectionStart + key.length;
       } else {
-        _inputNode.value += key;
+        _inputNode.value =
+            _inputNode.value.slice(0, cursorPosition) + key +
+            _inputNode.value.slice(cursorPosition);
+        cursorPosition += 1;
       }
 
       mimicKeyPress(_inputNode, key);

--- a/packages/ui/components/combobox/test-helpers/combobox-helpers.js
+++ b/packages/ui/components/combobox/test-helpers/combobox-helpers.js
@@ -74,26 +74,25 @@ export async function mimicUserTypingAdvanced(el, values) {
 
       if (key === 'Backspace') {
         if (hasSelection) {
-            _inputNode.value =
-                _inputNode.value.slice(0, selectionStart) +
-                _inputNode.value.slice(selectionEnd);
-            cursorPosition = selectionStart;
+          _inputNode.value =
+            _inputNode.value.slice(0, selectionStart) +
+            _inputNode.value.slice(selectionEnd);
+          cursorPosition = selectionStart;
         } else if (cursorPosition > 0) {
-            _inputNode.value =
-                _inputNode.value.slice(0, cursorPosition - 1) +
-                _inputNode.value.slice(cursorPosition);
-            cursorPosition -= 1;
+          _inputNode.value =
+            _inputNode.value.slice(0, cursorPosition - 1) +
+            _inputNode.value.slice(cursorPosition);
+          cursorPosition -= 1;
         }
       } else if (hasSelection) {
         _inputNode.value =
-            _inputNode.value.slice(0, selectionStart) +
-            key +
-            _inputNode.value.slice(selectionEnd);
+          _inputNode.value.slice(0, selectionStart) + key +
+          _inputNode.value.slice(selectionEnd);
         cursorPosition = selectionStart + key.length;
       } else {
         _inputNode.value =
-            _inputNode.value.slice(0, cursorPosition) + key +
-            _inputNode.value.slice(cursorPosition);
+          _inputNode.value.slice(0, cursorPosition) + key +
+          _inputNode.value.slice(cursorPosition);
         cursorPosition += 1;
       }
 

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1610,6 +1610,35 @@ describe('lion-combobox', () => {
       expect(el.checkedIndex).to.equal(0);
     });
 
+    it('filters options correctly when changing the middle of the word', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html`
+          <lion-combobox name="foo" autocomplete="inline">
+            <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
+            <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
+            <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>
+            <lion-option .choiceValue="${'Victoria Plum'}">Victoria Plum</lion-option>
+          </lion-combobox>
+        `)
+      );
+
+      mimicUserTyping(el, 'chard');
+      await el.updateComplete; // Char
+      expect(el.activeIndex).to.equal(1);
+      expect(el.checkedIndex).to.equal(1);
+
+      await mimicUserTypingAdvanced(el, ['ArrowLeft', 'Backspace']); // Chr
+      await el.updateComplete;
+
+      expect(getFilteredOptionValues(el)).to.eql([]);
+      await mimicUserTypingAdvanced(el, ['i', 'c', 'o']); // Chicor
+      await el.updateComplete;
+
+      expect(el.activeIndex).to.equal(2);
+      expect(el.checkedIndex).to.equal(2);
+      expect(getFilteredOptionValues(el)).to.eql(['Chicory']);
+    });
+
     it('computation of "user intends autofill" works correctly afer autofill', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1613,7 +1613,7 @@ describe('lion-combobox', () => {
     it('filters options correctly when changing the middle of the word', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`
-          <lion-combobox name="foo" autocomplete="both">
+          <lion-combobox name="foo" autocomplete="list" match-mode="all">
             <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
             <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
             <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>
@@ -1622,20 +1622,20 @@ describe('lion-combobox', () => {
         `)
       );
 
-      mimicUserTyping(el, 'chard');
+      const { _inputNode } = getComboboxMembers(el);
+
+      mimicUserTyping(el, 'char');
+      expect(_inputNode.value).to.equal('char');
       await el.updateComplete; // Char
-      expect(el.activeIndex).to.equal(1);
-      expect(el.checkedIndex).to.equal(1);
 
-      await mimicUserTypingAdvanced(el, ['ArrowLeft', 'Backspace']); // Chr
-      await el.updateComplete;
+      expect(getFilteredOptionValues(el)).to.eql(['Chard']);
 
-      expect(getFilteredOptionValues(el)).to.eql([]);
-      await mimicUserTypingAdvanced(el, ['i', 'c', 'o']); // Chicor
-      await el.updateComplete;
+      _inputNode.selectionStart = 3;
+      _inputNode.selectionEnd = 3;
+      await mimicUserTypingAdvanced(el, ['Backspace', 'i', 'c', 'o']);
+      await el.updateComplete; // Chicor
 
-      expect(el.activeIndex).to.equal(2);
-      expect(el.checkedIndex).to.equal(2);
+      expect(_inputNode.value).to.equal('chicor');
       expect(getFilteredOptionValues(el)).to.eql(['Chicory']);
     });
 

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1630,8 +1630,7 @@ describe('lion-combobox', () => {
 
       expect(getFilteredOptionValues(el)).to.eql(['Chard']);
 
-      _inputNode.selectionStart = 3;
-      _inputNode.selectionEnd = 3;
+      _inputNode.setSelectionRange(3, 3);
       await mimicUserTypingAdvanced(el, ['Backspace', 'i', 'c', 'o']);
       await el.updateComplete; // Chicor
 

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1613,7 +1613,7 @@ describe('lion-combobox', () => {
     it('filters options correctly when changing the middle of the word', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`
-          <lion-combobox name="foo" autocomplete="inline">
+          <lion-combobox name="foo" autocomplete="both">
             <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
             <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
             <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>


### PR DESCRIPTION
## What I did
The _handleAutocompletion recognized a selection in the input even if the selection was empty.

Corresponding issue and the problem explanation: fixes https://github.com/ing-bank/lion/issues/2084