### PR TITLE
Test environment (npm run test:browser) behaves differently than real browser

### DIFF
--- a/packages/ui/components/button/test-suites/LionButton.suite.js
+++ b/packages/ui/components/button/test-suites/LionButton.suite.js
@@ -16,6 +16,39 @@ export function LionButtonSuite({ klass = LionButton } = {}) {
   const tagStringButton = defineCE(class extends klass {});
   const tagButton = unsafeStatic(tagStringButton);
 
+  // This test below is exactly the same code that we see in this reproductino link:
+  // https://studio.webcomponents.dev/edit/CdTHK8iuVNqVSuive1NH/src/index.js?p=README.md
+  // and in this branch, the output of the code in the console is identical to the
+  // output of the code in the reproduction link.
+  it('Clicking on disabled button', () => {
+    customElements.define('lion-button', LionButton);
+
+    ['lion-button', 'button'].forEach(async tagName => {
+      let counter = 1;
+
+      const theButton = document.createElement(tagName);
+      theButton.textContent = `This is ${tagName}`;
+      document.body.appendChild(theButton);
+
+      theButton.addEventListener('click', () => {
+        console.log(`Hello from ${tagName} - ${counter}`);
+      });
+
+      theButton.click();
+      counter += 1;
+
+      theButton.setAttribute('disabled', 'true');
+
+      theButton.click();
+      counter += 1;
+
+      theButton.removeAttribute('disabled');
+
+      theButton.click();
+      counter += 1;
+    });
+  });
+
   describe('LionButton', () => {
     it('has .type="button" and type="button" by default', async () => {
       const el = /** @type {LionButton} */ (await fixture(html`<${tagButton}>foo</${tagButton}>`));

--- a/packages/ui/components/button/test-suites/LionButton.suite.js
+++ b/packages/ui/components/button/test-suites/LionButton.suite.js
@@ -23,7 +23,7 @@ export function LionButtonSuite({ klass = LionButton } = {}) {
   it('Clicking on disabled button', () => {
     customElements.define('lion-button', LionButton);
 
-    ['lion-button', 'button'].forEach(async tagName => {
+    ['lion-button', 'button'].forEach(tagName => {
       let counter = 1;
 
       const theButton = document.createElement(tagName);

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -31,10 +31,9 @@ const testRunnerHtml = testRunnerImport =>
   `
 <html>
   <head>
-    <!-- This line below is where the problem is coming from. This alters behavior -->
-    <!-- And I believe its dangerous, because it gives us false positives. -->
-    <!-- Not everybody is importing this module in their app -->
-    <!-- Only tests that need it, should import it individually -->
+    <!-- This line below is where the problem is coming from. This alters behavior in tests vs browser -->
+    <!-- Running all tests with this polyfill gives us false positives. -->
+    <!-- Not everybody is importing this polyfill in their app -->
     <!-- <script src="/node_modules/@webcomponents/scoped-custom-element-registry/scoped-custom-element-registry.min.js"></script> -->
 
     <script type="module" src="${testRunnerImport}"></script>


### PR DESCRIPTION
This is a PR to demonstrate how our tests behave differently than in the real browser. The issue is explained thoroughly here: https://github.com/ing-bank/lion/issues/2351

Commenting out this line: https://github.com/ing-bank/lion/pull/2352/files#diff-7bfdd444e5650854e7536869ef3973956e89fbfc8562197c7c13f99cfb3047bfR37 makes the tests environment behave correctly as like in the normal browser.

I'm working on a real MR for fixing this issue which makes test environments more reliable.