### PR TITLE
fix: add files more than once doesn't overwrite anymore

### DIFF
--- a/.changeset/dry-turkeys-flash.md
+++ b/.changeset/dry-turkeys-flash.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[input-file] add files more than once doesn't overwrite model value anymore

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -499,13 +499,13 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
 
     this._inputNode.files = ev.dataTransfer.files;
 
-    const computedFiles = this.__computeNewAddedFiles(
-      /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)),
-    );
     if (this.multiple) {
+      const computedFiles = this.__computeNewAddedFiles(
+        /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)),
+      );
       this.modelValue = [...(this.modelValue ?? []), ...computedFiles];
     } else {
-      this.modelValue = computedFiles;
+      this.modelValue = Array.from(ev.dataTransfer.files);
     }
 
     // @ts-ignore

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -175,6 +175,11 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
 
     /** @private */
     this.__duplicateFileNamesValidator = new DuplicateFileNames({ show: false });
+    /**
+     * @private
+     * @type {FileList | null}
+     */
+    this.__previouslyParsedFiles = null;
   }
 
   /**
@@ -282,8 +287,20 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
    * @returns {InputFile[]} parsedValue
    */
   parser() {
-    // @ts-ignore
-    return this._inputNode.files ? Array.from(this._inputNode.files) : [];
+    // parser is called twice for one user event; one for 'user-input-change', another for 'change'
+    if (this.__previouslyParsedFiles === this._inputNode.files) {
+      return this.modelValue;
+    }
+    this.__previouslyParsedFiles = this._inputNode.files;
+
+    const files = this._inputNode.files
+      ? /** @type {InputFile[]} */ (Array.from(this._inputNode.files))
+      : [];
+    if (this.multiple) {
+      return [...(this.modelValue ?? []), ...files];
+    }
+
+    return files;
   }
 
   /**
@@ -481,15 +498,17 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
     }
 
     this._inputNode.files = ev.dataTransfer.files;
+
+    const computedFiles = this.__computeNewAddedFiles(
+      /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)),
+    );
+    if (this.multiple) {
+      this.modelValue = [...(this.modelValue ?? []), ...computedFiles];
+    } else {
+      this.modelValue = computedFiles;
+    }
+
     // @ts-ignore
-    this.modelValue = Array.from(ev.dataTransfer.files);
-    // if same file is selected again, e.dataTransfer.files lists that file.
-    // So filter if the file already exists
-    // @ts-ignore
-    // const newFiles = this.__computeNewAddedFiles(Array.from(ev.dataTransfer.files));
-    // if (newFiles.length > 0) {
-    //   this._processFiles(newFiles);
-    // }
     this._processFiles(Array.from(ev.dataTransfer.files));
   }
 
@@ -623,6 +642,7 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
       .map(({ systemFile }) => /** @type {InputFile} */ (systemFile));
 
     if (_successFiles.length > 0) {
+      // this.modelValue = [...this.modelValue, _successFiles];
       this._dispatchFileListChangeEvent(_successFiles);
     }
   }

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -505,11 +505,10 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
       );
       this.modelValue = [...(this.modelValue ?? []), ...computedFiles];
     } else {
-      this.modelValue = Array.from(ev.dataTransfer.files);
+      this.modelValue = /** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files));
     }
 
-    // @ts-ignore
-    this._processFiles(Array.from(ev.dataTransfer.files));
+    this._processFiles(/** @type {InputFile[]} */ (Array.from(ev.dataTransfer.files)));
   }
 
   /**
@@ -642,7 +641,6 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
       .map(({ systemFile }) => /** @type {InputFile} */ (systemFile));
 
     if (_successFiles.length > 0) {
-      // this.modelValue = [...this.modelValue, _successFiles];
       this._dispatchFileListChangeEvent(_successFiles);
     }
   }


### PR DESCRIPTION
## What I did

This is the same fix as in https://github.com/ing-bank/lion/pull/2308, but for 0.5.x which uses lit2.
