### PR TITLE
opened-changed event detail exposes opened state

### DIFF
--- a/.changeset/fuzzy-poets-brake.md
+++ b/.changeset/fuzzy-poets-brake.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+opened-changed event detail exposes opened state

--- a/docs/components/dialog/src/external-dialog.js
+++ b/docs/components/dialog/src/external-dialog.js
@@ -1,0 +1,32 @@
+import { LitElement, html } from 'lit';
+
+class DialogTriggerDemo extends LitElement {
+  static get properties() {
+    return {
+      _isOpen: { state: true },
+    };
+  }
+
+  toggleDialog(open) {
+    // eslint-disable-next-line no-return-assign
+    return () => (this._isOpen = open);
+  }
+
+  handleDialog(e) {
+    this._isOpen = e.detail.opened;
+  }
+
+  render() {
+    return html`
+      <button @click=${this.toggleDialog(true)}>Open dialog</button>
+      <lion-dialog ?opened=${this._isOpen} @opened-changed=${this.handleDialog}>
+        <div slot="content" class="dialog demo-box">
+          Hello! You can close this notification here:
+          <button class="close-button" @click=${this.toggleDialog(false)}>⨯</button>
+        </div>
+      </lion-dialog>
+    `;
+  }
+}
+
+customElements.define('dialog-trigger-demo', DialogTriggerDemo);

--- a/docs/components/dialog/use-cases.md
+++ b/docs/components/dialog/use-cases.md
@@ -10,6 +10,7 @@ import '@lion/ui/define/lion-dialog.js';
 import { demoStyle } from './src/demoStyle.js';
 import './src/styled-dialog-content.js';
 import './src/slots-dialog-content.js';
+import './src/external-dialog.js';
 ```
 
 ```html
@@ -20,6 +21,51 @@ import './src/slots-dialog-content.js';
   <div>
   <button slot="invoker">Click me</button>
 </lion-dialog>
+```
+
+## External trigger
+
+```js preview-story
+export const externalTrigger = () => {
+  const externalTriggerDialog = () => {
+    class DialogTriggerDemo extends LitElement {
+      static get properties() {
+        return {
+          _isOpen: { state: true },
+        };
+      }
+
+      toggleDialog(open) {
+        return () => (this._isOpen = open);
+      }
+
+      handleDialog(e) {
+        this._isOpen = e.detail.opened;
+      }
+
+      render() {
+        return html`
+          <button @click=${this.toggleDialog(true)}>Open dialog</button>
+          <lion-dialog ?opened=${this._isOpen} @opened-changed=${this.handleDialog}>
+            <div slot="content" class="dialog demo-box">
+              Hello! You can close this notification here:
+              <button class="close-button" @click=${this.toggleDialog(false)}>⨯</button>
+            </div>
+          </lion-dialog>
+        `;
+      }
+    }
+  };
+
+  return html`
+    <style>
+      ${demoStyle}
+    </style>
+    <div class="demo-box_placements">
+      <dialog-trigger-demo></dialog-trigger-demo>
+    </div>
+  `;
+};
 ```
 
 ## Placement overrides

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -143,6 +143,7 @@ describe('lion-dialog', () => {
       expect(el.opened).to.be.true;
 
       el.addEventListener('opened-changed', e => {
+        // @ts-expect-error [allow-detail-since-custom-event]
         expect(e.detail.opened).to.be.false;
       });
       el.removeAttribute('opened');

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -127,5 +127,42 @@ describe('lion-dialog', () => {
       invokerNode.click();
       expect(document.activeElement).to.equal(invokerNode);
     });
+
+    it('opened-changed event should send detail object with opened state', async () => {
+      const el = /** @type {LionDialog} */ await fixture(html`
+        <lion-dialog .config=${{ trapsKeyboardFocus: false }}>
+          <button slot="invoker">invoker button</button>
+          <div slot="content">
+            <label for="myInput">Label</label>
+            <input id="myInput" autofocus />
+          </div>
+        </lion-dialog>
+      `);
+
+      el.setAttribute('opened', '');
+      expect(el.opened).to.be.true;
+
+      el.addEventListener('opened-changed', e => {
+        expect(e.detail.opened).to.be.false;
+      });
+      el.removeAttribute('opened');
+    });
+
+    it("opened-changed event's target should point to lion-dialog", async () => {
+      const el = /** @type {LionDialog} */ await fixture(html`
+        <lion-dialog .config=${{ trapsKeyboardFocus: false }}>
+          <button slot="invoker">invoker button</button>
+          <div slot="content">
+            <label for="myInput">Label</label>
+            <input id="myInput" autofocus />
+          </div>
+        </lion-dialog>
+      `);
+
+      el.addEventListener('opened-changed', e => {
+        expect(e.target).to.equal(el);
+      });
+      el.setAttribute('opened', '');
+    });
   });
 });

--- a/packages/ui/components/overlays/src/OverlayMixin.js
+++ b/packages/ui/components/overlays/src/OverlayMixin.js
@@ -72,7 +72,11 @@ export const OverlayMixinImplementation = superclass =>
     requestUpdate(name, oldValue, options) {
       super.requestUpdate(name, oldValue, options);
       if (name === 'opened' && this.opened !== oldValue) {
-        this.dispatchEvent(new Event('opened-changed'));
+        this.dispatchEvent(
+          new CustomEvent('opened-changed', {
+            detail: { opened: this.opened },
+          }),
+        );
       }
     }
 


### PR DESCRIPTION
## What I Did

1. Replaced the `Event` with `CustomEvent` to include the `opened` state in the event's detail.
2. The `CustomEvent` now also references the host element in its event target.

### Note:

The `opened-changed` event previously lacked detail, and the `event.target` was `null`, making it impossible to determine the dialog's state within the event. This caused issues when attempting to control the dialog's state dynamically via the `opened` property.

A potential scenario is where a user dynamically triggers the dialog through the `opened` property, expecting to open or close the dialog accordingly. However, when the ESC key is pressed and the dialog closes, the state is not synced externally. As a result, the dialog might not reopen the next time the `opened` property is set to `true`.

By including `{ detail: { opened: true/false } }`, it becomes possible to accurately determine the dialog's state and update the `opened` property externally, ensuring it remains in sync with the actual dialog state. 
