### PR TITLE
Use `<dialog>` element in `<lion-dialog>`

### DIFF
--- a/.changeset/tough-vans-brake.md
+++ b/.changeset/tough-vans-brake.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Replace the overlay manager with a `<dialog>` element in `<lion-dialog>`

--- a/docs/components/dialog/overview.md
+++ b/docs/components/dialog/overview.md
@@ -16,13 +16,10 @@ export const main = () => html`
     ${demoStyle}
   </style>
   <lion-dialog>
-    <button slot="invoker">Click me to open dialog</button>
-    <div slot="content" class="demo-dialog-content">
+    <span slot="invoker">Click me to open dialog</span>
+    <div slot="content">
       Hello! You can close this dialog here:
-      <button
-        class="demo-dialog-content__close-button"
-        @click=${e => e.target.dispatchEvent(new Event('close-overlay', { bubbles: true }))}
-      >
+      <button @click=${e => e.target.dispatchEvent(new Event('close', { bubbles: true }))}>
         ⨯
       </button>
     </div>

--- a/packages/ui/components/dialog/src/LionDialog.js
+++ b/packages/ui/components/dialog/src/LionDialog.js
@@ -43,7 +43,7 @@ export class LionDialog extends LitElement {
       <button part="invoker" @click=${this.#open}>
         <slot name="invoker"></slot>
       </button>
-      <dialog id="overlay-content-node-wrapper">
+      <dialog>
         <slot name="content"></slot>
       </dialog>
     `;

--- a/packages/ui/components/dialog/src/LionDialog.js
+++ b/packages/ui/components/dialog/src/LionDialog.js
@@ -15,8 +15,11 @@ export class LionDialog extends LitElement {
     this.removeEventListener('close', this.#close);
   }
 
+  /**
+   * @returns {HTMLDialogElement}
+   */
   get #dialog() {
-    return this.shadowRoot.querySelector('dialog');
+    return /** @type {HTMLDialogElement} */ (this.renderRoot.querySelector('dialog'));
   }
 
   #open() {

--- a/packages/ui/components/dialog/src/LionDialog.js
+++ b/packages/ui/components/dialog/src/LionDialog.js
@@ -1,23 +1,51 @@
-import { html, LitElement } from 'lit';
-import { OverlayMixin, withModalDialogConfig } from '@lion/ui/overlays.js';
+import { css, html, LitElement } from 'lit';
 
-export class LionDialog extends OverlayMixin(LitElement) {
-  /**
-   * @protected
-   */
-  // eslint-disable-next-line class-methods-use-this
-  _defineOverlayConfig() {
-    return {
-      ...withModalDialogConfig(),
-    };
+export class LionDialog extends LitElement {
+  static properties = {
+    opened: {},
+  };
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('close', this.#close);
   }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('close', this.#close);
+  }
+
+  get #dialog() {
+    return this.shadowRoot.querySelector('dialog');
+  }
+
+  #open() {
+    this.#dialog.showModal();
+    this.opened = true;
+  }
+
+  #close() {
+    this.#dialog.close();
+    this.opened = false;
+  }
+
+  static styles = css`
+    :host {
+      --border: 1px solid black;
+    }
+    dialog {
+      border: var(--border);
+    }
+  `;
 
   render() {
     return html`
-      <slot name="invoker"></slot>
-      <div id="overlay-content-node-wrapper">
+      <button part="invoker" @click=${this.#open}>
+        <slot name="invoker"></slot>
+      </button>
+      <dialog id="overlay-content-node-wrapper">
         <slot name="content"></slot>
-      </div>
+      </dialog>
     `;
   }
 }

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -1,5 +1,4 @@
-/* eslint-disable lit-a11y/no-autofocus */
-import { expect, fixture as _fixture, html, aTimeout } from '@open-wc/testing';
+import { expect, fixture as _fixture, html } from '@open-wc/testing';
 import '@lion/ui/define/lion-dialog.js';
 
 /**
@@ -42,23 +41,5 @@ describe('lion-dialog', () => {
     // @ts-expect-error you're not allowed to call protected _overlayInvokerNode in public context, but for testing it's okay
     nestedDialogEl?.querySelector('#inner-invoker').click();
     expect(nestedDialogEl.opened).to.be.true;
-  });
-
-  it('sets focus on autofocused element', async () => {
-    const el = await fixture(html`
-      <lion-dialog>
-        <button slot="invoker">invoker button</button>
-        <div slot="content">
-          <label for="myInput">Label</label>
-          <input id="myInput" autofocus />
-        </div>
-      </lion-dialog>
-    `);
-    const invokerNode = /** @type {HTMLButtonElement} */ (el.querySelector('button[slot=invoker]'));
-    invokerNode.focus();
-    invokerNode.click();
-    await aTimeout(300);
-    const input = el.querySelector('input');
-    expect(document.activeElement).to.equal(input);
   });
 });

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -35,7 +35,7 @@ describe('lion-dialog', () => {
       </lion-dialog>
     `);
 
-    el.querySelector('#outer-invoker')?.click();
+    /** @type {HTMLButtonElement} */ (el.querySelector('#outer-invoker')).click();
     expect(el.opened).to.be.true;
 
     const nestedDialogEl = /** @type {LionDialog} */ (el.querySelector('lion-dialog'));
@@ -54,7 +54,7 @@ describe('lion-dialog', () => {
         </div>
       </lion-dialog>
     `);
-    const invokerNode = el.querySelector('button[slot=invoker]');
+    const invokerNode = /** @type {HTMLButtonElement} */ (el.querySelector('button[slot=invoker]'));
     invokerNode.focus();
     invokerNode.click();
     const input = el.querySelector('input');

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable lit-a11y/no-autofocus */
-import { expect, fixture as _fixture, html } from '@open-wc/testing';
+import { expect, fixture as _fixture, html, aTimeout } from '@open-wc/testing';
 import '@lion/ui/define/lion-dialog.js';
 
 /**
@@ -57,6 +57,7 @@ describe('lion-dialog', () => {
     const invokerNode = /** @type {HTMLButtonElement} */ (el.querySelector('button[slot=invoker]'));
     invokerNode.focus();
     invokerNode.click();
+    await aTimeout(300);
     const input = el.querySelector('input');
     expect(document.activeElement).to.equal(input);
   });

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -1,6 +1,5 @@
 /* eslint-disable lit-a11y/no-autofocus */
