### PR TITLE
Run every test with and without scoped-element-registry polyfill

### DIFF
--- a/packages/ui/components/core/test/SlotMixin.polyfill.test.js
+++ b/packages/ui/components/core/test/SlotMixin.polyfill.test.js
@@ -1,0 +1,40 @@
+import sinon from 'sinon';
+import { defineCE, expect, fixture, unsafeStatic, html } from '@open-wc/testing';
+import { ScopedElementsMixin } from '@open-wc/scoped-elements/lit-element.js';
+import { SlotMixin } from '@lion/ui/core.js';
+import { LitElement } from 'lit';
+
+it('supports scoped elements when polyfill loaded', async () => {
+  // @ts-ignore the scoped-custom-element-registry polyfill makes sure `ShadowRoot.prototype.createElement` is defined
+  const createElementSpy = sinon.spy(ShadowRoot.prototype, 'createElement');
+
+  class ScopedEl extends LitElement {}
+
+  const tagName = defineCE(
+    class extends ScopedElementsMixin(SlotMixin(LitElement)) {
+      static get scopedElements() {
+        return {
+          // @ts-expect-error
+          ...super.scopedElements,
+          'scoped-elm': ScopedEl,
+        };
+      }
+
+      get slots() {
+        return {
+          ...super.slots,
+          template: () => html`<scoped-elm></scoped-elm>`,
+        };
+      }
+
+      render() {
+        return html`<slot name="template"></slot>`;
+      }
+    },
+  );
+
+  const tag = unsafeStatic(tagName);
+  await fixture(html`<${tag}></${tag}>`);
+
+  expect(createElementSpy.getCalls()).to.have.length(1);
+});

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -24,7 +24,7 @@ const testGroups = fs
     files: `${pkg.path}/**/*.test.js`,
   }));
 
-const testsThatShouldRunWithScopedCustomElementRegistryPolyfill = testGroups.map(testGroup => {
+const testsThatMustRunWithScopedCustomElementRegistryPolyfill = testGroups.map(testGroup => {
   const files = [
     testGroup.files,
     `!${testGroup.files.replace('*.test.js', '*.no-polyfill.test.js')}`,
@@ -47,7 +47,7 @@ const testsThatShouldRunWithScopedCustomElementRegistryPolyfill = testGroups.map
   };
 });
 
-const testsThatShouldNotRunWithPolyfill = testGroups.map(testGroup => {
+const testsThatMustRunWithoutPolyfill = testGroups.map(testGroup => {
   const files = [testGroup.files, `!${testGroup.files.replace('*.test.js', '*.polyfill.test.js')}`];
 
   return {
@@ -90,7 +90,7 @@ export default {
     playwrightLauncher({ product: 'webkit' }),
   ],
   groups: [].concat([
-    ...testsThatShouldRunWithScopedCustomElementRegistryPolyfill,
-    ...testsThatShouldNotRunWithPolyfill,
+    ...testsThatMustRunWithScopedCustomElementRegistryPolyfill,
+    ...testsThatMustRunWithoutPolyfill,
   ]),
 };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -89,8 +89,7 @@ export default {
     playwrightLauncher({ product: 'chromium' }),
     playwrightLauncher({ product: 'webkit' }),
   ],
-  groups: [].concat([
+  groups: testsThatMustRunWithoutPolyfill.concat([
     ...testsThatMustRunWithScopedCustomElementRegistryPolyfill,
-    ...testsThatMustRunWithoutPolyfill,
   ]),
 };


### PR DESCRIPTION
This PR fixes https://github.com/ing-bank/lion/issues/2351

- Runs every test two times: once with the scoped-element-registry polyfill and once without it.
- Uses `testGroups` to achieve this
- Why? Because that polyfill affects the behavior of components, and gives us false positives. The users of the lion library may not all have loaded that polyfill.
- Creates two suffixes for test files: `some-test.polyfill.test.js` and `some-test.no-polyfill.test.js` for tests that require to be run only with/without the polyfill. (Example is the SlotMixin tests)
- The SlotMixin test had two tests at the end of the file:
- - Moved one of them to another file and suffixed it with `.polyfill`, because that needed polyfill to pass. Also refactored it to use a simple `spy` instead of a mocked object.
- - Removed the other test because it was lying. The title of the test was `does not scope elements when polyfill not loaded` but when you actually remove the polyfill from test config, it fails! (I gave more explanation here: https://github.com/ing-bank/lion/issues/2358)
- - :question: Do I need to extract the refactor and removal of SlotMixin tests as a separate MR?
- :question:  I'd loved to be able to hint when a test fails, did it fail with or without the polyfill, but failed to do so. Any idea?

**UPDATE: Below is the original message of MR, which is not accurate anymore. This PR is re-purposed.**

~~- We should not load a polyfill globally in tests environment, because it affects how tests behave and may give us false positive and false confidence.~~
~~- Every test that needs polyfill, loads the polyfill only for itself.~~
~~- No unnecessary mocking is required. Spy would do the job in this scneario.~~
~~- Adds a util for adding a script in tests on demand.~~
~~- Removes one unnecessary ts-ignore~~