### PR TITLE
fix(combobox): unexpected overlay opening

### DIFF
--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -4,9 +4,9 @@ import { LionListbox } from '@lion/ui/listbox.js';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { OverlayMixin, withDropdownConfig } from '@lion/ui/overlays.js';
 import { css, html } from 'lit';
+import { CustomChoiceGroupMixin } from '../../form-core/src/choice-group/CustomChoiceGroupMixin.js';
 import { makeMatchingTextBold, unmakeMatchingTextBold } from './utils/makeMatchingTextBold.js';
 import { MatchesOption } from './validators.js';
-import { CustomChoiceGroupMixin } from '../../form-core/src/choice-group/CustomChoiceGroupMixin.js';
 
 const matchA11ySpanReverseFns = new WeakMap();
 
@@ -705,7 +705,7 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(CustomChoiceGroupMi
   // eslint-disable-next-line no-unused-vars
   _textboxOnInput(ev) {
     this.__shouldAutocompleteNextUpdate = true;
-    this.opened = true;
+    this.opened = this._showOverlayCondition({});
   }
 
   /**


### PR DESCRIPTION
## What I did

Added condition to check if overlay should be opened, but this change breaks 17 unit tests due to differences between programmatic actions in unit tests and actual UI behavior. Verified that most of the affected scenarios function as expected in the UI.

Unit tests need further work as discussed with @okadurin. He confirmed the unexpected unit tests behavior.

Reproduction scenario of a bug I am trying to fix:
1. Override` _showOverlayCondition` with `return false` to simplify the use case when subclassers override this method and return false due to some logic.
2. Go to the multiple choice combobox and start typing
3. You will notice that the overlay opens on keydown and closes on key release. Input is cleared as a side-effect.

Please see what kind of fix could be applied to unit tests.
