### PR TITLE
deps: update "@custom-elements-manifest/analyzer" to 0.10.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@babel/core": "^7.24.5",
         "@bundled-es-modules/fetch-mock": "^6.5.2",
         "@changesets/cli": "^2.27.1",
-        "@custom-elements-manifest/analyzer": "^0.9.4",
+        "@custom-elements-manifest/analyzer": "^0.10.3",
         "@custom-elements-manifest/to-markdown": "^0.1.0",
         "@open-wc/building-rollup": "^2.2.3",
         "@open-wc/eslint-config": "^12.0.3",
@@ -2386,9 +2386,9 @@
       }
     },
     "node_modules/@custom-elements-manifest/analyzer": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.9.9.tgz",
-      "integrity": "sha512-G0JLRMosgdEmwUOqT/8vmXgWUg9W8JX9TzS865obUffyNdHXvZ3Nv3ssR4fcZGcPoEd/jRJwQzMpUl/D6BHaPg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.10.3.tgz",
+      "integrity": "sha512-e2Ax59vK9sNedmDlPqZS11L54iAlKSjOJuv5etpTy5SygLBW3GcUtocHZm8wO013L0griTPpgWB0tuV7/JXy5A==",
       "dev": true,
       "dependencies": {
         "@custom-elements-manifest/find-dependencies": "^0.0.5",
@@ -22975,7 +22975,7 @@
       }
     },
     "packages-node/providence-analytics": {
-      "version": "0.16.4",
+      "version": "0.16.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -23960,7 +23960,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.7.3",
+      "version": "0.7.6",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@babel/core": "^7.24.5",
     "@bundled-es-modules/fetch-mock": "^6.5.2",
     "@changesets/cli": "^2.27.1",
-    "@custom-elements-manifest/analyzer": "^0.9.4",
+    "@custom-elements-manifest/analyzer": "^0.10.3",
     "@custom-elements-manifest/to-markdown": "^0.1.0",
     "@open-wc/building-rollup": "^2.2.3",
     "@open-wc/eslint-config": "^12.0.3",


### PR DESCRIPTION
Fixes https://github.com/ing-bank/lion/issues/2345

## What I did

1. Updated "@custom-elements-manifest/analyzer" to version 0.10.3 (currently the latest version)
2. It was causing the malformed "API Tables" pages described in this issue: Fixes https://github.com/ing-bank/lion/issues/2345
3. I don't know why it occurred and how its fixed. Just randomly updated the dependency and it worked. 


* `package-lock.json` is updated using npm@9.5.1