### PR TITLE
chore: fix DE locale typo for validation messages

### DIFF
--- a/.changeset/tender-cows-exercise.md
+++ b/.changeset/tender-cows-exercise.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix: DE locale typo for validation messages

--- a/packages/ui/components/validate-messages/translations/de.js
+++ b/packages/ui/components/validate-messages/translations/de.js
@@ -5,13 +5,13 @@ export default {
     MinLength: 'Du musst mindestens {params} Zeichen eingeben.',
     MaxLength: 'Du kannst maximal {params} Zeichen eingeben.',
     MinMaxLength: 'Du musst zwischen {params.min} und {params.max} Zeichen eingeben.',
-    Pattern: 'Geben Sie ein gültiges {fieldName} ein.',
-    IsNumber: 'Geben Sie ein gültiges {fieldName} ein.',
+    Pattern: 'Geben Sie ein gültige {fieldName} ein.',
+    IsNumber: 'Geben Sie ein gültige {fieldName} ein.',
     MinNumber: 'Geben Sie für {fieldName} einen Wert über {params} ein.',
     MaxNumber: 'Geben Sie für {fieldName} einen Wert unter {params} ein.',
     MinMaxNumber:
       'Geben Sie für {fieldName} einen Wert zwischen {params.min} und {params.max} ein.',
-    IsDate: 'Bitte geben Sie ein gültiges Datum ein (TT.MM.JJJJ).',
+    IsDate: 'Bitte geben Sie ein gültige Datum ein (TT.MM.JJJJ).',
     MinDate: 'Geben Sie für {fieldName} einen Wert ein, der nach {params, date, YYYYMMDD} liegt.',
     MaxDate: 'Geben Sie für {fieldName} einen Wert ein, der vor {params, date, YYYYMMDD} liegt.',
     MinMaxDate:
@@ -27,12 +27,12 @@ export default {
     MinLength: 'Du solltest mindestens {params} Zeichen eingeben.',
     MaxLength: 'Du kannst maximal {params} Zeichen eingeben.',
     MinMaxLength: 'Du solltest zwischen {params.min} und {params.max} Zeichen eingeben.',
-    IsNumber: 'Geben Sie ein gültiges {fieldName} ein.',
+    IsNumber: 'Geben Sie ein gültige {fieldName} ein.',
     MinNumber: 'Geben Sie für {fieldName} einen Wert über {params} ein.',
     MaxNumber: 'Geben Sie für {fieldName} einen Wert unter {params} ein.',
     MinMaxNumber:
       'Geben Sie für {fieldName} einen Wert zwischen {params.min} und {params.max} ein.',
-    IsDate: 'Bitte geben Sie ein gültiges Datum ein (TT.MM.JJJJ).',
+    IsDate: 'Bitte geben Sie ein gültige Datum ein (TT.MM.JJJJ).',
     MinDate: 'Geben Sie für {fieldName} einen Wert ein, der nach {params, date, YYYYMMDD} liegt.',
     MaxDate: 'Geben Sie für {fieldName} einen Wert ein, der vor {params, date, YYYYMMDD} liegt.',
     MinMaxDate:

--- a/packages/ui/components/validate-messages/translations/de.js
+++ b/packages/ui/components/validate-messages/translations/de.js
@@ -32,7 +32,7 @@ export default {
     MaxNumber: 'Geben Sie für {fieldName} einen Wert unter {params} ein.',
     MinMaxNumber:
       'Geben Sie für {fieldName} einen Wert zwischen {params.min} und {params.max} ein.',
-    IsDate: 'Bitte geben Sie ein gültige Datum ein (TT.MM.JJJJ).',
+    IsDate: 'Bitte geben Sie ein gültiges Datum ein (TT.MM.JJJJ).',
     MinDate: 'Geben Sie für {fieldName} einen Wert ein, der nach {params, date, YYYYMMDD} liegt.',
     MaxDate: 'Geben Sie für {fieldName} einen Wert ein, der vor {params, date, YYYYMMDD} liegt.',
     MinMaxDate:

--- a/packages/ui/components/validate-messages/translations/de.js
+++ b/packages/ui/components/validate-messages/translations/de.js
@@ -11,7 +11,7 @@ export default {
     MaxNumber: 'Geben Sie für {fieldName} einen Wert unter {params} ein.',
     MinMaxNumber:
       'Geben Sie für {fieldName} einen Wert zwischen {params.min} und {params.max} ein.',
-    IsDate: 'Bitte geben Sie ein gültige Datum ein (TT.MM.JJJJ).',
+    IsDate: 'Bitte geben Sie ein gültiges Datum ein (TT.MM.JJJJ).',
     MinDate: 'Geben Sie für {fieldName} einen Wert ein, der nach {params, date, YYYYMMDD} liegt.',
     MaxDate: 'Geben Sie für {fieldName} einen Wert ein, der vor {params, date, YYYYMMDD} liegt.',
     MinMaxDate:


### PR DESCRIPTION
## What I did

1. Fixed a typo for DE locale on validation messages
