### PR TITLE
@lion/ajax: BREAKING: Only add XSRF token on mutable requests and on same origin or whitelisted origins

### DIFF
--- a/.changeset/two-plums-run.md
+++ b/.changeset/two-plums-run.md
@@ -1,0 +1,9 @@
+---
+'@lion/ajax': major
+---
+
+BREAKING: Only add XSRF token on mutable requests and on same origin or whitelisted origins
+
+Previously the XSRF token was added to any call to any origin.  
+This is changed to only attach the token to requests that are POST/PUT/PATCH/DELETE.  
+And another change is that it will validate if the request origin is the same as current origin or when the origin is in the xsrfTrustedOrigins.

--- a/.changeset/two-plums-run.md
+++ b/.changeset/two-plums-run.md
@@ -4,8 +4,9 @@
 
 BREAKING: Only add XSRF token on mutable requests and on same origin or whitelisted origins
 
-Previously the XSRF token was added to any call to any origin.  
-This is changed to only attach the token to requests that are POST/PUT/PATCH/DELETE.  
-And another change is that it will validate if the request origin is the same as current origin or when the origin is in the xsrfTrustedOrigins.
+Previously the XSRF token was added to any call to any origin.
+This is changed in two ways.  
+(1) The token is now only attached to requests that are POST/PUT/PATCH/DELETE.
+(2) It will validate if the request origin is the same as current origin or when the origin is in the xsrfTrustedOrigins.
 
-This is a fix for a vulnerability found, as we inadvertently revealed the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information.
+This is a fix for a vulnerability: we inadvertently revealed the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host. This allowed attackers to view sensitive information.

--- a/.changeset/two-plums-run.md
+++ b/.changeset/two-plums-run.md
@@ -7,3 +7,5 @@ BREAKING: Only add XSRF token on mutable requests and on same origin or whitelis
 Previously the XSRF token was added to any call to any origin.  
 This is changed to only attach the token to requests that are POST/PUT/PATCH/DELETE.  
 And another change is that it will validate if the request origin is the same as current origin or when the origin is in the xsrfTrustedOrigins.
+
+This is a fix for a vulnerability found, as we inadvertently revealed the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information.

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -69,8 +69,10 @@ export class Ajax {
     }
 
     const { xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins } = this.__config;
