### PR TITLE
Fix the bug that accept attribute in the input field didn't work properly

### DIFF
--- a/.changeset/fair-tables-pay.md
+++ b/.changeset/fair-tables-pay.md
@@ -1,0 +1,5 @@
+---
+"@lion/ui": patch
+---
+
+[input-file] fix the bug that accept attribute in the input field didn't work properly

--- a/packages/ui/components/input-file/src/FileHandle.js
+++ b/packages/ui/components/input-file/src/FileHandle.js
@@ -53,7 +53,7 @@ export class FileHandle {
    */
   // eslint-disable-next-line class-methods-use-this
   _getFileNameExtension(fileName) {
-    return fileName.slice(fileName.lastIndexOf('.') + 1);
+    return fileName.slice(fileName.lastIndexOf('.'));
   }
 
   // TODO: seems to suggest upload is going on...

--- a/packages/ui/components/input-file/src/LionInputFile.js
+++ b/packages/ui/components/input-file/src/LionInputFile.js
@@ -232,7 +232,7 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
     /** @type {string[]} */
     let allowedFileExtensions = [];
     if (this.accept) {
-      const acceptedFiles = this.accept.replace(/\s+/g, '').replace(/\.+/g, '').split(',');
+      const acceptedFiles = this.accept.replace(/\s+/g, '').split(',');
       allowedFileTypes = acceptedFiles.filter(acceptedFile => acceptedFile.includes('/'));
       allowedFileExtensions = acceptedFiles.filter(acceptedFile => !acceptedFile.includes('/'));
     }
@@ -692,8 +692,6 @@ export class LionInputFile extends ScopedElementsMixin(LocalizeMixin(LionField))
 
     if (allowedFileExtensions.length) {
       array = allowedFileExtensions;
-      // eslint-disable-next-line no-return-assign
-      array = array.map(item => (item = `.${item}`));
       lastItem = array.pop();
       arrayLength = array.length;
     } else if (allowedFileTypes.length) {

--- a/packages/ui/components/input-file/test/lion-input-file.test.js
+++ b/packages/ui/components/input-file/test/lion-input-file.test.js
@@ -354,20 +354,6 @@ describe('lion-input-file', () => {
         expect(error.message).to.equal('Please select a .jpg, .png or .pdf file with max 500MB.');
       });
     });
-
-    it('error message should add all file extensions to the validator message also works without dots "."', async () => {
-      const el = await fixture(html`
-        <lion-input-file label="Select" accept="jpg, png, pdf"></lion-input-file>
-      `);
-
-      mimicSelectFile(el, [fileWrongType]);
-      await el.updateComplete;
-
-      // @ts-expect-error [allow-protected-in-test]
-      el._selectedFilesMetaData[0].validationFeedback?.forEach(error => {
-        expect(error.message).to.equal('Please select a .jpg, .png or .pdf file with max 500MB.');
-      });
-    });
   });
 
   describe('invalid file sizes', async () => {

--- a/packages/ui/components/input-file/test/lion-input-file.test.js
+++ b/packages/ui/components/input-file/test/lion-input-file.test.js
@@ -158,6 +158,17 @@ describe('lion-input-file', () => {
       })
     );
 
+    it('error should not be there when the file extensions are accepted', async () => {
+      const el = await fixture(html`
+        <lion-input-file label="Select" accept=".txt"></lion-input-file>
+      `);
+
+      mimicSelectFile(el, [fileWrongType]);
+      await el.updateComplete;
+
+      expect(el.hasFeedbackFor.length).to.equal(0);
+    });
+
     it('should not be added to the selected list', async () => {
       const el = await fixture(html`
         <lion-input-file label="Select" accept="text/plain"></lion-input-file>


### PR DESCRIPTION
## What I did

1. Fix the bug that the `accept` attribute in the input field didn't work
    - When the accepted extensions have `.`, the `IsAcceptedFile` validator always fails. (It tries to compare `jpg` (from the accept attirbute) and `.jpg` (from file name)
       -  Quick reproduction: go to https://lion-web.netlify.app/components/input-file/use-cases/#basic-file-upload, select an accepted file then check the `hasFeedbackFor` property of the `lion-input-file` from the inspector
    - When the accepted extensions doesn't have `.`, the file dialog disable those file with the extensions (`accept="jpg"` will make jpg files unselectable - actually all files become unselectible)

### Technically breaking change
Apparently we officially supported extensions without `.` for the `accept` attribute, but [this is not a valid accept attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept#unique_file_type_specifiers) and breaks the behaviour of browsers (tested on Chrome 128.0.6613.114, Mac). So I removed the normalization (removing `.`) of the extension and the relevant test.

It's technically a breaking change, but it seems rather a bug fix, to me (if a consumer used extensions without `.`, it would break the browser behavior, anyway)
