### PR TITLE
fix(overlay-controller): do not scroll to invoker if it is visible

### DIFF
--- a/.changeset/hot-otters-push.md
+++ b/.changeset/hot-otters-push.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Fix scroll behavior when closing an overlay

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -933,7 +933,7 @@ export class OverlayController extends EventTarget {
 
     if (this.elementToFocusAfterHide) {
       this.elementToFocusAfterHide.focus();
-      this.elementToFocusAfterHide.scrollIntoView({ block: 'center' });
+      this.elementToFocusAfterHide.scrollIntoView({ block: 'nearest' });
     } else {
       /** @type {HTMLElement} */ (this.__activeElementRightBeforeHide).blur();
     }


### PR DESCRIPTION
When closing an overlay, `scrollIntoView` forced the invoker element to be placed in the middle of the screen. This fix prevents the scroll if the invoker is already visible, but still scrolls it into view if needed.

Related to #1957. Existing tests still apply.

## What I did

1. Replace the `scrollIntoView` [block options](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block) from `center` to `nearest`
