### PR TITLE
fix(lion-combobox): The event emitted during clear has stale value

### DIFF
--- a/.changeset/poor-trains-drive.md
+++ b/.changeset/poor-trains-drive.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Fix: Event emited when clearing a combobox sends stale value

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -1185,8 +1185,8 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(LionListbox)) {
   }
 
   clear() {
-    super.clear();
     this.value = '';
+    super.clear();
     this.__shouldAutocompleteNextUpdate = true;
   }
 }

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -453,6 +453,32 @@ describe('lion-combobox', () => {
       expect(el2._inputNode.value).to.equal('');
     });
 
+    it('correctly emits event with an empty value when clear() is called', async () => {
+      const el = /** @type {LionCombobox} */ (
+        await fixture(
+          html`<lion-combobox>
+            <lion-option .choiceValue=${'red'}>Red</lion-option>
+            <lion-option .choiceValue=${'green'}>Green</lion-option>
+            <lion-option .choiceValue=${'blue'}>Blue</lion-option>
+          </lion-combobox>`,
+        )
+      );
+
+      el.modelValue = 'red';
+      await el.updateComplete;
+
+      el.addEventListener('model-value-changed', ({ target }) => {
+        expect(target).to.not.be.null;
+
+        const { modelValue, value } = /** @type {LionCombobox} */ (target);
+        expect(value).to.equal('');
+        expect(modelValue).to.equal('');
+      });
+
+      el.clear();
+      await el.updateComplete;
+    });
+
     it('updates option list after clear()', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`


### PR DESCRIPTION
## What I did

1. Created a test to cover the issue reported at
https://github.com/ing-bank/lion/issues/2100
Note: I tried to use Spy instead of an arrow function, but I learned that sinon's `.calledWith` compares to the reference of the object used in the call, and since the value object is updated between call and the assertion it reports the "updated" value.

2. Now the value is first set to `''` before calling `super.clean()`, since no other event is called when changing this value, I assume this has no further impact.