### PR TITLE
fix(overlays): fix memory leaks of adopt-styles and OverlayMixin (#2300)

### DIFF
--- a/.changeset/quiet-apricots-sneeze.md
+++ b/.changeset/quiet-apricots-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[overlays] Fixed memory leak caused adopted style cache and the `OverlayMixin` not releasing the `OverlayController` on teardown

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -192,7 +192,6 @@ export class OverlayController extends EventTarget {
       zIndex: 9999,
     };
 
-    this.manager.add(this);
     /** @protected */
     this._contentId = `overlay-content--${Math.random().toString(36).slice(2, 10)}`;
     /** @private */
@@ -475,6 +474,14 @@ export class OverlayController extends EventTarget {
     this._init();
     /** @private */
     this.__elementToFocusAfterHide = undefined;
+
+    if (!this.#isRegisteredOnManager()) {
+      this.manager.add(this);
+    }
+  }
+
+  #isRegisteredOnManager() {
+    return Boolean(this.manager.list.find(ctrl => this === ctrl));
   }
 
   /**
@@ -1341,6 +1348,10 @@ export class OverlayController extends EventTarget {
     this.__handleOverlayStyles({ phase: 'teardown' });
     this._handleFeatures({ phase: 'teardown' });
     this.__wrappingDialogNode?.removeEventListener('cancel', this.__cancelHandler);
+
+    if (this.#isRegisteredOnManager()) {
+      this.manager.remove(this);
+    }
   }
 
   /** @private */

--- a/packages/ui/components/overlays/src/OverlayMixin.js
+++ b/packages/ui/components/overlays/src/OverlayMixin.js
@@ -182,6 +182,13 @@ export const OverlayMixinImplementation = superclass =>
       this._setupOverlayCtrl();
     }
 
+    connectedCallback() {
+      super.connectedCallback();
+      if (this._overlayCtrl) {
+        this.__connectOverlayCtrl();
+      }
+    }
+
     disconnectedCallback() {
       super.disconnectedCallback();
       if (this._overlayCtrl) {
@@ -247,16 +254,35 @@ export const OverlayMixinImplementation = superclass =>
       this.__syncToOverlayController();
       this.__setupSyncFromOverlayController();
       this._setupOpenCloseListeners();
+      this.__connectOverlayCtrl();
+    }
+
+    /** @private */
+    __connectOverlayCtrl() {
+      const ctrlToConnect = /** @type {OverlayController} */ (this._overlayCtrl);
+      if (!ctrlToConnect.manager.list.find(ctrl => ctrl === ctrlToConnect)) {
+        ctrlToConnect.manager.add(ctrlToConnect);
+      }
+    }
+
+    /**
+     * Necessary to prevent a memory leak caused by the manager never letting the controller go.
+     * @private
+     */
+    __unregisterOverlayCtrl() {
+      const ctrlToDisconnect = /** @type {OverlayController} */ (this._overlayCtrl);
+      if (ctrlToDisconnect.manager.list.find(ctrl => ctrl === ctrlToDisconnect)) {
+        ctrlToDisconnect.manager.remove(ctrlToDisconnect);
+      }
     }
 
     /** @protected */
     _teardownOverlayCtrl() {
       this._teardownOpenCloseListeners();
       this.__teardownSyncFromOverlayController();
-      /** @type {OverlayController} */
-      (this._overlayCtrl).teardown();
-      /** @type {OverlayController} */
-      (this._overlayCtrl).manager.remove(/** @type {OverlayController} */ (this._overlayCtrl));
+      const ctrlToTeardown = /** @type {OverlayController} */ (this._overlayCtrl);
+      ctrlToTeardown.teardown();
+      this.__unregisterOverlayCtrl();
     }
 
     /**

--- a/packages/ui/components/overlays/src/OverlayMixin.js
+++ b/packages/ui/components/overlays/src/OverlayMixin.js
@@ -255,6 +255,8 @@ export const OverlayMixinImplementation = superclass =>
       this.__teardownSyncFromOverlayController();
       /** @type {OverlayController} */
       (this._overlayCtrl).teardown();
+      /** @type {OverlayController} */
+      (this._overlayCtrl).manager.remove(/** @type {OverlayController} */ (this._overlayCtrl));
     }
 
     /**

--- a/packages/ui/components/overlays/src/utils/adopt-styles.js
+++ b/packages/ui/components/overlays/src/utils/adopt-styles.js
@@ -25,7 +25,7 @@ export const _adoptStyleUtils = {
   adoptStyles: undefined,
 };
 
-const styleCache = new Map();
+const styleCache = new WeakMap();
 
 /**
  * @param {CSSStyleSheet} cssStyleSheet
@@ -81,10 +81,10 @@ function adoptStyleWhenAdoptedStylesheetsNotSupported(
  */
 function handleCache(renderRoot, style, { teardown = false } = {}) {
   let haltFurtherExecution = false;
-  if (!styleCache.has(renderRoot)) {
+  if (renderRoot && !styleCache.has(renderRoot)) {
     styleCache.set(renderRoot, []);
   }
-  const addedStylesForRoot = styleCache.get(renderRoot);
+  const addedStylesForRoot = styleCache.get(renderRoot) ?? [];
   const foundStyle = addedStylesForRoot.find(
     (/** @type {import("lit").CSSResultOrNative} */ addedStyle) => style === addedStyle,
   );

--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -37,6 +37,14 @@ async function mimicEscapePress(element) {
 }
 
 /**
+ * @param {OverlayController} ctrlToFind
+ * @returns {boolean}
+ */
+function isRegisteredOnManager(ctrlToFind) {
+  return Boolean(ctrlToFind.manager?.list?.find(ctrl => ctrlToFind === ctrl));
+}
+
+/**
  * Make sure that all browsers serialize html in a similar way
  * (Firefox tends to output empty style attrs)
  * @param {HTMLElement} node
@@ -275,8 +283,18 @@ describe('OverlayController', () => {
     });
   });
 
-  // TODO: Add teardown feature tests
-  describe('Teardown', () => {});
+  // TODO: Add more teardown feature tests
+  describe('Teardown', () => {
+    it('unregisters itself from overlayManager', async () => {
+      const ctrl = new OverlayController(withGlobalTestConfig());
+
+      expect(isRegisteredOnManager(ctrl)).to.be.true;
+
+      ctrl.teardown();
+
+      expect(isRegisteredOnManager(ctrl)).to.be.false;
+    });
+  });
 
   describe('Node Configuration', () => {
     describe('Content', async () => {


### PR DESCRIPTION
## What I did

1. Adjust the `adopt-style` styleCache to be a `WeakMap` preventing the `renderRoot`s from being garbage collected
2. Let the `OverlayMixin` unwire its `OverlayController` from the `OverlayManager` on teardown
