### PR TITLE
fix(select-rich): only close the overlay on tab when trapsKeyboardFoc…

### DIFF
--- a/.changeset/silly-laws-yell.md
+++ b/.changeset/silly-laws-yell.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[select-rich] only close the overlay on tab when trapsKeyboardFocus is false

--- a/packages/ui/components/select-rich/src/LionSelectRich.js
+++ b/packages/ui/components/select-rich/src/LionSelectRich.js
@@ -541,6 +541,9 @@ export class LionSelectRich extends SlotMixin(ScopedElementsMixin(OverlayMixin(L
     switch (key) {
       case 'Tab':
         // Tab can only be caught in keydown
+        if (this._overlayCtrl.config.trapsKeyboardFocus === true) {
+          return;
+        }
         this.opened = false;
         break;
       case 'Escape':

--- a/packages/ui/components/select-rich/test/lion-select-rich.test.js
+++ b/packages/ui/components/select-rich/test/lion-select-rich.test.js
@@ -501,6 +501,18 @@ describe('lion-select-rich', () => {
       _listboxNode.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
       expect(el.opened).to.be.false;
     });
+
+    it('does not close the listbox with [Tab] key once opened when trapsKeyboardFocus is true', async () => {
+      const el = await fixture(
+        html`
+          <lion-select-rich opened .config=${{ trapsKeyboardFocus: true }}> </lion-select-rich>
+        `,
+      );
+      // tab can only be caught via keydown
+      const { _listboxNode } = getSelectRichMembers(el);
+      _listboxNode.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+      expect(el.opened).to.be.true;
+    });
   });
 
   describe('Mouse navigation', () => {


### PR DESCRIPTION
…us is false

## What I did

1. In our extension of the select-rich we set `trapsKeyboardFocus: true`, but the select-rich still closed the overlay on tab. Which was not wanted in our case. 
