### PR TITLE
chore: allow ajax test to work with different dev server ports

### DIFF
--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -597,7 +597,7 @@ describe('Ajax', () => {
         'foobar',
       );
 
-      expect(error.message).to.include('http://localhost:8000/foobar');
+      expect(/http:\/\/localhost:\d*\/foobar/.test(error.message)).to.be.true;
       expect(error.message).to.include('418');
       expect(error.message).to.include("I'm a teapot");
     });


### PR DESCRIPTION
hardcoded port of 8000 leads to failing tests when multiple local servers are running
