### PR TITLE
fix(markdown-table): Fixed code block in markdown api table

### DIFF
--- a/.changeset/friendly-spoons-cover.md
+++ b/.changeset/friendly-spoons-cover.md
@@ -1,0 +1,5 @@
+---
+'publish-docs': patch
+---
+
+fixed multiline code to render correctly inside markdown api table


### PR DESCRIPTION
## What I did

1. Rule applied only for multiline code blocks (Only multiline code was breaking)
2. Wrapped the code block inside `<pre><code><!-- code here --></code></pre>`
3. Escaped HTML characters
4. Preserved line breaks and spaces (for indentation)

#### Multiline code block before fix
<img width="1188" alt="broken-markdown-table" src="https://github.com/user-attachments/assets/cc2c1633-84a0-4e52-88d9-bd454e786093">

#### Multiline code block after fix
<img width="1386" alt="broken-markdown-table-fixed" src="https://github.com/user-attachments/assets/ebe2db94-514e-44d5-bd77-e2c4ee1ad038">


