### PR TITLE
feat(ui): [SlotMixin] allow to (re)render scoped elements as direct light dom child

### DIFF
--- a/.changeset/smooth-suits-compare.md
+++ b/.changeset/smooth-suits-compare.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[core/SlotMixin] allow to (re)render scoped elements as direct light dom child

--- a/packages/ui/components/core/types/SlotMixinTypes.ts
+++ b/packages/ui/components/core/types/SlotMixinTypes.ts
@@ -18,6 +18,14 @@ export type SlotRerenderObject = {
    * For new components, please align with ReactiveElement/LitElement reactive cycle callbacks.
    */
   firstRenderOnConnected?: boolean;
+  /**
+   * This is recommended to set to true always, as its behavior is usually desired and more in line with slot nodes that
+   * are not configured as rerenderable.
+   * For backward compatibility, it is set to false by default.
+   * When not configured, content is wrapped in a div (this can be problematic for ::slotted css selectors and for
+   * querySelectors that expect [slot=x] to have some semantic or (presentational) value).
+   */
+  renderAsDirectHostChild?: boolean;
 };
 
 export type SlotFunctionResult = TemplateResult | Element | SlotRerenderObject | undefined;

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -84,6 +84,7 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
             .multiple=${this.multiple}
           ></lion-selected-file-list>
         `,
+        renderAsDirectHostChild: true,
       }),
     };
   }
@@ -183,7 +184,7 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
    */
   get _fileListNode() {
     return /** @type {LionSelectedFileList} */ (
-      Array.from(this.children).find(child => child.slot === 'selected-file-list')?.children[0]
+      Array.from(this.children).find(child => child.slot === 'selected-file-list')
     );
   }
 

--- a/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -180,6 +180,7 @@ export class LionInputTelDropdown extends LionInputTel {
 
         return {
           template: templates.dropdown(this._templateDataDropdown),
+          renderAsDirectHostChild: Boolean,
         };
       },
     };

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
@@ -215,7 +215,7 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
       it('renders to prefix slot in light dom', async () => {
         const el = await fixture(html` <${tag} .allowedRegions="${['DE']}"></${tag}> `);
         const prefixSlot = /** @type {HTMLElement} */ (
-          /** @type {HTMLElement} */ (el.refs.dropdown.value).parentElement
+          /** @type {HTMLElement} */ (el.refs.dropdown.value)
         );
         expect(prefixSlot.getAttribute('slot')).to.equal('prefix');
         expect(prefixSlot.slot).to.equal('prefix');

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -22,8 +22,8 @@ const packages = fs
  * @type {import('@web/test-runner').TestRunnerConfig['testRunnerHtml']}
  *
  */
-const testRunnerHtml = (testRunnerImport) =>
-`
+const testRunnerHtml = testRunnerImport =>
+  `
 <html>
   <head>
     <script src="/node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script>
@@ -38,10 +38,10 @@ export default {
     report: true,
     reportDir: 'coverage',
     threshold: {
-      statements: 90,
-      branches: 65,
-      functions: 80,
-      lines: 90,
+      statements: 95,
+      functions: 95,
+      branches: 95,
+      lines: 95,
     },
   },
   testFramework: {


### PR DESCRIPTION
```ts
/**
 * This is recommended to set to true always, as its behavior is usually desired and more in line with slot nodes that
 * are not configured as rerenderable.
 * For backward compatibility, it is set to false by default.
 * When not configured, content is wrapped in a div (this can be problematic for ::slotted css selectors and for
 * querySelectors that expect [slot=x] to have some semantic or (presentational) value).
 */
renderAsDirectHostChild?: boolean;
```