### PR TITLE
fix(localize): let parseNumber() deal with extra '-' chars (#2227)

### DIFF
--- a/packages/ui/components/localize/src/number/parseNumber.js
+++ b/packages/ui/components/localize/src/number/parseNumber.js
@@ -87,6 +87,20 @@ function parseHeuristic(value) {
 }
 
 /**
+ * Removes extra minus signs following the first occurrence.
+ * @param {string} value String to be parsed as a number
+ */
+function dropExtraMinus(value) {
+  if (!value.includes('-')) {
+    return value;
+  }
+  const index = value.indexOf('-');
+  const beforeMinus = value.substring(0, index);
+  const afterMinus = value.substring(index + 1);
+  return `${beforeMinus}-${afterMinus.replace(/-/g, '')}`;
+}
+
+/**
  * Parses a number string and returns the best possible javascript number.
  * For edge cases it may use locale to give the best possible assumption.
  *
@@ -115,7 +129,7 @@ export function parseNumber(value, options) {
   if (!matchedInput) {
     return undefined;
   }
-  const cleanedInput = matchedInput.join('');
+  const cleanedInput = dropExtraMinus(matchedInput.join(''));
   const parseMode = getParseMode(cleanedInput, options);
   switch (parseMode) {
     case 'unparseable': {

--- a/packages/ui/components/localize/test/number/parseNumber.test.js
+++ b/packages/ui/components/localize/test/number/parseNumber.test.js
@@ -159,6 +159,13 @@ describe('parseNumber()', () => {
       expect(parseNumber('-1,234,56')).to.equal(-123456);
       expect(parseNumber('-1 234 56')).to.equal(-123456);
     });
+
+    it('ignores extra minus signs e.g. --1', () => {
+      expect(parseNumber('--1.234.56')).to.equal(-123456);
+      expect(parseNumber('-−1,234,56')).to.equal(-123456);
+      expect(parseNumber('−-1 234 56')).to.equal(-123456);
+      expect(parseNumber('−−1 234 56')).to.equal(-123456);
+    });
   });
 
   it('ignores non-number characters and returns undefined', () => {


### PR DESCRIPTION
## What I did

1. In the `@lion/ui/localize` wrapped a utility that drops any additional '-' character from the original `cleanedInput ` so that parsing will result in a negative number instead of `NaN`

This behavior will also align better with how the parser would behave if '+' character would be used in a similar fashion.
