### PR TITLE
fix(ui/calendar): use correct firstUpdated type signature

### DIFF
--- a/.changeset/perfect-jeans-search.md
+++ b/.changeset/perfect-jeans-search.md
@@ -1,0 +1,5 @@
+---
+"@lion/ui": patch
+---
+
+fix(ui/calendar): use correct firstUpdated type signature

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -300,7 +300,9 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     }
   }
 
-  firstUpdated() {
+  /** @param {import('lit').PropertyValues } changedProperties */
+  firstUpdated(changedProperties) {
+    super.firstUpdated(changedProperties);
     this.__calculateInitialCentralDate();
 
     // setup data for initial render


### PR DESCRIPTION
## What I did

1. Adjusted the `firstUpdated` of LionCalendar based on other working examples (LionStep specifically).
