### PR TITLE
fix(overlay): avoid calling push in iterable object to avoid error lo…

### DIFF
--- a/.changeset/forty-cats-unite.md
+++ b/.changeset/forty-cats-unite.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+avoid calling push in iterable object to avoid error loading overlays in old chromium versions

--- a/package-lock.json
+++ b/package-lock.json
@@ -22698,7 +22698,7 @@
     },
     "packages/ajax": {
       "name": "@lion/ajax",
-      "version": "1.2.1",
+      "version": "1.2.3",
       "license": "MIT"
     },
     "packages/singleton-manager": {
@@ -22707,7 +22707,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.4.0-prerelease-bypass-export-map.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.0.4",

--- a/packages/ui/components/overlays/src/utils/adopt-styles.js
+++ b/packages/ui/components/overlays/src/utils/adopt-styles.js
@@ -119,7 +119,7 @@ export function adoptStyle(renderRoot, style, { teardown = false } = {}) {
   if (!teardown) {
     // @ts-ignore
     // eslint-disable-next-line no-param-reassign
-    renderRoot.adoptedStyleSheets.push(sheet);
+    renderRoot.adoptedStyleSheets = [...renderRoot.adoptedStyleSheets, sheet];
   } else if (renderRoot.adoptedStyleSheets.includes(sheet)) {
     renderRoot.adoptedStyleSheets.splice(renderRoot.adoptedStyleSheets.indexOf(sheet), 1);
   }


### PR DESCRIPTION
…ading overlays in old chromium versions

## What I did

1. Change .push in iterator to avoid error loading overlays. This only happens in old chromium version but we support old versions. 

Resolves #2086 
