### PR TITLE
fix(localize): parseDate by default to 2000 instead of 1900 when date is below 49

### DIFF
--- a/.changeset/grumpy-bags-give.md
+++ b/.changeset/grumpy-bags-give.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[localize] parseDate by default to 2000 instead of 1900 when date is below 49

--- a/packages/ui/components/localize/src/date/parseDate.js
+++ b/packages/ui/components/localize/src/date/parseDate.js
@@ -58,8 +58,12 @@ export function parseDate(dateString) {
   }
 
   const [year, month, day] = parsedString.split('/').map(Number);
-  const parsedDate = new Date(new Date(year, month - 1, day));
+  let correctedYear = year;
+  if (year < 50) {
+    correctedYear = 2000 + year;
+  }
 
+  const parsedDate = new Date(new Date(correctedYear, month - 1, day));
   // Check if parsedDate is not `Invalid Date` or that the date has changed (e.g. the not existing 31.02.2020)
   if (
     year > 0 &&

--- a/packages/ui/components/localize/test/date/parseDate.test.js
+++ b/packages/ui/components/localize/test/date/parseDate.test.js
@@ -23,6 +23,12 @@ describe('parseDate()', () => {
     localizeTearDown();
   });
 
+  it('handles year correctly', () => {
+    expect(equalsDate(parseDate('1/11/1'), new Date('2001/11/01'))).to.equal(true);
+    expect(equalsDate(parseDate('1/11/49'), new Date('2049/11/01'))).to.equal(true);
+    expect(equalsDate(parseDate('1/11/50'), new Date('1950/11/01'))).to.equal(true);
+  });
+
   it('adds leading zeros', () => {
     expect(equalsDate(parseDate('1-1-1979'), new Date('1979/01/01'))).to.equal(true);
     expect(equalsDate(parseDate('1-11-1979'), new Date('1979/11/01'))).to.equal(true);


### PR DESCRIPTION
The date picker Autofill the wrong date starting from 1900 year when trying to enter manually for e.g. -
12/12/1 => it auto completes to 12/12/1901
12/12/2 => it auto completes to 12/12/1902... etc

So in the code `12/12/1` resulted in `new Date(1, 11, 12))` which gave `12/12/1901`.
This fix adds 2000 to all numbers below 50.
