### PR TITLE
fix: add files more than once doesn't overwrite anymore

### DIFF
--- a/.changeset/rude-deers-taste.md
+++ b/.changeset/rude-deers-taste.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[input-file] add files more than once doesn't overwrite model value anymore

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -499,13 +499,13 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
 
     this._inputNode.files = ev.dataTransfer.files;
 
-    const computedFiles = this.__computeNewAddedFiles(
-      /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)),
-    );
     if (this.multiple) {
+      const computedFiles = this.__computeNewAddedFiles(
+        /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)),
+      );
       this.modelValue = [...(this.modelValue ?? []), ...computedFiles];
     } else {
-      this.modelValue = computedFiles;
+      this.modelValue = Array.from(ev.dataTransfer.files);
     }
 
     // @ts-ignore

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -505,11 +505,10 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
       );
       this.modelValue = [...(this.modelValue ?? []), ...computedFiles];
     } else {
-      this.modelValue = Array.from(ev.dataTransfer.files);
+      this.modelValue = /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files));
     }
 
-    // @ts-ignore
-    this._processFiles(Array.from(ev.dataTransfer.files));
+    this._processFiles(/** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)));
   }
 
   /**
@@ -628,7 +627,6 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
       .map(({ systemFile }) => /** @type {InputFile} */ (systemFile));
 
     if (_successFiles.length > 0) {
-      // this.modelValue = [...this.modelValue, _successFiles];
       this._dispatchFileListChangeEvent(_successFiles);
     }
   }

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -176,6 +176,11 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
 
     /** @private */
     this.__duplicateFileNamesValidator = new DuplicateFileNames({ show: false });
+    /**
+     * @private
+     * @type {FileList | null}
+     */
+    this.__previouslyParsedFiles = null;
   }
 
   /**
@@ -283,8 +288,20 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
    * @returns {InputFile[]} parsedValue
    */
   parser() {
-    // @ts-ignore
-    return this._inputNode.files ? Array.from(this._inputNode.files) : [];
+    // parser is called twice for one user event; one for 'user-input-change', another for 'change'
+    if (this.__previouslyParsedFiles === this._inputNode.files) {
+      return this.modelValue;
+    }
+    this.__previouslyParsedFiles = this._inputNode.files;
+
+    const files = this._inputNode.files
+      ? /** @type {InputFile[]} */ (Array.from(this._inputNode.files))
+      : [];
+    if (this.multiple) {
+      return [...(this.modelValue ?? []), ...files];
+    }
+
+    return files;
   }
 
   /**
@@ -481,15 +498,17 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
     }
 
     this._inputNode.files = ev.dataTransfer.files;
+
+    const computedFiles = this.__computeNewAddedFiles(
+      /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)),
+    );
+    if (this.multiple) {
+      this.modelValue = [...(this.modelValue ?? []), ...computedFiles];
+    } else {
+      this.modelValue = computedFiles;
+    }
+
     // @ts-ignore
-    this.modelValue = Array.from(ev.dataTransfer.files);
-    // if same file is selected again, e.dataTransfer.files lists that file.
-    // So filter if the file already exists
-    // @ts-ignore
-    // const newFiles = this.__computeNewAddedFiles(Array.from(ev.dataTransfer.files));
-    // if (newFiles.length > 0) {
-    //   this._processFiles(newFiles);
-    // }
     this._processFiles(Array.from(ev.dataTransfer.files));
   }
 
@@ -609,6 +628,7 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
       .map(({ systemFile }) => /** @type {InputFile} */ (systemFile));
 
     if (_successFiles.length > 0) {
+      // this.modelValue = [...this.modelValue, _successFiles];
       this._dispatchFileListChangeEvent(_successFiles);
     }
   }


### PR DESCRIPTION
## What I did

1. Fixed a bug that when user adds files more than once, the model value is overwritten by the last addition but the file list grows, adding the last addition to the existing list
   - Example: User added two files, `a` and `b` in a file dialog, then  added another file `c` opening a file dialog once more. The file list would have `a`, `b`, `c` but the model value would be `c`. After the fix, the model value also would be `a`, `b`, `c`.
   - Tested on both dialog and drag & drop


----
- [x] Fixing an issue when we upload the same file, the model value gets empty.

