### PR TITLE
Add caching tests for when getCacheIdentifier is asynchronous

### DIFF
--- a/.changeset/stupid-pandas-greet.md
+++ b/.changeset/stupid-pandas-greet.md
@@ -1,0 +1,5 @@
+---
+'@lion/ajax': patch
+---
+
+Add caching tests for when getCacheIdentifier is asynchronous


### PR DESCRIPTION
## What I did

1. Previous to this two PRs were merged that added an option for getCacheIdentifier to be asynchronous and for the cache to be cleaned up gracefully when the session ID changed.

2. This PR adds tests for  the cache cleanup when using the new async getCacheIdentifier functionality
