### PR TITLE
do not show overlay when _showOverlayCondition is "false"

### DIFF
--- a/.changeset/weak-hairs-jump.md
+++ b/.changeset/weak-hairs-jump.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+show overlay based on overridden "\_showOverlayCondition"

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -705,7 +705,7 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(CustomChoiceGroupMi
   // eslint-disable-next-line no-unused-vars
   _textboxOnInput(ev) {
     this.__shouldAutocompleteNextUpdate = true;
-    this.opened = true;
+    this.opened = this._showOverlayCondition({});
   }
 
   /**

--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -663,7 +663,11 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(CustomChoiceGroupMi
     ) {
       return false;
     }
-    if (this.filled || this.showAllOnEmpty) {
+    if (
+      this.filled ||
+      this.showAllOnEmpty ||
+      (!this.filled && this.multipleChoice && this.__prevCboxValueNonSelected)
+    ) {
       return true;
     }
     // when no keyboard action involved (on focused change), return current opened state

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -1303,7 +1303,7 @@ describe('lion-combobox', () => {
 
         await mimicUserTyping(el, 'art');
         await el.updateComplete;
-        expect(el.opened).to.equal(true); // valid
+        expect(el.opened).to.equal(true);
 
         const visibleOptions = options.filter(o => o.style.display !== 'none');
         expect(visibleOptions.length).to.not.equal(0);
@@ -3116,7 +3116,7 @@ describe('lion-combobox', () => {
       await mimicUserTyping(el, 'ch');
       await el.updateComplete;
 
-      expect(el.opened).to.equal(true); // valid
+      expect(el.opened).to.equal(true);
       const visibleOptions = el.formElements.filter(o => o.style.display !== 'none');
       visibleOptions[0].click();
       expect(el.opened).to.equal(true);
@@ -3138,7 +3138,7 @@ describe('lion-combobox', () => {
 
       await mimicUserTyping(el, 'art');
       await el.updateComplete;
-      expect(el.opened).to.equal(true); // valid
+      expect(el.opened).to.equal(true);
 
       // N.B. we do only trigger keydown here (and not mimicKeypress (both keyup and down)),
       // because this closely mimics what happens in the browser
@@ -3164,7 +3164,7 @@ describe('lion-combobox', () => {
       await mimicUserTyping(el, 'art');
       await el.updateComplete;
 
-      expect(el.opened).to.equal(true); // valid
+      expect(el.opened).to.equal(true);
       const visibleOptions = () => options.filter(o => o.style.display !== 'none');
       expect(visibleOptions().length).to.equal(1);
 
@@ -3194,7 +3194,7 @@ describe('lion-combobox', () => {
       await mimicUserTyping(el, 'art');
       await el.updateComplete;
 
-      expect(el.opened).to.equal(true); // valid
+      expect(el.opened).to.equal(true);
       const visibleOptions = () => options.filter(o => o.style.display !== 'none');
       expect(visibleOptions().length).to.equal(1);
 

--- a/packages/ui/components/combobox/test/lion-combobox.test.js
+++ b/packages/ui/components/combobox/test/lion-combobox.test.js
@@ -931,6 +931,50 @@ describe('lion-combobox', () => {
       expect(el.opened).to.equal(false);
     });
 
+    it('does not flash the menu when _showOverlayCondition returns "false"', async () => {
+      class ComplexCombobox extends LionCombobox {
+        _showOverlayCondition() {
+          return false;
+        }
+      }
+
+      const tagName = defineCE(ComplexCombobox);
+      const tag = unsafeStatic(tagName);
+
+      const el = /** @type {LionCombobox} */ (
+        await fixture(html` 
+          <${tag} name="combo" label="Display only the label once selected">
+            <lion-option .choiceValue="${'Artichoke'}">Artichoke</lion-option>
+            <lion-option .choiceValue="${'Chard'}">Chard</lion-option>
+            <lion-option .choiceValue="${'Chicory'}">Chicory</lion-option>
+            <lion-option .choiceValue="${'Victoria Plum'}">Victoria Plum</lion-option>
+          </${tag}>
+        `)
+      );
+
+      const dialog = el.shadowRoot?.querySelector('dialog');
+      /**
+       * hasDropdownFlashed is `true` if the menu was shown for a short period of time and then got closed
+       */
+      let hasDropdownFlashed = false;
+      const observer = new MutationObserver(mutationList => {
+        // eslint-disable-next-line no-unused-vars
+        for (const mutation of mutationList) {
+          if (dialog?.style.display === '') {
+            hasDropdownFlashed = true;
+          }
+        }
+      });
+      observer.observe(/** @type {Node} */ (dialog), { attributeFilter: ['style'] });
+
+      const { _inputNode } = getComboboxMembers(el);
+      _inputNode.focus();
+      await sendKeys({
+        type: 'art',
+      });
+      expect(hasDropdownFlashed).to.be.false;
+    });
+
     it('shows overlay on click when filled', async () => {
       const el = /** @type {LionCombobox} */ (
         await fixture(html`
@@ -1157,7 +1201,10 @@ describe('lion-combobox', () => {
         class ShowOverlayConditionCombobox extends LionCombobox {
           /** @param {{ currentValue: string, lastKey:string }} options */
           _showOverlayCondition(options) {
-            return options.currentValue.length > 3 && super._showOverlayCondition(options);
+            return (
+              // @ts-ignore
+              this.__prevCboxValueNonSelected.length > 3 && super._showOverlayCondition(options)
+            );
           }
         }
         const tagName = defineCE(ShowOverlayConditionCombobox);
@@ -1182,7 +1229,10 @@ describe('lion-combobox', () => {
         class ShowOverlayConditionCombobox extends LionCombobox {
           /** @param {{ currentValue: string, lastKey:string }} options */
           _showOverlayCondition(options) {
-            return options.currentValue.length > 3 && super._showOverlayCondition(options);
+            return (
+              // @ts-ignore
+              this.__prevCboxValueNonSelected.length > 3 && super._showOverlayCondition(options)
+            );
           }
         }
         const tagName = defineCE(ShowOverlayConditionCombobox);
@@ -1207,7 +1257,10 @@ describe('lion-combobox', () => {
         class ShowOverlayConditionCombobox extends LionCombobox {
           /** @param {{ currentValue: string, lastKey:string }} options */
           _showOverlayCondition(options) {
-            return options.currentValue.length > 3 && super._showOverlayCondition(options);
+            return (
+              // @ts-ignore
+              this.__prevCboxValueNonSelected.length > 3 && super._showOverlayCondition(options)
+            );
           }
         }
         const tagName = defineCE(ShowOverlayConditionCombobox);
@@ -1250,7 +1303,7 @@ describe('lion-combobox', () => {
 
         await mimicUserTyping(el, 'art');
         await el.updateComplete;
-        expect(el.opened).to.equal(true);
+        expect(el.opened).to.equal(true); // valid
 
         const visibleOptions = options.filter(o => o.style.display !== 'none');
         expect(visibleOptions.length).to.not.equal(0);
@@ -3063,7 +3116,7 @@ describe('lion-combobox', () => {
       await mimicUserTyping(el, 'ch');
       await el.updateComplete;
 
-      expect(el.opened).to.equal(true);
+      expect(el.opened).to.equal(true); // valid
       const visibleOptions = el.formElements.filter(o => o.style.display !== 'none');
       visibleOptions[0].click();
       expect(el.opened).to.equal(true);
@@ -3085,7 +3138,7 @@ describe('lion-combobox', () => {
 
       await mimicUserTyping(el, 'art');
       await el.updateComplete;
-      expect(el.opened).to.equal(true);
+      expect(el.opened).to.equal(true); // valid
 
       // N.B. we do only trigger keydown here (and not mimicKeypress (both keyup and down)),
       // because this closely mimics what happens in the browser
@@ -3111,7 +3164,7 @@ describe('lion-combobox', () => {
       await mimicUserTyping(el, 'art');
       await el.updateComplete;
 
-      expect(el.opened).to.equal(true);
+      expect(el.opened).to.equal(true); // valid
       const visibleOptions = () => options.filter(o => o.style.display !== 'none');
       expect(visibleOptions().length).to.equal(1);
 
@@ -3141,7 +3194,7 @@ describe('lion-combobox', () => {
       await mimicUserTyping(el, 'art');
       await el.updateComplete;
 
-      expect(el.opened).to.equal(true);
+      expect(el.opened).to.equal(true); // valid
       const visibleOptions = () => options.filter(o => o.style.display !== 'none');
       expect(visibleOptions().length).to.equal(1);
 


### PR DESCRIPTION
1. I added a test called `'does not flash the menu when _showOverlayCondition returns "false"` which fails in the master and works with the proposed PR. The test makes sure the overlay indeed does not flash when it is not expected
2. In some tests I replaced `return options.currentValue.length > 3 && super._showOverlayCondition(options);` with 
```js
  return (
    // @ts-ignore
    this.__prevCboxValueNonSelected.length > 3 && super._showOverlayCondition(options)
  );
```
because the tests like that do not check if the menu shows up after each letter typed and check it only after all text is typed. And at the very beginning `options.currentValue` is the whole option value like `Artichoke` which is a error.  `this.__prevCboxValueNonSelected` contains the actual value typed by that is a private variable which are not supposed to use. So that is a temporary fix
3. For the rest of the tests where I added `// valid` I checked the code in the browser and I can see that the overlay does not show up with on current branch and shows up on `master`. 