### PR TITLE
fix(adopt-styles): use traditional style on ios

### DIFF
--- a/.changeset/khaki-scissors-refuse.md
+++ b/.changeset/khaki-scissors-refuse.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Export isIOS and isMacSafari functions as part of browserDetection utility

--- a/.changeset/khaki-scissors-refuse.md
+++ b/.changeset/khaki-scissors-refuse.md
@@ -1,5 +1,5 @@
 ---
-'@lion/ui': minor
+'@lion/ui': patch
 ---
 
 Export isIOS and isMacSafari functions as part of browserDetection utility

--- a/.changeset/nice-spoons-rush.md
+++ b/.changeset/nice-spoons-rush.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Use traditional styleSheet on IOS for overlays

--- a/packages/ui/components/core/src/browserDetection.js
+++ b/packages/ui/components/core/src/browserDetection.js
@@ -36,4 +36,12 @@ export const browserDetection = {
   isIOSChrome: checkChrome('ios'),
   isChromium: checkChrome('chromium'),
   isMac: navigator.appVersion.indexOf('Mac') !== -1,
+  isIOS: /iPhone|iPad|iPod/i.test(navigator.userAgent),
+  isMacSafari:
+    navigator.vendor &&
+    navigator.vendor.indexOf('Apple') > -1 &&
+    navigator.userAgent &&
+    navigator.userAgent.indexOf('CriOS') === -1 &&
+    navigator.userAgent.indexOf('FxiOS') === -1 &&
+    navigator.appVersion.indexOf('Mac') !== -1,
 };

--- a/packages/ui/components/overlays/src/OverlaysManager.js
+++ b/packages/ui/components/overlays/src/OverlaysManager.js
@@ -1,22 +1,11 @@
+import { browserDetection } from '@lion/ui/core.js';
+
 /**
  * @typedef {import('lit').CSSResult} CSSResult
  * @typedef {import('./OverlayController.js').OverlayController} OverlayController
  */
 
 import { overlayDocumentStyle } from './overlayDocumentStyle.js';
