### PR TITLE
feat: allow SlotRerenderObject to to first render on connectedCallbac…

### DIFF
--- a/.changeset/funny-numbers-prove.md
+++ b/.changeset/funny-numbers-prove.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+feat: allow SlotRerenderObject to first render on connectedCallback via `firstRenderOnConnected`

--- a/docs/fundamentals/systems/core/SlotMixin.md
+++ b/docs/fundamentals/systems/core/SlotMixin.md
@@ -104,6 +104,13 @@ A `SlotRerenderObject` looks like this:
 ```ts
 {
   template: TemplateResult;
+  /**
+   * For backward compat with traditional light render methods,
+   * it might be needed to have slot contents available in `connectedCallback`.
+   * Only enable this for existing components that rely on light content availability in connectedCallback.
+   * For new components, please align with ReactiveElement/LitElement reactive cycle callbacks.
+   */
+  firstRenderOnConnected?: boolean;
 }
 ```
 

--- a/packages/ui/components/core/src/SlotMixin.js
+++ b/packages/ui/components/core/src/SlotMixin.js
@@ -195,6 +195,11 @@ const SlotMixinImplementation = superclass =>
         } else if (isRerenderConfig(slotFunctionResult)) {
           // Rerenderable slots are scheduled in the "updated loop"
           this.__slotsThatNeedRerender.add(slotName);
+
+          // For backw. compat, we allow a first render on connectedCallback
+          if (slotFunctionResult.firstRenderOnConnected) {
+            this.__rerenderSlot(slotName);
+          }
         } else {
           throw new Error(
             `Slot "${slotName}" configured inside "get slots()" (in prototype) of ${this.constructor.name} may return these types: TemplateResult | Node | {template:TemplateResult, afterRender?:function} | undefined.

--- a/packages/ui/components/core/types/SlotMixinTypes.ts
+++ b/packages/ui/components/core/types/SlotMixinTypes.ts
@@ -8,9 +8,16 @@ export type SlotRerenderObject = {
   template: TemplateResult;
   /**
    * Add logic that will be performed after the render
-   * @deprecated
+   * @deprecated use regular ReactiveElement/LitElement reactive cycle callbacks instead
    */
   afterRender?: Function;
+  /**
+   * For backward compat with traditional light render methods,
+   * it might be needed to have slot contents available in `connectedCallback`.
+   * Only enable this for existing components that rely on light content availability in connectedCallback.
+   * For new components, please align with ReactiveElement/LitElement reactive cycle callbacks.
+   */
+  firstRenderOnConnected?: boolean;
 };
 
 export type SlotFunctionResult = TemplateResult | Element | SlotRerenderObject | undefined;


### PR DESCRIPTION
feat: allow SlotRerenderObject to first render on connectedCallback via `firstRenderOnConnected`