### PR TITLE
fix dialog aria-expand attribute

### DIFF
--- a/.changeset/olive-mirrors-grab.md
+++ b/.changeset/olive-mirrors-grab.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+add "aria-expanded" attribute only for the non-modal dialogs

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable lit-a11y/no-autofocus */
-import { expect, fixture as _fixture, html, unsafeStatic } from '@open-wc/testing';
+import { expect, fixture as _fixture, html, unsafeStatic, aTimeout } from '@open-wc/testing';
 import { runOverlayMixinSuite } from '../../overlays/test-suites/OverlayMixin.suite.js';
 import '@lion/ui/define/lion-dialog.js';
 
@@ -164,6 +164,26 @@ describe('lion-dialog', () => {
         expect(e.target).to.equal(el);
       });
       el.setAttribute('opened', '');
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('adds [aria-expanded] to invoker button', async () => {
+      const el = await fixture(
+        html` <lion-dialog>
+          <div slot="content" class="dialog">Hey there</div>
+          <button slot="invoker">Popup button</button>
+        </lion-dialog>`,
+      );
+      const invokerButton = /** @type {HTMLElement} */ (el.querySelector('[slot="invoker"]'));
+
+      expect(invokerButton.getAttribute('aria-expanded')).to.equal(null);
+      await invokerButton.click();
+      await aTimeout(0);
+      expect(invokerButton.getAttribute('aria-expanded')).to.equal(null);
+      await invokerButton.click();
+      await aTimeout(0);
+      expect(invokerButton.getAttribute('aria-expanded')).to.equal(null);
     });
   });
 });

--- a/packages/ui/components/dialog/test/lion-dialog.test.js
+++ b/packages/ui/components/dialog/test/lion-dialog.test.js
@@ -168,7 +168,7 @@ describe('lion-dialog', () => {
   });
 
   describe('Accessibility', () => {
-    it('adds [aria-expanded] to invoker button', async () => {
+    it('does not add [aria-expanded] to invoker button', async () => {
       const el = await fixture(
         html` <lion-dialog>
           <div slot="content" class="dialog">Hey there</div>

--- a/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
@@ -495,11 +495,11 @@ describe('<lion-input-datepicker>', () => {
       const el = await fixture(html`<lion-input-datepicker></lion-input-datepicker>`);
       const elObj = new DatepickerInputObject(el);
 
-      expect(elObj.invokerEl.getAttribute('aria-expanded')).to.equal('false');
+      expect(elObj.invokerEl.getAttribute('aria-expanded')).to.equal(null);
       await elObj.openCalendar();
-      expect(elObj.invokerEl.getAttribute('aria-expanded')).to.equal('true');
+      expect(elObj.invokerEl.getAttribute('aria-expanded')).to.equal(null);
       await elObj.closeCalendar();
-      expect(elObj.invokerEl.getAttribute('aria-expanded')).to.equal('false');
+      expect(elObj.invokerEl.getAttribute('aria-expanded')).to.equal(null);
     });
 
     it('is accessible when closed', async () => {

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -1093,7 +1093,7 @@ export class OverlayController extends EventTarget {
         // @ts-ignore
         this.__wrappingDialogNode.close();
         // @ts-ignore
-        this.__wrappingDialogNode.show();
+        this.__wrappingDialogNode.showModal();
       }
       // else {
       this.enableTrapsKeyboardFocus();

--- a/packages/ui/components/overlays/src/OverlayController.js
+++ b/packages/ui/components/overlays/src/OverlayController.js
@@ -640,13 +640,14 @@ export class OverlayController extends EventTarget {
   __setupTeardownAccessibility({ phase }) {
     if (phase === 'init') {
       this.__storeOriginalAttrs(this.contentNode, ['role', 'id']);
+      const isModal = this.hasBackdrop;
 
       if (this.invokerNode) {
-        this.__storeOriginalAttrs(this.invokerNode, [
-          'aria-expanded',
-          'aria-labelledby',
-          'aria-describedby',
-        ]);
+        const attributesToStore = ['aria-labelledby', 'aria-describedby'];
+        if (!isModal) {
+          attributesToStore.push('aria-expanded');
+        }
+        this.__storeOriginalAttrs(this.invokerNode, attributesToStore);
       }
 
       if (!this.contentNode.id) {
@@ -661,7 +662,7 @@ export class OverlayController extends EventTarget {
         }
         this.contentNode.setAttribute('role', 'tooltip');
       } else {
-        if (this.invokerNode) {
+        if (this.invokerNode && !isModal) {
           this.invokerNode.setAttribute('aria-expanded', `${this.isShown}`);
         }
         if (!this.contentNode.getAttribute('role')) {
@@ -1092,7 +1093,7 @@ export class OverlayController extends EventTarget {
         // @ts-ignore
         this.__wrappingDialogNode.close();
         // @ts-ignore
-        this.__wrappingDialogNode.showModal();
+        this.__wrappingDialogNode.show();
       }
       // else {
       this.enableTrapsKeyboardFocus();
@@ -1299,7 +1300,8 @@ export class OverlayController extends EventTarget {
     if (phase === 'init' || phase === 'teardown') {
       this.__setupTeardownAccessibility({ phase });
     }
-    if (this.invokerNode && !this.isTooltip) {
+    const isModal = this.hasBackdrop;
+    if (this.invokerNode && !this.isTooltip && !isModal) {
       this.invokerNode.setAttribute('aria-expanded', `${phase === 'show'}`);
     }
   }

--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -1528,7 +1528,7 @@ describe('OverlayController', () => {
       expect(ctrl.invokerNode?.getAttribute('aria-expanded')).to.equal('false');
     });
 
-    it('synchronizes [aria-expanded] on invoker when the overlay is modal', async () => {
+    it('does not synchronize [aria-expanded] on invoker when the overlay is modal', async () => {
       const invokerNode = /** @type {HTMLElement} */ (
         await fixture('<div role="button">invoker</div>')
       );

--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -1528,6 +1528,23 @@ describe('OverlayController', () => {
       expect(ctrl.invokerNode?.getAttribute('aria-expanded')).to.equal('false');
     });
 
+    it('synchronizes [aria-expanded] on invoker when the overlay is modal', async () => {
+      const invokerNode = /** @type {HTMLElement} */ (
+        await fixture('<div role="button">invoker</div>')
+      );
+      const ctrl = new OverlayController({
+        ...withLocalTestConfig(),
+        hasBackdrop: true,
+        handlesAccessibility: true,
+        invokerNode,
+      });
+      expect(ctrl.invokerNode?.getAttribute('aria-expanded')).to.equal(null);
+      await ctrl.show();
+      expect(ctrl.invokerNode?.getAttribute('aria-expanded')).to.equal(null);
+      await ctrl.hide();
+      expect(ctrl.invokerNode?.getAttribute('aria-expanded')).to.equal(null);
+    });
+
     it('creates unique id for content', async () => {
       const ctrl = new OverlayController({
         ...withLocalTestConfig(),


### PR DESCRIPTION
Add `aria-expanded` attribute to the dialog element only when it is a non-modal dialog