### PR TITLE
Clean up cache properly if session ID changes

### DIFF
--- a/.changeset/quick-seas-help.md
+++ b/.changeset/quick-seas-help.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+Reset cache and pending requests when cache session ID changes

--- a/packages/ajax/src/PendingRequestStore.js
+++ b/packages/ajax/src/PendingRequestStore.js
@@ -55,6 +55,7 @@ export default class PendingRequestStore {
   }
 
   reset() {
+    this.resolveMatching(/.*/);
     this._pendingRequests = {};
   }
 }

--- a/packages/ajax/src/cacheManager.js
+++ b/packages/ajax/src/cacheManager.js
@@ -33,6 +33,15 @@ export const pendingRequestStore = new PendingRequestStore();
 export const isCurrentSessionId = cacheId => cacheId === cacheSessionId;
 
 /**
+ * Sets the current cache session ID.
+ *
+ * @param {string} id The id that will be tied to the current session
+ */
+export const setCacheSessionId = id => {
+  cacheSessionId = id;
+};
+
+/**
  * Resets the cache session when the cacheId changes.
  *
  * There can be only 1 active session at all times.
@@ -43,7 +52,7 @@ export const resetCacheSession = cacheId => {
     throw new Error('Invalid cache identifier');
   }
   if (!isCurrentSessionId(cacheId)) {
-    cacheSessionId = cacheId;
+    setCacheSessionId(cacheId);
     ajaxCache.reset();
     pendingRequestStore.reset();
   }

--- a/packages/ajax/src/interceptors/cacheInterceptors.js
+++ b/packages/ajax/src/interceptors/cacheInterceptors.js
@@ -96,6 +96,12 @@ const createCacheRequestInterceptor =
     if (pendingRequest) {
       // there is another concurrent request, wait for it to finish
       await pendingRequest;
+
+      // If session ID changes while waiting for the pending request to complete,
+      // then do not read the cache.
+      if (!isCurrentSessionId(request.cacheSessionId)) {
+        return request;
+      }
     }
 
     const cachedResponse = ajaxCache.get(requestId, { maxAge, maxResponseSize });


### PR DESCRIPTION
## What I did

1. Sometimes the logged in session ID will change when processing a "pending" request before a "current" request is processed, meaning that the "current" request no longer should be cached. This PR cleans up and invalidates the request and cache if the session ID changes.
