### PR TITLE
feat(lion-tabs): introduced before-selected-changed cancelable event

### DIFF
--- a/packages/ui/components/tabs/src/LionTabs.js
+++ b/packages/ui/components/tabs/src/LionTabs.js
@@ -364,6 +364,16 @@ export class LionTabs extends LitElement {
     if (value === -1) {
       return;
     }
+
+    const beforeSelectedChangedEvent = new CustomEvent('before-selected-changed', {
+      cancelable: true,
+      detail: { selectedIndex: value },
+    });
+    this.dispatchEvent(beforeSelectedChangedEvent);
+    if (beforeSelectedChangedEvent.defaultPrevented) {
+      return;
+    }
+
     const stale = this.__selectedIndex;
     this.__selectedIndex = value;
     this.__updateSelected(true);


### PR DESCRIPTION
## What I did

1. introduced "before-selected-changed" cancelable event which is dispatched before the tab change takes effect, only if the change is caused by user interaction. Calling preventDefault() in event handler prevents tab change
2. added unit tests to prove backwards compatibility and the new behaviour
