### PR TITLE
fix(slotmixin): Now throws shadowRoot not found in case of shadowRoot…

### DIFF
--- a/.changeset/stupid-hats-jam.md
+++ b/.changeset/stupid-hats-jam.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Now prints console error when shadowRoot is not found

--- a/packages/ui/components/core/src/SlotMixin.js
+++ b/packages/ui/components/core/src/SlotMixin.js
@@ -134,6 +134,7 @@ const SlotMixinImplementation = superclass =>
         const hasShadowRoot = Boolean(this.shadowRoot);
         if (!hasShadowRoot) {
           // TODO: throw an error in a breaking release
+          // eslint-disable no-console
           console.error(`[SlotMixin] No shadowRoot was found`);
         }
         const registryRoot = supportsScopedRegistry ? this.shadowRoot : document;

--- a/packages/ui/components/core/src/SlotMixin.js
+++ b/packages/ui/components/core/src/SlotMixin.js
@@ -134,7 +134,7 @@ const SlotMixinImplementation = superclass =>
         const hasShadowRoot = Boolean(this.shadowRoot);
         if (!hasShadowRoot) {
           // TODO: throw an error in a breaking release
-          // eslint-disable no-console
+          // eslint-disable-next-line no-console
           console.error(`[SlotMixin] No shadowRoot was found`);
         }
         const registryRoot = supportsScopedRegistry ? this.shadowRoot : document;

--- a/packages/ui/components/core/src/SlotMixin.js
+++ b/packages/ui/components/core/src/SlotMixin.js
@@ -133,7 +133,8 @@ const SlotMixinImplementation = superclass =>
         const supportsScopedRegistry = !!ShadowRoot.prototype.createElement;
         const hasShadowRoot = Boolean(this.shadowRoot);
         if (!hasShadowRoot) {
-          throw new Error(`No shadowRoot was found`);
+          // TODO: throw an error in a breaking release
+          console.error(`[SlotMixin] No shadowRoot was found`);
         }
         const registryRoot = supportsScopedRegistry ? this.shadowRoot : document;
 

--- a/packages/ui/components/core/src/SlotMixin.js
+++ b/packages/ui/components/core/src/SlotMixin.js
@@ -131,7 +131,11 @@ const SlotMixinImplementation = superclass =>
       if (isFirstRender) {
         // @ts-expect-error wait for browser support
         const supportsScopedRegistry = !!ShadowRoot.prototype.createElement;
-        const registryRoot = supportsScopedRegistry ? this.shadowRoot || document : document;
+        const hasShadowRoot = Boolean(this.shadowRoot);
+        if (!hasShadowRoot) {
+          throw new Error(`No shadowRoot was found`);
+        }
+        const registryRoot = supportsScopedRegistry ? this.shadowRoot : document;
 
         // @ts-expect-error wait for browser support
         const renderTargetThatRespectsShadowRootScoping = registryRoot.createElement('div');


### PR DESCRIPTION
… equals to null

## What I did

1. I throw an error if shadowRoot was not found.
