### PR TITLE
[Calendar] Calendar buttons look the same on non-white backgrounds

### DIFF
--- a/packages/ui/components/calendar/src/calendarStyle.js
+++ b/packages/ui/components/calendar/src/calendarStyle.js
@@ -28,7 +28,7 @@ export const calendarStyle = css`
 
   .calendar__previous-button,
   .calendar__next-button {
-    background-color: #fff;
+    background-color: transparent;
     border: 0;
     padding: 0;
     min-width: 40px;
@@ -48,7 +48,7 @@ export const calendarStyle = css`
   }
 
   .calendar__day-button {
-    background-color: #fff;
+    background-color: transparent;
     border: 0;
     color: black;
     padding: 0;
@@ -88,7 +88,7 @@ export const calendarStyle = css`
   }
 
   .calendar__day-button[aria-disabled='true'] {
-    background-color: #fff;
+    background-color: transparent;
     color: #eee;
     outline: none;
   }


### PR DESCRIPTION
Fixes https://github.com/ing-bank/lion/issues/2338

## What I did

1. Made Calendar buttons (day buttons, disabled day buttons, next/previous month/year buttons) background transparent
2. This is because on white background they looked good, but on non-white backgrounds they started looking uglier
3. I believe this is a better default behavior for a reusable component.
4. However may introduce breaking changes if someone really wanted those white backgrounds on their non-white background.
5. This is how the Calendar looks like after my changes:

![Screenshot from 2024-08-21 00-27-51](https://github.com/user-attachments/assets/68df255b-51da-44e5-8922-b87d79a3dfec)

(on a white background, it should keep looking as it did previously)