### PR TITLE
fix: announce current page for pagination

### DIFF
--- a/.changeset/purple-paws-scream.md
+++ b/.changeset/purple-paws-scream.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[lion-pagination] announce current page

--- a/packages/ui/components/pagination/src/LionPagination.js
+++ b/packages/ui/components/pagination/src/LionPagination.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 
 /**
@@ -287,6 +287,7 @@ export class LionPagination extends LocalizeMixin(LitElement) {
               <button
                 aria-label="${this.msgLit('lion-pagination:page', { page })}"
                 aria-current=${page === this.current}
+                aria-live="${page === this.current ? 'polite' : nothing}"
                 @click=${() => this.__fire(page)}
               >
                 ${page}

--- a/packages/ui/components/pagination/src/LionPagination.js
+++ b/packages/ui/components/pagination/src/LionPagination.js
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { LitElement, html, css, nothing } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 
 /**

--- a/packages/ui/components/pagination/src/LionPagination.js
+++ b/packages/ui/components/pagination/src/LionPagination.js
@@ -287,7 +287,7 @@ export class LionPagination extends LocalizeMixin(LitElement) {
               <button
                 aria-label="${this.msgLit('lion-pagination:page', { page })}"
                 aria-current=${page === this.current}
-                aria-live="${page === this.current ? 'polite' : nothing}"
+                aria-live="${page === this.current ? 'polite' : 'off'}"
                 @click=${() => this.__fire(page)}
               >
                 ${page}

--- a/packages/ui/components/pagination/test/lion-pagination.test.js
+++ b/packages/ui/components/pagination/test/lion-pagination.test.js
@@ -105,7 +105,23 @@ describe('Pagination', () => {
       expect(el.current).to.equal(2);
     });
 
-    it('should goto next and previous page using `next()` and `previous()`', async () => {
+    it('should announce next and previous page using `next()` and `previous()`', async () => {
+      const el = await fixture(html` <lion-pagination count="6" current="2"></lion-pagination> `);
+      const buttons = Array.from(
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelectorAll('button'),
+      );
+      expect(buttons[2].getAttribute('aria-live')).to.equal('polite');
+      el.next();
+      await el.updateComplete;
+      expect(buttons[3].getAttribute('aria-live')).to.equal('polite');
+      expect(buttons[2].getAttribute('aria-live')).to.equal(null);
+      el.previous();
+      await el.updateComplete;
+      expect(buttons[3].getAttribute('aria-live')).to.equal(null);
+      expect(buttons[2].getAttribute('aria-live')).to.equal('polite');
+    });
+
+    it('should set `aria-live` for the current page using `next()`', async () => {
       const el = await fixture(html` <lion-pagination count="6" current="2"></lion-pagination> `);
       el.next();
       expect(el.current).to.equal(3);

--- a/packages/ui/components/pagination/test/lion-pagination.test.js
+++ b/packages/ui/components/pagination/test/lion-pagination.test.js
@@ -114,14 +114,14 @@ describe('Pagination', () => {
       el.next();
       await el.updateComplete;
       expect(buttons[3].getAttribute('aria-live')).to.equal('polite');
-      expect(buttons[2].getAttribute('aria-live')).to.equal(null);
+      expect(buttons[2].getAttribute('aria-live')).to.equal('off');
       el.previous();
       await el.updateComplete;
-      expect(buttons[3].getAttribute('aria-live')).to.equal(null);
+      expect(buttons[3].getAttribute('aria-live')).to.equal('off');
       expect(buttons[2].getAttribute('aria-live')).to.equal('polite');
     });
 
-    it('should set `aria-live` for the current page using `next()`', async () => {
+    it('should goto next and previous page using `next()` and `previous()`', async () => {
       const el = await fixture(html` <lion-pagination count="6" current="2"></lion-pagination> `);
       el.next();
       expect(el.current).to.equal(3);


### PR DESCRIPTION
The fix makes a text reader announce the current page when it is changed. 