### PR TITLE
fix(ui): only use elementToFocusAfterHide when provided as HTMLElement

### DIFF
--- a/.changeset/twelve-deers-punch.md
+++ b/.changeset/twelve-deers-punch.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix: only use elementToFocusAfterHide when provided as HTMLElement

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -931,7 +931,7 @@ export class OverlayController extends EventTarget {
       return;
     }
 
-    if (this.elementToFocusAfterHide) {
+    if (this.elementToFocusAfterHide instanceof HTMLElement) {
       this.elementToFocusAfterHide.focus();
       this.elementToFocusAfterHide.scrollIntoView({ block: 'nearest' });
     } else {


### PR DESCRIPTION
## What I did

1.
