### PR TITLE
added file last modified validator

### DIFF
--- a/packages/ui/components/form-core/src/validate/FileLastModifiedDateValidator.js
+++ b/packages/ui/components/form-core/src/validate/FileLastModifiedDateValidator.js
@@ -1,0 +1,33 @@
+import { Validator } from './Validator.js';
+
+export class FileLastModifiedDateValidator extends Validator {
+  static validatorName = 'FileLastModifiedDate';
+
+  /**
+   * Checks if the file's last modified date is within the specified range.
+   * @param {Date} fileLastModifiedDate - The file's last modified date.
+   * @param {Date} startDate - The start date of the allowed range.
+   * @param {Date} endDate - The end date of the allowed range.
+   * @returns {boolean}
+   */
+  static isDateWithinRange(fileLastModifiedDate, startDate, endDate) {
+    return fileLastModifiedDate >= startDate && fileLastModifiedDate <= endDate;
+  }
+
+  /**
+   * @param {Array<File>} modelValue - Array of file objects.
+   * @param {{ startDate: Date; endDate: Date; }} params - Validation parameters.
+   * @returns {boolean}
+   */
+  execute(modelValue, params = this.param) {
+    const ctor = /** @type {typeof FileLastModifiedDateValidator} */ (this.constructor);
+    return modelValue.every(file => {
+      const fileDate = new Date(file.lastModified);
+      return ctor.isDateWithinRange(fileDate, params.startDate, params.endDate);
+    });
+  }
+
+  static async getMessage() {
+    return 'The file must have been last modified within the specified date range.';
+  }
+}

--- a/packages/ui/components/form-core/test/validate/FileLastModifiedDateValidator.test.js
+++ b/packages/ui/components/form-core/test/validate/FileLastModifiedDateValidator.test.js
@@ -1,0 +1,40 @@
+import { expect } from '@open-wc/testing';
+import { FileLastModifiedDateValidator } from '@lion/ui/FileLastModifiedDateValidator';
+
+describe('FileLastModifiedDateValidator', () => {
+  let validator;
+
+  beforeEach(() => {
+    validator = new FileLastModifiedDateValidator({
+      startDate: new Date('2022-01-01'),
+      endDate: new Date('2023-01-01'),
+    });
+  });
+
+  it('validates files within the specified date range', () => {
+    const validFile = new File(['content'], 'test.txt', {
+      type: 'text/plain',
+      lastModified: new Date('2022-06-01').getTime(),
+    });
+
+    const result = validator.execute([validFile]);
+    expect(result).to.be.true;
+  });
+
+  it('invalidates files outside the specified date range', () => {
+    const invalidFile = new File(['content'], 'test.txt', {
+      type: 'text/plain',
+      lastModified: new Date('2021-12-31').getTime(),
+    });
+
+    const result = validator.execute([invalidFile]);
+    expect(result).to.be.false;
+  });
+
+  it('returns a validation message for invalid files', async () => {
+    const message = await FileLastModifiedDateValidator.getMessage();
+    expect(message).to.equal(
+      'The file must have been last modified within the specified date range.',
+    );
+  });
+});

--- a/packages/ui/exports/form-core.js
+++ b/packages/ui/exports/form-core.js
@@ -46,6 +46,7 @@ export {
 export { DefaultSuccess } from '../components/form-core/src/validate/resultValidators/DefaultSuccess.js';
 
 export { LionValidationFeedback } from '../components/form-core/src/validate/LionValidationFeedback.js';
+export { FileLastModifiedDateValidator } from '../components/form-core/src/validate/FileLastModifiedDateValidator.js';
 
 export { ChoiceGroupMixin } from '../components/form-core/src/choice-group/ChoiceGroupMixin.js';
 export { ChoiceInputMixin } from '../components/form-core/src/choice-group/ChoiceInputMixin.js';


### PR DESCRIPTION

## File last modified date validator
This validator can be used to ensure that the uploaded file was last modified within a specific date range. This can be useful in scenarios where you want to ensure that users are uploading recent files, such as recent documents, photos, or reports.

To use this validator, you would provide the desired date range as parameters when adding it to a form element:
```
const fileInput = document.querySelector('lion-input-file');
const validator = new  FileLastModifiedDateValidator({ 
	startDate: new  Date('2022-01-01'),
	endDate: new  Date('2023-01-01') 
});
fileInput.addValidator(validator);
```
This would ensure that only files modified between January 1, 2022, and January 1, 2023, are considered valid.