### PR TITLE
bugfix: import missing dependencies for configuration.md

### DIFF
--- a/docs/fundamentals/systems/overlays/configuration.md
+++ b/docs/fundamentals/systems/overlays/configuration.md
@@ -4,6 +4,7 @@
 import { html } from '@mdjs/mdjs-preview';
 import './assets/demo-el-using-overlaymixin.mjs';
 import './assets/applyDemoOverlayStyles.mjs';
+import { withDropdownConfig, withTooltipConfig } from '@lion/ui/overlays.js';
 ```
 
 The `OverlayController` has many configuration options.


### PR DESCRIPTION
At the moment if going to https://lion-web.netlify.app/fundamentals/systems/overlays/configuration/ there are errors in the browser console as follows:
```
__mdjs-stories.js:8 Uncaught (in promise) ReferenceError: withDropdownConfig is not defined
    at HTMLElement.placementLocal [as __story] (__mdjs-stories.js:8:36)
    at HTMLElement.update (MdJsPreview.js:308:45)
    at HTMLElement.performUpdate (reactive-element.ts:1327:14)
    at HTMLElement.scheduleUpdate (reactive-element.ts:1259:17)
    at HTMLElement._$Ej (reactive-element.ts:1231:25)
```
The fix remedies it.