-
-// Export this as protected var, so that we can easily mock it in tests
-// TODO: combine with browserDetection of core?
-export const _browserDetection = {
-  isIOS: /iPhone|iPad|iPod/i.test(navigator.userAgent),
-  isMacSafari:
-    navigator.vendor &&
-    navigator.vendor.indexOf('Apple') > -1 &&
-    navigator.userAgent &&
-    navigator.userAgent.indexOf('CriOS') === -1 &&
-    navigator.userAgent.indexOf('FxiOS') === -1 &&
-    navigator.appVersion.indexOf('Mac') !== -1,
-};
 
 /**
  * `OverlaysManager` which manages overlays which are rendered into the body
@@ -182,7 +171,7 @@ export class OverlaysManager {
 
   // eslint-disable-next-line class-methods-use-this
   requestToPreventScroll() {
-    const { isIOS, isMacSafari } = _browserDetection;
+    const { isIOS, isMacSafari } = browserDetection;
     // no check as classList will dedupe it anyways
     document.body.classList.add('overlays-scroll-lock');
     if (isIOS || isMacSafari) {
@@ -203,7 +192,7 @@ export class OverlaysManager {
       return;
     }
 
-    const { isIOS, isMacSafari } = _browserDetection;
+    const { isIOS, isMacSafari } = browserDetection;
     document.body.classList.remove('overlays-scroll-lock');
     if (isIOS || isMacSafari) {
       document.body.classList.remove('overlays-scroll-lock-ios-fix');

--- a/packages/ui/components/overlays/src/utils/adopt-styles.js
+++ b/packages/ui/components/overlays/src/utils/adopt-styles.js
@@ -108,6 +108,9 @@ export function adoptStyle(renderRoot, style, { teardown = false } = {}) {
     return;
   }
 
+  // ios seems to have issues when using the adoptedStyleSheets where some styles are applied
+  // while others are ignored so the overlays are rendered incorrectly, to mitigate it we use
+  // traditional "stylesheet".
   if (!_adoptStyleUtils.supportsAdoptingStyleSheets || browserDetection.isIOS) {
     adoptStyleWhenAdoptedStylesheetsNotSupported(renderRoot, style, { teardown });
     return;

--- a/packages/ui/components/overlays/src/utils/adopt-styles.js
+++ b/packages/ui/components/overlays/src/utils/adopt-styles.js
@@ -1,3 +1,5 @@
+import { browserDetection } from '@lion/ui/core.js';
+
 // See: https://github.com/ing-bank/lion/issues/1880
 
 /**
@@ -106,7 +108,7 @@ export function adoptStyle(renderRoot, style, { teardown = false } = {}) {
     return;
   }
 
-  if (!_adoptStyleUtils.supportsAdoptingStyleSheets) {
+  if (!_adoptStyleUtils.supportsAdoptingStyleSheets || browserDetection.isIOS) {
     adoptStyleWhenAdoptedStylesheetsNotSupported(renderRoot, style, { teardown });
     return;
   }

--- a/packages/ui/components/overlays/test-suites/OverlayMixin.suite.js
+++ b/packages/ui/components/overlays/test-suites/OverlayMixin.suite.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { overlays as overlaysManager, OverlayController } from '@lion/ui/overlays.js';
 
 import '@lion/ui/define/lion-dialog.js';
-import { _browserDetection } from '../src/OverlaysManager.js';
+import { browserDetection } from '@lion/ui/core.js';
 
 /**
  * @typedef {import('../types/OverlayConfig.js').OverlayConfig} OverlayConfig
@@ -99,7 +99,7 @@ export function runOverlayMixinSuite({ tagString, tag, suffix = '' }) {
       // For now, we skip this test for MacSafari, since the body.overlays-scroll-lock-ios-fix
       // class results in a scrollbar when preventsScroll is true.
       // However, fully functioning interacive elements (input fields) in the dialog are more important
-      if (_browserDetection.isMacSafari && elWithBigParent._overlayCtrl.preventsScroll) {
+      if (browserDetection.isMacSafari && elWithBigParent._overlayCtrl.preventsScroll) {
         return;
       }
 

--- a/packages/ui/components/overlays/test/OverlaysManager.test.js
+++ b/packages/ui/components/overlays/test/OverlaysManager.test.js
@@ -1,7 +1,8 @@
 import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit/static-html.js';
+import sinon from 'sinon';
+import { browserDetection } from '@lion/ui/core.js';
 import { OverlayController, OverlaysManager } from '@lion/ui/overlays.js';
-import { _browserDetection } from '../src/OverlaysManager.js';
 
 /**
  * @typedef {import('../types/OverlayConfig.js').OverlayConfig} OverlayConfig
@@ -101,24 +102,24 @@ describe('OverlaysManager', () => {
   });
 
   describe('Browser/device edge cases', () => {
-    const isIOSOriginal = _browserDetection.isIOS;
-    const isMacSafariOriginal = _browserDetection.isMacSafari;
+    const isIOSDetectionStub = sinon.stub(browserDetection, 'isIOS');
+    const isMacSafariDetectionStub = sinon.stub(browserDetection, 'isMacSafari');
 
     function mockIOS() {
-      _browserDetection.isIOS = true;
-      _browserDetection.isMacSafari = false;
+      isIOSDetectionStub.value(true);
+      isMacSafariDetectionStub.value(false);
     }
 
     function mockMacSafari() {
       // When we are iOS
-      _browserDetection.isIOS = false;
-      _browserDetection.isMacSafari = true;
+      isIOSDetectionStub.value(false);
+      isMacSafariDetectionStub.value(true);
     }
 
     afterEach(() => {
       // Restore original values
-      _browserDetection.isIOS = isIOSOriginal;
-      _browserDetection.isMacSafari = isMacSafariOriginal;
+      isIOSDetectionStub.restore();
+      isMacSafariDetectionStub.restore();
     });
 
     describe('When initialized with "preventsScroll: true"', () => {
@@ -137,8 +138,8 @@ describe('OverlaysManager', () => {
         );
 
         // When we are not iOS nor MacSafari
-        _browserDetection.isIOS = false;
-        _browserDetection.isMacSafari = false;
+        isIOSDetectionStub.value(false);
+        isMacSafariDetectionStub.value(false);
 
         const dialog2 = new OverlayController({ ...defaultOptions, preventsScroll: true }, mngr);
         await dialog2.show();

--- a/packages/ui/components/overlays/test/utils-tests/adopt-styles.test.js
+++ b/packages/ui/components/overlays/test/utils-tests/adopt-styles.test.js
@@ -165,7 +165,7 @@ describe('adoptStyle()', () => {
   });
 });
 
-describe('Fallback when IOS user open overlay', () => {
+describe('Fallback when IOS user opens overlay', () => {
   it('adds a "traditional" stylesheet to the body', async () => {
     const browserDetectionStub = sinon.stub(browserDetection, 'isIOS').value(true);
 


### PR DESCRIPTION
## What I did

We have detected problems on iOS 16.4 and newer versions where the overlays styles were not applied to the overlay and only the basic overlay were keep.

To test the fix we have patched it in our component and tested it with our customers and we have not detected any new error since we applied it.

We have not found a way to isolated the problem and replicate it as the problem was not happening in all the sessions, it seems some kind of race condition when applying the styles to the overlay.

To mitigate this issue I propose this PR to avoid applying the styles using adopt styles on ios devices.