### PR TITLE
fix(overlays): clicking outside iframe not closing the overlay

### DIFF
--- a/.changeset/spotty-penguins-taste.md
+++ b/.changeset/spotty-penguins-taste.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[overlays] now closes when iframe loses focus

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -1242,7 +1242,12 @@ export class OverlayController extends EventTarget {
       /** @type {EventListenerOrEventListenerObject} */
       this.__onWindowBlur = () => {
         // When the current window loses the focus (clicking outside iframe) the overlay gets hidden
-        this.hide();
+        setTimeout(() => {
+          const ctrlManaged = this.manager.list.includes(this);
+          if (ctrlManaged) {
+            this.hide();
+          }
+        });
       };
     }
 

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -1243,10 +1243,7 @@ export class OverlayController extends EventTarget {
       this.__onWindowBlur = () => {
         // When the current window loses the focus (clicking outside iframe) the overlay gets hidden
         setTimeout(() => {
-          const ctrlManaged = this.manager.list.includes(this);
-          if (ctrlManaged) {
-            this.hide();
-          }
+          this.hide();
         });
       };
     }
@@ -1289,7 +1286,6 @@ export class OverlayController extends EventTarget {
       'blur',
       /** @type {EventListenerOrEventListenerObject} */
       (this.__onWindowBlur),
-      true,
     );
   }
 

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -1238,6 +1238,12 @@ export class OverlayController extends EventTarget {
           wasMouseUpInside = false;
         });
       };
+
+      /** @type {EventListenerOrEventListenerObject} */
+      this.__onWindowBlur = () => {
+        // When the current window loses the focus (clicking outside iframe) the overlay gets hidden
+        this.hide();
+      };
     }
 
     this.contentWrapperNode[addOrRemoveListener](
@@ -1272,6 +1278,12 @@ export class OverlayController extends EventTarget {
       'mouseup',
       /** @type {EventListenerOrEventListenerObject} */
       (this.__onDocumentMouseUp),
+      true,
+    );
+    window[addOrRemoveListener](
+      'blur',
+      /** @type {EventListenerOrEventListenerObject} */
+      (this.__onWindowBlur),
       true,
     );
   }

--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -878,6 +878,19 @@ describe('OverlayController', () => {
 
         expect(ctrl.isShown).to.be.true;
       });
+
+      it('hides when window is blurred (useful for iframes)', async () => {
+        const ctrl = new OverlayController({
+          ...withGlobalTestConfig(),
+          hidesOnOutsideClick: true,
+        });
+        await ctrl.show();
+
+        window.dispatchEvent(new Event('blur'));
+        await aTimeout(0);
+
+        expect(ctrl.isShown).to.be.false;
+      });
     });
 
     describe('elementToFocusAfterHide', () => {


### PR DESCRIPTION
In lion-overlays a blur event listener was added to window, which closes the overlay when focused outside when hidesOnOutsideClick is enabled in the overlay config.


Corresponding issue and the problem explanation: fixes https://github.com/ing-bank/lion/issues/2315