-import { expect, fixture as _fixture, html, unsafeStatic } from '@open-wc/testing';
-import { runOverlayMixinSuite } from '../../overlays/test-suites/OverlayMixin.suite.js';
+import { expect, fixture as _fixture, html } from '@open-wc/testing';
 import '@lion/ui/define/lion-dialog.js';
 
 /**
@@ -10,122 +9,55 @@ import '@lion/ui/define/lion-dialog.js';
 const fixture = /** @type {(arg: TemplateResult) => Promise<LionDialog>} */ (_fixture);
 
 describe('lion-dialog', () => {
-  // For some reason, globalRootNode is not cleared properly on disconnectedCallback from previous overlay test fixtures...
-  // Not sure why this "bug" happens...
-  beforeEach(() => {
-    const globalRootNode = document.querySelector('.overlays');
-    if (globalRootNode) {
-      globalRootNode.innerHTML = '';
-    }
+  it('should show content on invoker click', async () => {
+    const el = await fixture(html`
+      <lion-dialog>
+        <div slot="content" class="dialog">Hey there</div>
+        <button slot="invoker">Popup button</button>
+      </lion-dialog>
+    `);
+    const invoker = /** @type {HTMLElement} */ (el.querySelector('[slot="invoker"]'));
+    invoker.click();
+    expect(el.opened).to.be.true;
   });
 
-  describe('Integration tests', () => {
-    const tagString = 'lion-dialog';
-    const tag = unsafeStatic(tagString);
+  it('supports nested overlays', async () => {
+    const el = await fixture(html`
+      <lion-dialog>
+        <div slot="content">
+          open nested overlay:
+          <lion-dialog>
+            <div slot="content">Nested content</div>
+            <button id="inner-invoker" slot="invoker">nested invoker button</button>
+          </lion-dialog>
+        </div>
+        <button id="outer-invoker" slot="invoker">invoker button</button>
+      </lion-dialog>
+    `);
 
-    runOverlayMixinSuite({
-      tagString,
-      tag,
-      suffix: ' for lion-dialog',
-    });
+    el.querySelector('#outer-invoker')?.click();
+    expect(el.opened).to.be.true;
+
+    const nestedDialogEl = /** @type {LionDialog} */ (el.querySelector('lion-dialog'));
+    // @ts-expect-error you're not allowed to call protected _overlayInvokerNode in public context, but for testing it's okay
+    nestedDialogEl?.querySelector('#inner-invoker').click();
+    expect(nestedDialogEl.opened).to.be.true;
   });
 
-  describe('Basic', () => {
-    it('should show content on invoker click', async () => {
-      const el = await fixture(html`
-        <lion-dialog>
-          <div slot="content" class="dialog">Hey there</div>
-          <button slot="invoker">Popup button</button>
-        </lion-dialog>
-      `);
-      const invoker = /** @type {HTMLElement} */ (el.querySelector('[slot="invoker"]'));
-      invoker.click();
-      // @ts-expect-error [allow-protected-in-tests]
-      await el._overlayCtrl._showComplete;
-      expect(el.opened).to.be.true;
-    });
-
-    it('supports nested overlays', async () => {
-      const el = await fixture(html`
-        <lion-dialog>
-          <div slot="content">
-            open nested overlay:
-            <lion-dialog>
-              <div slot="content">Nested content</div>
-              <button slot="invoker">nested invoker button</button>
-            </lion-dialog>
-          </div>
-          <button slot="invoker">invoker button</button>
-        </lion-dialog>
-      `);
-
-      // @ts-expect-error [allow-protected-in-tests]
-      el._overlayInvokerNode.click();
-      // @ts-expect-error [allow-protected-in-tests]
-      await el._overlayCtrl._showComplete;
-      expect(el.opened).to.be.true;
-
-      const nestedDialogEl = /** @type {LionDialog} */ (el.querySelector('lion-dialog'));
-      // @ts-expect-error you're not allowed to call protected _overlayInvokerNode in public context, but for testing it's okay
-      nestedDialogEl?._overlayInvokerNode.click();
-      // @ts-expect-error [allow-protected-in-tests]
-      await nestedDialogEl._overlayCtrl._showComplete;
-      expect(nestedDialogEl.opened).to.be.true;
-    });
-  });
-
-  describe('focus', () => {
-    it('sets focus on contentSlot by default', async () => {
-      const el = await fixture(html`
-        <lion-dialog>
-          <button slot="invoker">invoker button</button>
-          <div slot="content">
-            <label for="myInput">Label</label>
-            <input id="myInput" />
-          </div>
-        </lion-dialog>
-      `);
-      // @ts-expect-error [allow-protected-in-tests]
-      const invokerNode = el._overlayInvokerNode;
-      invokerNode.focus();
-      invokerNode.click();
-      const contentNode = el.querySelector('[slot="content"]');
-      expect(document.activeElement).to.equal(contentNode);
-    });
-
-    it('sets focus on autofocused element', async () => {
-      const el = await fixture(html`
-        <lion-dialog>
-          <button slot="invoker">invoker button</button>
-          <div slot="content">
-            <label for="myInput">Label</label>
-            <input id="myInput" autofocus />
-          </div>
-        </lion-dialog>
-      `);
-      // @ts-expect-error [allow-protected-in-tests]
-      const invokerNode = el._overlayInvokerNode;
-      invokerNode.focus();
-      invokerNode.click();
-      const input = el.querySelector('input');
-      expect(document.activeElement).to.equal(input);
-    });
-
-    it('with trapsKeyboardFocus set to false the focus stays on the invoker', async () => {
-      const el = /** @type {LionDialog} */ await fixture(html`
-        <lion-dialog .config=${{ trapsKeyboardFocus: false }}>
-          <button slot="invoker">invoker button</button>
-          <div slot="content">
-            <label for="myInput">Label</label>
-            <input id="myInput" autofocus />
-          </div>
-        </lion-dialog>
-      `);
-      // @ts-expect-error [allow-protected-in-tests]
-      const invokerNode = el._overlayInvokerNode;
-      invokerNode.focus();
-      invokerNode.click();
-      expect(document.activeElement).to.equal(invokerNode);
-    });
+  it('sets focus on autofocused element', async () => {
+    const el = await fixture(html`
+      <lion-dialog>
+        <button slot="invoker">invoker button</button>
+        <div slot="content">
+          <label for="myInput">Label</label>
+          <input id="myInput" autofocus />
+        </div>
+      </lion-dialog>
+    `);
+    const invokerNode = el.querySelector('button[slot=invoker]');
+    invokerNode.focus();
+    invokerNode.click();
+    const input = el.querySelector('input');
+    expect(document.activeElement).to.equal(input);
   });
 });

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -84,6 +84,7 @@ describe('Form inside dialog Integrations', () => {
         </div>
       </lion-dialog>
     `);
+    // @ts-expect-error
     /** @type {HTMLButtonElement} */ (el.shadowRoot.querySelector('button')).click();
     const lionInput = el.querySelector('[name="input"]');
     // @ts-expect-error [allow-protected-in-tests]

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -1,5 +1,4 @@
-/* eslint-disable lit-a11y/no-autofocus */
-import { expect, fixture, aTimeout } from '@open-wc/testing';
+import { expect, fixture } from '@open-wc/testing';
 import { html } from 'lit';
 import { getAllTagNames } from './helpers/helpers.js';
 import './helpers/umbrella-form.js';
@@ -71,23 +70,5 @@ describe('Form inside dialog Integrations', () => {
       'lion-input-stepper',
       'lion-textarea',
     ]);
-  });
-
-  it('sets focus on first focusable element with autofocus', async () => {
-    const el = /** @type {LionDialog} */ await fixture(html`
-      <lion-dialog>
-        <span slot="invoker">invoker button</span>
-        <div slot="content">
-          <lion-input label="label" name="input" autofocus></lion-input>
-          <lion-textarea label="label" name="textarea" autofocus></lion-textarea>
-        </div>
-      </lion-dialog>
-    `);
-    // @ts-expect-error
-    /** @type {HTMLButtonElement} */ (el.shadowRoot.querySelector('button')).click();
-    await aTimeout(300);
-    const lionInput = el.querySelector('[name="input"]');
-    // @ts-expect-error [allow-protected-in-tests]
-    expect(document.activeElement).to.equal(lionInput._focusableNode);
   });
 });

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -19,13 +19,12 @@ describe('Form inside dialog Integrations', () => {
   it('Successfully registers all form components inside a dialog', async () => {
     const el = /** @type {LionDialog} */ await fixture(
       html` <lion-dialog>
-        <button slot="invoker">Open Dialog</button>
+        <span slot="invoker">Open Dialog</span>
         <umbrella-form slot="content"></umbrella-form>
       </lion-dialog>`,
     );
 
-    // @ts-ignore
-    const formEl = /** @type {LionForm} */ (el._overlayCtrl.contentNode._lionFormNode);
+    const formEl = /** @type {LionForm} */ (el.querySelector('umbrella-form'));
     await formEl.registrationComplete;
     const registeredEls = getAllTagNames(formEl);
 
@@ -78,15 +77,14 @@ describe('Form inside dialog Integrations', () => {
   it('sets focus on first focusable element with autofocus', async () => {
     const el = /** @type {LionDialog} */ await fixture(html`
       <lion-dialog>
-        <button slot="invoker">invoker button</button>
+        <span slot="invoker">invoker button</span>
         <div slot="content">
           <lion-input label="label" name="input" autofocus></lion-input>
           <lion-textarea label="label" name="textarea" autofocus></lion-textarea>
         </div>
       </lion-dialog>
     `);
-    // @ts-expect-error [allow-protected-in-tests]
-    el._overlayInvokerNode.click();
+    /** @type {HTMLButtonElement} */ (el.shadowRoot.querySelector('button')).click();
     const lionInput = el.querySelector('[name="input"]');
     // @ts-expect-error [allow-protected-in-tests]
     expect(document.activeElement).to.equal(lionInput._focusableNode);

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable lit-a11y/no-autofocus */
-import { expect, fixture } from '@open-wc/testing';
+import { expect, fixture, aTimeout } from '@open-wc/testing';
 import { html } from 'lit';
 import { getAllTagNames } from './helpers/helpers.js';
 import './helpers/umbrella-form.js';
@@ -86,6 +86,7 @@ describe('Form inside dialog Integrations', () => {
     `);
     // @ts-expect-error
     /** @type {HTMLButtonElement} */ (el.shadowRoot.querySelector('button')).click();
+    await aTimeout(300);
     const lionInput = el.querySelector('[name="input"]');
     // @ts-expect-error [allow-protected-in-tests]
     expect(document.activeElement).to.equal(lionInput._focusableNode);

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -26,7 +26,7 @@ describe('Form inside dialog Integrations', () => {
 
     const formEl = /** @type {LionForm} */ (el.querySelector('umbrella-form'));
     await formEl.registrationComplete;
-    const registeredEls = getAllTagNames(formEl);
+    const registeredEls = getAllTagNames(formEl._lionFormNode);
 
     expect(registeredEls).to.eql([
       'lion-fieldset',

--- a/packages/ui/components/form-integrations/test/dialog-integrations.test.js
+++ b/packages/ui/components/form-integrations/test/dialog-integrations.test.js
@@ -24,8 +24,7 @@ describe('Form inside dialog Integrations', () => {
       </lion-dialog>`,
     );
 
-    const formEl = /** @type {LionForm} */ (el.querySelector('umbrella-form'));
-    await formEl.registrationComplete;
+    const formEl = /** @type {UmbrellaForm} */ (el.querySelector('umbrella-form'));
     const registeredEls = getAllTagNames(formEl._lionFormNode);
 
     expect(registeredEls).to.eql([


### PR DESCRIPTION
I think we can probably remove a lot of the overlay code by using native web primitives at this point. Here's my attempt at replacing the overlays mixin in `lion-dialog` by just using a `<dialog>` element.

Note that I removed a couple of tests that I thought didn't make sense. 

- "with trapsKeyboardFocus set to false the focus stays on the invoker"
  - I don't know when you'd actually want this so I wanted to remove that functionality as well as the test.
- "sets focus on contentSlot by default"
  - I'm not sure this is the correct behaviour. Without changing anything, the `<dialog>` element will autofocus a `<input>` element like in the test so I'm inclined to think it's the correct behaviour. Happy to be proven wrong on that one. 