### PR TITLE
fix: incorrect file type of script for lint-staged rc

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -5,7 +5,7 @@ module.exports = {
     'prettier --write',
     "markdownlint --ignore '{.github/**/*.md,.changeset/*.md,**/CHANGELOG.md,packages/ui/_legacy-changelogs/*.md}'",
   ],
-  'package-lock.json': ['node ./scripts/lock-scan.js'],
+  'package-lock.json': ['node ./scripts/lock-scan.mjs'],
   '*package.json': absolutePaths => {
     const sortPackages = [];
     absolutePaths.forEach(p => {


### PR DESCRIPTION
## What I did

1. run correct lock-scan file type