-    if (xsrfCookieName && xsrfHeaderName && xsrfTrustedOrigins) {
-      this.addRequestInterceptor(createXsrfRequestInterceptor(xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins));
+    if (xsrfCookieName && xsrfHeaderName) {
+      this.addRequestInterceptor(
+        createXsrfRequestInterceptor(xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins),
+      );
     }
 
     // eslint-disable-next-line prefer-destructuring
@@ -281,7 +283,7 @@ export class Ajax {
     for (const intercept of this._responseInterceptors) {
       // In this instance we actually do want to await for each sequence
       // eslint-disable-next-line no-await-in-loop
-      interceptedResponse = await intercept(/** @type {CacheResponse} */(interceptedResponse));
+      interceptedResponse = await intercept(/** @type {CacheResponse} */ (interceptedResponse));
     }
     return interceptedResponse;
   }

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -50,6 +50,7 @@ export class Ajax {
       addCaching: false,
       xsrfCookieName: 'XSRF-TOKEN',
       xsrfHeaderName: 'X-XSRF-TOKEN',
+      xsrfTrustedOrigins: [],
       jsonPrefix: '',
       ...config,
       cacheOptions: {
@@ -67,9 +68,9 @@ export class Ajax {
       this.addRequestInterceptor(acceptLanguageRequestInterceptor);
     }
 
-    const { xsrfCookieName, xsrfHeaderName } = this.__config;
-    if (xsrfCookieName && xsrfHeaderName) {
-      this.addRequestInterceptor(createXsrfRequestInterceptor(xsrfCookieName, xsrfHeaderName));
+    const { xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins } = this.__config;
+    if (xsrfCookieName && xsrfHeaderName && xsrfTrustedOrigins) {
+      this.addRequestInterceptor(createXsrfRequestInterceptor(xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins));
     }
 
     // eslint-disable-next-line prefer-destructuring
@@ -280,7 +281,7 @@ export class Ajax {
     for (const intercept of this._responseInterceptors) {
       // In this instance we actually do want to await for each sequence
       // eslint-disable-next-line no-await-in-loop
-      interceptedResponse = await intercept(/** @type {CacheResponse} */ (interceptedResponse));
+      interceptedResponse = await intercept(/** @type {CacheResponse} */(interceptedResponse));
     }
     return interceptedResponse;
   }

--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -69,7 +69,7 @@ export class Ajax {
     }
 
     const { xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins } = this.__config;
-    if (xsrfCookieName && xsrfHeaderName) {
+    if (xsrfCookieName && xsrfHeaderName && xsrfTrustedOrigins) {
       this.addRequestInterceptor(
         createXsrfRequestInterceptor(xsrfCookieName, xsrfHeaderName, xsrfTrustedOrigins),
       );

--- a/packages/ajax/src/interceptors/xsrfHeader.js
+++ b/packages/ajax/src/interceptors/xsrfHeader.js
@@ -3,6 +3,61 @@
  */
 
 /**
+* Parse a URL to discover it's components
+*
+* @param {String | object} url The URL to be parsed
+* @returns {{protocol: string, host: string }}
+*/
+function resolveURL(url) {
+  if (typeof url !== 'string') {
+    return url;
+  }
+  let href = url;
+  let urlParsingNode = document.createElement('a');
+  urlParsingNode.setAttribute('href', href);
+
+  // urlParsingNode provides the UrlUtils interface - http://url.spec.whatwg.org/#urlutils
+  return {
+    protocol: urlParsingNode.protocol ? urlParsingNode.protocol.replace(/:$/, '') : '',
+    host: urlParsingNode.host,
+  };
+}
+
+/**
+ * Determine if two URLs share the same origin.
+ *
+ * @param {string| object} url1 - First URL to compare as a string or a normalized URL in the form of
+ *     a dictionary object returned by `urlResolve()`.
+ * @param {string | object} url2 - Second URL to compare as a string or a normalized URL in the form
+ *     of a dictionary object returned by `urlResolve()`.
+ *
+ * @returns {boolean} - True if both URLs have the same origin, and false otherwise.
+ */
+function urlsAreSameOrigin(url1, url2) {
+  const parsedUrl1 = resolveURL(url1);
+  const parsedUrl2 = resolveURL(url2);
+
+  return (parsedUrl1.protocol === parsedUrl2.protocol &&
+    parsedUrl1.host === parsedUrl2.host);
+}
+
+/**
+* Check if the URL provided has the same origin as the one used.
+* Or if it is for a trusted XSRF origin.
+*
+* @param {String} requestURL The requestedURL
+* @param {string[]} xsrfTrustedOrigins List of allowed origins
+* @returns {boolean} true if it is the same origin, else false
+*/
+function isURLTrustedOrSameOrigin(requestURL, xsrfTrustedOrigins) {
+  const parsed = (typeof requestURL === 'string') ? resolveURL(requestURL) : requestURL;
+  const originURL = resolveURL(window.location.href);
+  const parsedAllowedOriginUrls = [originURL].concat(xsrfTrustedOrigins.map(resolveURL));
+
+  return parsedAllowedOriginUrls.some(urlsAreSameOrigin.bind(null, parsed));
+}
+
+/**
  * @param {string} name the cookie name
  * @param {Document | { cookie: string }} _document overwriteable for testing
  * @returns {string | null}
@@ -17,16 +72,21 @@ export function getCookie(name, _document = document) {
  * against cross-site request forgery.
  * @param {string} cookieName the cookie name
  * @param {string} headerName the header name
+ * @param {string[]} xsrfTrustedOrigins List of trusted origins
  * @param {Document | { cookie: string }} _document overwriteable for testing
  * @returns {RequestInterceptor}
  */
-export function createXsrfRequestInterceptor(cookieName, headerName, _document = document) {
+export function createXsrfRequestInterceptor(cookieName, headerName, xsrfTrustedOrigins, _document = document) {
   /**
    * @param {Request} request
    */
   async function xsrfRequestInterceptor(request) {
     const xsrfToken = getCookie(cookieName, _document);
-    if (xsrfToken) {
+
+    const isSameSite = isURLTrustedOrSameOrigin(request.url, xsrfTrustedOrigins);
+
+    // Only add the XSRF token when it is needed and/or allowed.
+    if (['POST', 'PUT', 'DELETE', 'PATCH'].includes(request.method) && isSameSite && xsrfToken) {
       request.headers.set(headerName, xsrfToken);
     }
     return request;
@@ -34,3 +94,4 @@ export function createXsrfRequestInterceptor(cookieName, headerName, _document =
 
   return xsrfRequestInterceptor;
 }
+

--- a/packages/ajax/src/interceptors/xsrfHeader.js
+++ b/packages/ajax/src/interceptors/xsrfHeader.js
@@ -3,11 +3,11 @@
  */
 
 /**
-* Parse a URL to discover its components
-*
-* @param {String | object} url The URL to be parsed
-* @returns {{protocol: string, host: string }}
-*/
+ * Parse a URL to discover its components
+ *
+ * @param {String | {protocol: string, host: string }} url The URL to be parsed
+ * @returns {{protocol: string, host: string }}
+ */
 function resolveURL(url) {
   if (typeof url !== 'string') {
     return url;
@@ -26,8 +26,8 @@ function resolveURL(url) {
 /**
  * Determine if two URLs share the same origin.
  *
- * @param {string | object} url1 - First URL to compare as a string or a normalized URL
- * @param {string | object} url2 - Second URL to compare as a string or a normalized URL
+ * @param {string | {protocol: string, host: string }} url1 - First URL to compare as a string or a normalized URL
+ * @param {string | {protocol: string, host: string }} url2 - Second URL to compare as a string or a normalized URL
  *
  * @returns {boolean} - true if both URLs have the same origin, and false otherwise.
  */
@@ -35,20 +35,19 @@ function urlsAreSameOrigin(url1, url2) {
   const parsedUrl1 = resolveURL(url1);
   const parsedUrl2 = resolveURL(url2);
 
-  return (parsedUrl1.protocol === parsedUrl2.protocol &&
-    parsedUrl1.host === parsedUrl2.host);
+  return parsedUrl1.protocol === parsedUrl2.protocol && parsedUrl1.host === parsedUrl2.host;
 }
 
 /**
-* Check if the URL provided has the same origin as the one used.
-* Or if it is for a trusted XSRF origin.
-*
-* @param {String} requestURL The requestedURL
-* @param {string[]} xsrfTrustedOrigins List of allowed origins
-* @returns {boolean} true if it is the same origin, else false
-*/
+ * Check if the URL provided has the same origin as the one used.
+ * Or if it is for a trusted XSRF origin.
+ *
+ * @param {String} requestURL The requestedURL
+ * @param {string[]} xsrfTrustedOrigins List of allowed origins
+ * @returns {boolean} true if it is the same origin, else false
+ */
 function isURLTrustedOrSameOrigin(requestURL, xsrfTrustedOrigins) {
-  const parsed = (typeof requestURL === 'string') ? resolveURL(requestURL) : requestURL;
+  const parsed = typeof requestURL === 'string' ? resolveURL(requestURL) : requestURL;
   const originURL = resolveURL(window.location.href);
   const parsedAllowedOriginUrls = [originURL].concat(xsrfTrustedOrigins.map(resolveURL));
 
@@ -74,7 +73,12 @@ export function getCookie(name, _document = document) {
  * @param {Document | { cookie: string }} _document overwriteable for testing
  * @returns {RequestInterceptor}
  */
-export function createXsrfRequestInterceptor(cookieName, headerName, xsrfTrustedOrigins, _document = document) {
+export function createXsrfRequestInterceptor(
+  cookieName,
+  headerName,
+  xsrfTrustedOrigins,
+  _document = document,
+) {
   /**
    * @param {Request} request
    */
@@ -92,4 +96,3 @@ export function createXsrfRequestInterceptor(cookieName, headerName, xsrfTrusted
 
   return xsrfRequestInterceptor;
 }
-

--- a/packages/ajax/src/interceptors/xsrfHeader.js
+++ b/packages/ajax/src/interceptors/xsrfHeader.js
@@ -3,7 +3,7 @@
  */
 
 /**
-* Parse a URL to discover it's components
+* Parse a URL to discover its components
 *
 * @param {String | object} url The URL to be parsed
 * @returns {{protocol: string, host: string }}
@@ -12,8 +12,8 @@ function resolveURL(url) {
   if (typeof url !== 'string') {
     return url;
   }
-  let href = url;
-  let urlParsingNode = document.createElement('a');
+  const href = url;
+  const urlParsingNode = document.createElement('a');
   urlParsingNode.setAttribute('href', href);
 
   // urlParsingNode provides the UrlUtils interface - http://url.spec.whatwg.org/#urlutils

--- a/packages/ajax/src/interceptors/xsrfHeader.js
+++ b/packages/ajax/src/interceptors/xsrfHeader.js
@@ -26,7 +26,7 @@ function resolveURL(url) {
 /**
  * Determine if two URLs share the same origin.
  *
- * @param {string| object} url1 - First URL to compare as a string or a normalized URL
+ * @param {string | object} url1 - First URL to compare as a string or a normalized URL
  * @param {string | object} url2 - Second URL to compare as a string or a normalized URL
  *
  * @returns {boolean} - true if both URLs have the same origin, and false otherwise.

--- a/packages/ajax/src/interceptors/xsrfHeader.js
+++ b/packages/ajax/src/interceptors/xsrfHeader.js
@@ -26,12 +26,10 @@ function resolveURL(url) {
 /**
  * Determine if two URLs share the same origin.
  *
- * @param {string| object} url1 - First URL to compare as a string or a normalized URL in the form of
- *     a dictionary object returned by `urlResolve()`.
- * @param {string | object} url2 - Second URL to compare as a string or a normalized URL in the form
- *     of a dictionary object returned by `urlResolve()`.
+ * @param {string| object} url1 - First URL to compare as a string or a normalized URL
+ * @param {string | object} url2 - Second URL to compare as a string or a normalized URL
  *
- * @returns {boolean} - True if both URLs have the same origin, and false otherwise.
+ * @returns {boolean} - true if both URLs have the same origin, and false otherwise.
  */
 function urlsAreSameOrigin(url1, url2) {
   const parsedUrl1 = resolveURL(url1);

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -436,15 +436,13 @@ describe('Ajax', () => {
 
     it('should set the XSRF header if origin is in the trusted origin list', async () => {
       const customAjax = new Ajax({
-        xsrfCookieName: 'CSRF-TOKEN',
-        xsrfHeaderName: 'X-CSRF-TOKEN',
         xsrfTrustedOrigins: ['https://api.localhost'],
       });
 
-      await customAjax.fetch('https://api.localhost:8000/foo', { method: 'POST' });
+      await customAjax.fetch('https://api.localhost/foo', { method: 'POST' });
 
       const request = fetchStub.getCall(0).args[0];
-      expect(request.headers.get('X-XSRF-TOKEN')).to.be.null;
+      expect(request.headers.get('X-XSRF-TOKEN')).to.equal('1234');
     });
   });
 

--- a/packages/ajax/test/interceptors/xsrfHeader.test.js
+++ b/packages/ajax/test/interceptors/xsrfHeader.test.js
@@ -23,16 +23,16 @@ describe('getCookie()', () => {
 
 describe('createXsrfRequestInterceptor()', () => {
   it('adds the xsrf token header to the request', () => {
-    const interceptor = createXsrfRequestInterceptor('XSRF-TOKEN', 'X-XSRF-TOKEN', {
+    const interceptor = createXsrfRequestInterceptor('XSRF-TOKEN', 'X-XSRF-TOKEN', [], {
       cookie: 'XSRF-TOKEN=foo',
     });
-    const request = new Request('/foo/');
+    const request = new Request('/foo/', { method: 'POST' });
     interceptor(request);
     expect(request.headers.get('X-XSRF-TOKEN')).to.equal('foo');
   });
 
   it('does not set anything if the cookie is not there', () => {
-    const interceptor = createXsrfRequestInterceptor('XSRF-TOKEN', 'X-XSRF-TOKEN', {
+    const interceptor = createXsrfRequestInterceptor('XSRF-TOKEN', 'X-XSRF-TOKEN', [], {
       cookie: 'XXSRF-TOKEN=foo',
     });
     const request = new Request('/foo/');

--- a/packages/ajax/types/types.ts
+++ b/packages/ajax/types/types.ts
@@ -16,6 +16,7 @@ export interface AjaxConfig {
   xsrfCookieName?: string | null;
   xsrfHeaderName?: string | null;
   cacheOptions?: CacheOptionsWithIdentifier;
+  xsrfTrustedOrigins?: string[] | null;
   jsonPrefix?: string;
 }
 

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -36,9 +36,9 @@ export default {
     },
   },
   browsers: [
-
+    playwrightLauncher({ product: 'firefox', concurrency: 1 }),
     playwrightLauncher({ product: 'chromium' }),
-    
+    playwrightLauncher({ product: 'webkit' }),
   ],
   groups: packages.map(pkg => ({
     name: pkg.name,

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -36,9 +36,9 @@ export default {
     },
   },
   browsers: [
-    playwrightLauncher({ product: 'firefox', concurrency: 1 }),
+
     playwrightLauncher({ product: 'chromium' }),
-    playwrightLauncher({ product: 'webkit' }),
+    
   ],
   groups: packages.map(pkg => ({
     name: pkg.name,


### PR DESCRIPTION
Previously the XSRF token was added to any call to any origin.  
This is changed to only attach the token to requests that are POST/PUT/PATCH/DELETE.  
And another change is that it will validate if the request origin is the same as current origin or when the origin is in the xsrfTrustedOrigins.

This is a fix for a vulnerability found, as we inadvertently revealed the confidential XSRF-TOKEN stored in cookies by including it in the HTTP header X-XSRF-TOKEN for every request made to any host allowing attackers to view sensitive information.