### PR TITLE
docs: use dark theme for devices that prefer dark theme

### DIFF
--- a/docs/_assets/style.css
+++ b/docs/_assets/style.css
@@ -1,3 +1,14 @@
+body, #content-wrapper {
+  background-color: white;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #222;
+    filter: invert(1) hue-rotate(180deg);
+  }
+}
+
 body[layout='layout-home'] .markdown-body .call-to-action:nth-of-type(2) {
   background: linear-gradient(to right, #555, #222);
 }


### PR DESCRIPTION
## What I did
- created a dark theme

## Here is a comparison of how this dark theme looks like compared to original theme on mobile

[ing-lion-dark-light-theme-compare-mobile.webm](https://github.com/user-attachments/assets/f1821fb5-7af4-48d3-beee-2ff8344dc554)

## The same comparison for desktop (FLASHING warning)

[ing-lion-dark-light-theme-compare-desktop.webm](https://github.com/user-attachments/assets/0a7ea43d-8657-4bc0-8e11-54b2b8994ae0)

## Alternatives I tried/though of

1. Thought of creating a button that allows switching between dark/light/auto themes, persist in local storage, put it in topbar/sidenav, etc... . But picked delivering a dark theme now over perfecting it.
2. tried moving the dark theme related styles to a separate file and `@import url(./dark-theme.css);`. But the problem was I had to put the @import at the beginning of the file, and then the dark theme would lose its specifity and gets overriden by white background of body. Chose not to go with `!important` for this minimal change and keep it simple for now. The benefit of moving to a separate file (later) would be that we can fine-tune all dark-theme-related styles in that file.

This PR fixes https://github.com/ing-bank/lion/issues/2336