### PR TITLE
fix(ui/types): export FocusHost type from types/form-core.js (fixes: #2366)

### DIFF
--- a/.changeset/metal-ears-bathe.md
+++ b/.changeset/metal-ears-bathe.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(ui/types): export FocusHost type from types/form-core.js

--- a/packages/ui/exports/types/form-core.ts
+++ b/packages/ui/exports/types/form-core.ts
@@ -1,5 +1,6 @@
 export { ChoiceGroupHost } from '../../components/form-core/types/choice-group/ChoiceGroupMixinTypes.js';
 export { ChoiceInputHost } from '../../components/form-core/types/choice-group/ChoiceInputMixinTypes.js';
+export { FocusHost } from '../../components/form-core/types/FocusMixinTypes.js';
 export { FormControlHost } from '../../components/form-core/types/FormControlMixinTypes.js';
 export { HTMLElementWithValue } from '../../components/form-core/types/FormControlMixinTypes.js';
 export { FormGroupHost } from '../../components/form-core/types/form-group/FormGroupMixinTypes.js';


### PR DESCRIPTION
## What I did

1. Exported the missing `FocusHost` type so that component libraries can use the FocusMixin and get their type definitions correctly generated.
