### PR TITLE
fix(overlays): fix OverlayController being added to a target that is already removed

### DIFF
--- a/.changeset/nice-months-applaud.md
+++ b/.changeset/nice-months-applaud.md
@@ -1,0 +1,5 @@
+---
+'@lion/overlays': patch
+---
+
+fix(overlays): fix OverlayController being added to a target that is already removed

--- a/packages/overlays/src/OverlayMixin.js
+++ b/packages/overlays/src/OverlayMixin.js
@@ -166,7 +166,8 @@ export const OverlayMixinImplementation = superclass =>
       // we do a setup after every connectedCallback as firstUpdated will only be called once
       this.__needsSetup = true;
       this.updateComplete.then(() => {
-        if (this.__needsSetup) {
+        // The overlay can already be removed during the update, so let's make sure it is still connected
+        if (this.__needsSetup && this.isConnected) {
           this._setupOverlayCtrl();
         }
         this.__needsSetup = false;
@@ -174,9 +175,8 @@ export const OverlayMixinImplementation = superclass =>
     }
 
     disconnectedCallback() {
-      if (super.disconnectedCallback) {
-        super.disconnectedCallback();
-      }
+      super.disconnectedCallback();
+
       if (this._overlayCtrl) {
         this._teardownOverlayCtrl();
       }


### PR DESCRIPTION
The `OverlayMixin` connectedCallback has some async code to initialise the `OverlayController` which (by the time the promise is resolved) can already be removed. This change will make sure the mixin won't initialise a controller if the render target is not connected anymore.