### PR TITLE
fix(tabs): set selectedIndex only if differ from previous selectedIndex

### DIFF
--- a/.changeset/small-pumpkins-peel.md
+++ b/.changeset/small-pumpkins-peel.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(tabs): set selectedIndex only if value differ from previous value

--- a/packages/ui/components/tabs/src/LionTabs.js
+++ b/packages/ui/components/tabs/src/LionTabs.js
@@ -353,6 +353,7 @@ export class LionTabs extends LitElement {
       return;
     }
     const stale = this.__selectedIndex;
+    /** @type {number | undefined} */
     this.__selectedIndex = value;
     this.__updateSelected(false);
     this.dispatchEvent(new Event('selected-changed'));

--- a/packages/ui/components/tabs/src/LionTabs.js
+++ b/packages/ui/components/tabs/src/LionTabs.js
@@ -349,6 +349,9 @@ export class LionTabs extends LitElement {
    * @param {number} value The new index
    */
   set selectedIndex(value) {
+    if (value === this.__selectedIndex) {
+      return;
+    }
     const stale = this.__selectedIndex;
     this.__selectedIndex = value;
     this.__updateSelected(false);

--- a/packages/ui/components/tabs/test/lion-tabs.test.js
+++ b/packages/ui/components/tabs/test/lion-tabs.test.js
@@ -75,6 +75,14 @@ describe('<lion-tabs>', () => {
       expect(spy).to.have.been.calledOnce;
     });
 
+    it('does not send event "selected-changed" after selecting currently selected tab', async () => {
+      const el = /** @type {LionTabs} */ (await fixture(basicTabs));
+      const spy = sinon.spy();
+      el.addEventListener('selected-changed', spy);
+      el.selectedIndex = 0;
+      expect(spy).not.to.have.been.calledOnce;
+    });
+
     it('logs warning if unequal amount of tabs and panels', async () => {
       const stub = sinon.stub(console, 'warn');
       await fixture(html`

--- a/packages/ui/components/tabs/test/lion-tabs.test.js
+++ b/packages/ui/components/tabs/test/lion-tabs.test.js
@@ -80,7 +80,7 @@ describe('<lion-tabs>', () => {
       const spy = sinon.spy();
       el.addEventListener('selected-changed', spy);
       el.selectedIndex = 0;
-      expect(spy).not.to.have.been.calledOnce;
+      expect(spy).not.to.have.been.called;
     });
 
     it('logs warning if unequal amount of tabs and panels', async () => {


### PR DESCRIPTION
## What I did

I modified the selectedIndex setter. Now it sets the selectedIndex only if the new value is different than the current selectedIndex. 
