### PR TITLE
Chore/scoped registries improvements

### DIFF
--- a/.changeset/empty-students-grow.md
+++ b/.changeset/empty-students-grow.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+no registration of same class twice w/o scoped-registries polyfill

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "custom-elements-manifest": "npm run custom-elements-manifest --workspaces --if-present && node ./scripts/create-api-tables.mjs",
     "debug": "web-test-runner --watch --config web-test-runner-chrome.config.mjs",
     "debug:firefox": "web-test-runner --watch --config web-test-runner-firefox.config.mjs",
+    "debug:no-scoped-registries-polyfill": "npm run debug -- --no-scoped-registries-polyfill",
     "debug:webkit": "web-test-runner --watch --config web-test-runner-webkit.config.mjs",
     "format": "npm run format:eslint && npm run format:prettier",
     "format:eslint": "eslint --ext .js,.html . --fix",

--- a/packages/ui/components/core/src/ScopedElementsMixin.js
+++ b/packages/ui/components/core/src/ScopedElementsMixin.js
@@ -89,8 +89,8 @@ const ScopedElementsMixinImplementation = superclass =>
      */
     defineScopedElement(tagName, classToBeRegistered) {
       const registeredClass = this.registry.get(tagName);
-      const isAlreadyRegistered = registeredClass && registeredClass === classToBeRegistered;
-      if (isAlreadyRegistered && !supportsScopedRegistry()) {
+      const isNewClassWithSameName = registeredClass && registeredClass !== classToBeRegistered;
+      if (!supportsScopedRegistry() && isNewClassWithSameName) {
         // eslint-disable-next-line no-console
         console.error(
           [

--- a/packages/ui/components/form-core/test-suites/ValidateMixin.suite.js
+++ b/packages/ui/components/form-core/test-suites/ValidateMixin.suite.js
@@ -2,25 +2,25 @@ import { LitElement } from 'lit';
 import { aTimeout, defineCE, expect, fixture, html, unsafeStatic } from '@open-wc/testing';
 import {
   getFormControlMembers,
-  AlwaysInvalid,
-  AlwaysValid,
   AsyncAlwaysInvalid,
   AsyncAlwaysValid,
+  AlwaysInvalid,
+  AlwaysValid,
 } from '@lion/ui/form-core-test-helpers.js';
 import sinon from 'sinon';
 import {
+  ResultValidator,
+  ValidateMixin,
   EqualsLength,
+  Unparseable,
   MaxLength,
   MinLength,
-  Required,
-  ResultValidator,
-  Unparseable,
-  ValidateMixin,
   Validator,
+  Required,
 } from '@lion/ui/form-core.js';
 
-import '@lion/ui/define/lion-field.js';
 import '@lion/ui/define/lion-validation-feedback.js';
+import '@lion/ui/define/lion-field.js';
 
 /**
  * @typedef {import('@lion/ui/form-core.js').LionField} LionField


### PR DESCRIPTION
- [fix(core): no registration of same class twice w/o scoped-registries polyfill](https://github.com/ing-bank/lion/pull/2407/commits/bfcfd4a69fc40c5457c329e8c542228449332508)
- [chore: allow tests to run w/o polyfill](https://github.com/ing-bank/lion/pull/2407/commits/bf2a22d486332ed4c260ff799b9ce4c8c14abf6b)

- [chore: cleanup wtr config, add pkg script for running w/o polyfill](https://github.com/ing-bank/lion/pull/2407/commits/30204f5c6364adc51e807b2795b42bbc21635c8e)