### PR TITLE
Fix the issue that dynamically updated disabled date doesn't update the central date

### DIFF
--- a/.changeset/late-adults-ring.md
+++ b/.changeset/late-adults-ring.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Fix the bug that when the available date in datepicker changes the central date of calendar changes, too

--- a/.changeset/late-adults-ring.md
+++ b/.changeset/late-adults-ring.md
@@ -2,4 +2,4 @@
 '@lion/ui': patch
 ---
 
-Fix the bug that when the available date in datepicker changes the central date of calendar changes, too
+fix(calendar): align central date with dynamic disabled dates

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -364,7 +364,11 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     if (this.selectedDate) {
       this.focusSelectedDate();
     } else {
-      this.centralDate = /** @type {Date} */ (this.__initialCentralDate);
+      if (!this.__isEnabledDate(/** @type {Date} */ (this.__initialCentralDate))) {
+        this.centralDate = this.findNearestEnabledDate(this.__initialCentralDate);
+      } else {
+        this.centralDate = /** @type {Date} */ (this.__initialCentralDate);
+      }
       this.focusCentralDate();
     }
   }

--- a/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
@@ -19,9 +19,10 @@ import '@lion/ui/define/lion-input-datepicker.js';
  */
 function getProtectedMembersDatepicker(datepickerEl) {
   // @ts-ignore
-  const { __invokerId: invokerId } = datepickerEl;
+  const { __invokerId: invokerId, _calendarNode: calendarNode } = datepickerEl;
   return {
     invokerId,
+    calendarNode,
   };
 }
 
@@ -391,12 +392,6 @@ describe('<lion-input-datepicker>', () => {
         myMaxDateValidator.param = new Date('2020/03/03');
 
         expect(el.__calendarMaxDate.toString()).to.equal(new Date('2020/03/03').toString());
-
-        el._overlayInvokerNode.click();
-        await new Promise(res => {
-          setTimeout(res, 10);
-        });
-        expect(el._calendarNode.centralDate.toString()).to.equal(new Date('2020/03/03').toString());
       });
 
       it('should sync MinMaxDate validator param with Calendar Min And Max Date', async () => {
@@ -427,14 +422,18 @@ describe('<lion-input-datepicker>', () => {
         await new Promise(res => {
           setTimeout(res, 10);
         });
-        expect(el._calendarNode.centralDate.toString()).to.equal(new Date('2000/01/01').toString());
+        expect(getProtectedMembersDatepicker(el).calendarNode.centralDate.toString()).to.equal(
+          new Date('2000/01/01').toString(),
+        );
 
         el.validators = updatedValidators;
         el._overlayInvokerNode.click();
         await new Promise(res => {
           setTimeout(res, 10);
         });
-        expect(el._calendarNode.centralDate.toString()).to.equal(new Date('2020/01/01').toString());
+        expect(getProtectedMembersDatepicker(el).calendarNode.centralDate.toString()).to.equal(
+          new Date('2020/01/01').toString(),
+        );
       });
 
       it('should show error on invalid date passed to modelValue', async () => {

--- a/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
@@ -418,19 +418,17 @@ describe('<lion-input-datepicker>', () => {
         const el = await fixture(html`
           <lion-input-datepicker .validators="${initialValidators}"></lion-input-datepicker>
         `);
-        el._overlayInvokerNode.click();
-        await new Promise(res => {
-          setTimeout(res, 10);
-        });
+        const obj = new DatepickerInputObject(el);
+        await obj.openCalendar();
+
         expect(getProtectedMembersDatepicker(el).calendarNode.centralDate.toString()).to.equal(
           new Date('2000/01/01').toString(),
         );
 
+        await obj.closeCalendar();
         el.validators = updatedValidators;
-        el._overlayInvokerNode.click();
-        await new Promise(res => {
-          setTimeout(res, 10);
-        });
+        await obj.openCalendar();
+
         expect(getProtectedMembersDatepicker(el).calendarNode.centralDate.toString()).to.equal(
           new Date('2020/01/01').toString(),
         );

--- a/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
+++ b/packages/ui/components/input-datepicker/test/lion-input-datepicker.test.js
@@ -391,6 +391,12 @@ describe('<lion-input-datepicker>', () => {
         myMaxDateValidator.param = new Date('2020/03/03');
 
         expect(el.__calendarMaxDate.toString()).to.equal(new Date('2020/03/03').toString());
+
+        el._overlayInvokerNode.click();
+        await new Promise(res => {
+          setTimeout(res, 10);
+        });
+        expect(el._calendarNode.centralDate.toString()).to.equal(new Date('2020/03/03').toString());
       });
 
       it('should sync MinMaxDate validator param with Calendar Min And Max Date', async () => {
@@ -408,6 +414,27 @@ describe('<lion-input-datepicker>', () => {
 
         expect(el.__calendarMinDate.toString()).to.equal(new Date('2019/05/15').toString());
         expect(el.__calendarMaxDate.toString()).to.equal(new Date('2019/07/15').toString());
+      });
+
+      it('should update the central date of Calendar if updated validator made the current central date disabled', async () => {
+        const initialValidators = [new MaxDate(new Date('2000/01/01'))];
+        const updatedValidators = [new MaxDate(new Date('2020/01/01'))];
+
+        const el = await fixture(html`
+          <lion-input-datepicker .validators="${initialValidators}"></lion-input-datepicker>
+        `);
+        el._overlayInvokerNode.click();
+        await new Promise(res => {
+          setTimeout(res, 10);
+        });
+        expect(el._calendarNode.centralDate.toString()).to.equal(new Date('2000/01/01').toString());
+
+        el.validators = updatedValidators;
+        el._overlayInvokerNode.click();
+        await new Promise(res => {
+          setTimeout(res, 10);
+        });
+        expect(el._calendarNode.centralDate.toString()).to.equal(new Date('2020/01/01').toString());
       });
 
       it('should show error on invalid date passed to modelValue', async () => {


### PR DESCRIPTION
## What I did

In case the disabled dates of the calendar element in `LionInputDatepicker` changes dynamically (for instance, when two date pickers take start and end date from user, while start date changes the min value of the end date), the calendar's central date can be a disabled date and it doesn't get updated to the nearest enabled date.

This PR fixes the issue by getting nearest enabled date in case the initial central date becomes disabled.


### Caveat
I introduced 10ms timeout in the test. `await el.completeUpdate` nor `await el.{internal_node_getter}.completeUpdate` didn't work because the date picker waits for its child node to be updated before it calls `this._calendarNode.initCentralDate()`. I even tried to wait the calendar node to complete updates multiple times but no luck. Please enlighten me if I can avoid using timeout.
