### PR TITLE
fix(ui): Fix multiple Lit versions - pin @open-wc/scoped-elements to 2.2.0 (#2224)

### DIFF
--- a/.changeset/cold-pets-retire.md
+++ b/.changeset/cold-pets-retire.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[@lion/ui]: Fix "Multiple versions of Lit loaded." by pinning `@open-wc/scoped-elements` version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20919,7 +20919,7 @@
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.0.4",
         "@open-wc/dedupe-mixin": "^1.3.1",
-        "@open-wc/scoped-elements": "2.2.3",
+        "@open-wc/scoped-elements": "2.2.0",
         "@popperjs/core": "^2.11.6",
         "autosize": "4.0.2",
         "awesome-phonenumber": "^4.0.0",
@@ -20934,9 +20934,9 @@
       "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
     },
     "packages/ui/node_modules/@open-wc/scoped-elements": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.3.tgz",
-      "integrity": "sha512-U3nmKyc8gi6Doatum5uek7mfmcdrTc9dItWFJdb0feDmBIOpM9nhvJtThcntoXlg6zQ/sRqQFRZ+0ko2y7c+qA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.0.tgz",
+      "integrity": "sha512-Qe+vWsuVHFzUkdChwlmJGuQf9cA3I+QOsSHULV/6qf6wsqLM2/32svNRH+rbBIMwiPEwzZprZlkvkqQRucYnVA==",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
         "@open-wc/dedupe-mixin": "^1.4.0"
@@ -23016,7 +23016,7 @@
       "requires": {
         "@bundled-es-modules/message-format": "^6.0.4",
         "@open-wc/dedupe-mixin": "^1.3.1",
-        "@open-wc/scoped-elements": "2.2.3",
+        "@open-wc/scoped-elements": "2.2.0",
         "@popperjs/core": "^2.11.6",
         "autosize": "4.0.2",
         "awesome-phonenumber": "^4.0.0",
@@ -23031,9 +23031,9 @@
           "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
         },
         "@open-wc/scoped-elements": {
-          "version": "2.2.3",
-          "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.3.tgz",
-          "integrity": "sha512-U3nmKyc8gi6Doatum5uek7mfmcdrTc9dItWFJdb0feDmBIOpM9nhvJtThcntoXlg6zQ/sRqQFRZ+0ko2y7c+qA==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.0.tgz",
+          "integrity": "sha512-Qe+vWsuVHFzUkdChwlmJGuQf9cA3I+QOsSHULV/6qf6wsqLM2/32svNRH+rbBIMwiPEwzZprZlkvkqQRucYnVA==",
           "requires": {
             "@lit/reactive-element": "^1.0.0",
             "@open-wc/dedupe-mixin": "^1.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3178,6 +3178,7 @@
     },
     "node_modules/@open-wc/dedupe-mixin": {
       "version": "1.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@open-wc/eslint-config": {
@@ -3243,6 +3244,7 @@
     },
     "node_modules/@open-wc/scoped-elements": {
       "version": "2.1.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
@@ -19829,7 +19831,7 @@
       }
     },
     "packages-node/providence-analytics": {
-      "version": "0.15.1",
+      "version": "0.15.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20903,7 +20905,7 @@
     },
     "packages/ajax": {
       "name": "@lion/ajax",
-      "version": "1.3.0",
+      "version": "2.0.1",
       "license": "MIT"
     },
     "packages/singleton-manager": {
@@ -20912,18 +20914,32 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.5.2",
+      "version": "0.5.5",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.0.4",
         "@open-wc/dedupe-mixin": "^1.3.1",
-        "@open-wc/scoped-elements": "^2.1.4",
+        "@open-wc/scoped-elements": "2.2.3",
         "@popperjs/core": "^2.11.6",
         "autosize": "4.0.2",
         "awesome-phonenumber": "^4.0.0",
         "ibantools": "^2.2.0",
         "lit": "^2.4.0",
         "singleton-manager": "^1.7.0"
+      }
+    },
+    "packages/ui/node_modules/@open-wc/dedupe-mixin": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+      "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+    },
+    "packages/ui/node_modules/@open-wc/scoped-elements": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.3.tgz",
+      "integrity": "sha512-U3nmKyc8gi6Doatum5uek7mfmcdrTc9dItWFJdb0feDmBIOpM9nhvJtThcntoXlg6zQ/sRqQFRZ+0ko2y7c+qA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0",
+        "@open-wc/dedupe-mixin": "^1.4.0"
       }
     }
   },
@@ -23000,13 +23016,29 @@
       "requires": {
         "@bundled-es-modules/message-format": "^6.0.4",
         "@open-wc/dedupe-mixin": "^1.3.1",
-        "@open-wc/scoped-elements": "^2.1.4",
+        "@open-wc/scoped-elements": "2.2.3",
         "@popperjs/core": "^2.11.6",
         "autosize": "4.0.2",
         "awesome-phonenumber": "^4.0.0",
         "ibantools": "^2.2.0",
         "lit": "^2.4.0",
         "singleton-manager": "^1.7.0"
+      },
+      "dependencies": {
+        "@open-wc/dedupe-mixin": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
+          "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA=="
+        },
+        "@open-wc/scoped-elements": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-2.2.3.tgz",
+          "integrity": "sha512-U3nmKyc8gi6Doatum5uek7mfmcdrTc9dItWFJdb0feDmBIOpM9nhvJtThcntoXlg6zQ/sRqQFRZ+0ko2y7c+qA==",
+          "requires": {
+            "@lit/reactive-element": "^1.0.0",
+            "@open-wc/dedupe-mixin": "^1.4.0"
+          }
+        }
       }
     },
     "@lit-labs/ssr-dom-shim": {
@@ -23231,7 +23263,8 @@
       }
     },
     "@open-wc/dedupe-mixin": {
-      "version": "1.3.1"
+      "version": "1.3.1",
+      "dev": true
     },
     "@open-wc/eslint-config": {
       "version": "10.0.0",
@@ -23282,6 +23315,7 @@
     },
     "@open-wc/scoped-elements": {
       "version": "2.1.4",
+      "dev": true,
       "requires": {
         "@lit/reactive-element": "^1.0.0",
         "@open-wc/dedupe-mixin": "^1.3.0"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@bundled-es-modules/message-format": "^6.0.4",
     "@open-wc/dedupe-mixin": "^1.3.1",
-    "@open-wc/scoped-elements": "^2.1.4",
+    "@open-wc/scoped-elements": "2.2.3",
     "@popperjs/core": "^2.11.6",
     "autosize": "4.0.2",
     "awesome-phonenumber": "^4.0.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,7 +63,7 @@
   "dependencies": {
     "@bundled-es-modules/message-format": "^6.0.4",
     "@open-wc/dedupe-mixin": "^1.3.1",
-    "@open-wc/scoped-elements": "2.2.3",
+    "@open-wc/scoped-elements": "2.2.0",
     "@popperjs/core": "^2.11.6",
     "autosize": "4.0.2",
     "awesome-phonenumber": "^4.0.0",


### PR DESCRIPTION
## What I did

1. Pinned the version of `@open-wc/scoped-elements` to `2.2.0`

This is the last non-build breaking version that doesn't need `@lit/reactive-element` v2 for which AFAIK Lion is not yet ready due to using Lit v2 ATM. The issue with the `2.2.3` was that it failed type checks of some mixins.