### PR TITLE
fix(input-stepper): move role=spinbutton to input node

### DIFF
--- a/.changeset/dirty-scissors-invent.md
+++ b/.changeset/dirty-scissors-invent.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[input-stepper] move role="spinbutton" and relevant aria attributes to the inputNode

--- a/packages/ui/components/input-stepper/src/LionInputStepper.js
+++ b/packages/ui/components/input-stepper/src/LionInputStepper.js
@@ -97,8 +97,8 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
 
     this.__increment = this.__increment.bind(this);
     this.__decrement = this.__decrement.bind(this);
-    this.__boundOnEnterButton = this._onEnterButton.bind(this);
-    this.__boundOnLeaveButton = this._onLeaveButton.bind(this);
+    this._onEnterButton = this._onEnterButton.bind(this);
+    this._onLeaveButton = this._onLeaveButton.bind(this);
   }
 
   connectedCallback() {
@@ -365,8 +365,8 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
       <button
         ?disabled=${this.disabled || this.readOnly}
         @click=${this.__decrement}
-        @focus=${this.__boundOnEnterButton}
-        @blur=${this.__boundOnLeaveButton}
+        @focus=${this._onEnterButton}
+        @blur=${this._onLeaveButton}
         type="button"
         aria-label="${this.msgLit('lion-input-stepper:decrease')}"
       >
@@ -385,8 +385,8 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
       <button
         ?disabled=${this.disabled || this.readOnly}
         @click=${this.__increment}
-        @focus=${this.__boundOnEnterButton}
-        @blur=${this.__boundOnLeaveButton}
+        @focus=${this._onEnterButton}
+        @blur=${this._onLeaveButton}
         type="button"
         aria-label="${this.msgLit('lion-input-stepper:increase')}"
       >

--- a/packages/ui/components/input-stepper/test/lion-input-stepper.test.js
+++ b/packages/ui/components/input-stepper/test/lion-input-stepper.test.js
@@ -278,17 +278,23 @@ describe('<lion-input-stepper>', () => {
       await expect(el).to.be.accessible();
     });
 
+    it('has role="spinbutton"', async () => {
+      const el = await fixture(defaultInputStepper);
+      expect(el._inputNode.hasAttribute('role')).to.be.true;
+      expect(el._inputNode.getAttribute('role')).to.equal('spinbutton');
+    });
+
     it('updates aria-valuenow when stepper is changed', async () => {
       const el = await fixture(defaultInputStepper);
       el.modelValue = 1;
 
       await el.updateComplete;
-      expect(el.hasAttribute('aria-valuenow')).to.be.true;
-      expect(el.getAttribute('aria-valuenow')).to.equal('1');
+      expect(el._inputNode.hasAttribute('aria-valuenow')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuenow')).to.equal('1');
 
       el.modelValue = '';
       await el.updateComplete;
-      expect(el.hasAttribute('aria-valuenow')).to.be.false;
+      expect(el._inputNode.hasAttribute('aria-valuenow')).to.be.false;
     });
 
     it('updates aria-valuetext when stepper is changed', async () => {
@@ -299,12 +305,12 @@ describe('<lion-input-stepper>', () => {
       el.modelValue = 1;
       await el.updateComplete;
 
-      expect(el.hasAttribute('aria-valuetext')).to.be.true;
-      expect(el.getAttribute('aria-valuetext')).to.equal('1');
+      expect(el._inputNode.hasAttribute('aria-valuetext')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuetext')).to.equal('1');
 
       el.modelValue = '';
       await el.updateComplete;
-      expect(el.hasAttribute('aria-valuetext')).to.be.false;
+      expect(el._inputNode.hasAttribute('aria-valuetext')).to.be.false;
     });
 
     it('can give aria-valuetext to override default value as a human-readable text alternative', async () => {
@@ -318,30 +324,60 @@ describe('<lion-input-stepper>', () => {
       `);
       el.modelValue = 1;
       await el.updateComplete;
-      expect(el.hasAttribute('aria-valuetext')).to.be.true;
-      expect(el.getAttribute('aria-valuetext')).to.equal('first');
+      expect(el._inputNode.hasAttribute('aria-valuetext')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuetext')).to.equal('first');
     });
 
     it('updates aria-valuemin when stepper is changed', async () => {
       const el = await fixture(inputStepperWithAttrs);
       const incrementButton = el.querySelector('[slot=suffix]');
       incrementButton?.dispatchEvent(new Event('click'));
-      expect(el).to.have.attribute('aria-valuemin', '100');
+      expect(el._inputNode.hasAttribute('aria-valuemin')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuemin')).to.equal('100');
 
       el.min = 0;
       await el.updateComplete;
-      expect(el).to.have.attribute('aria-valuemin', '0');
+      expect(el._inputNode.hasAttribute('aria-valuemin')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuemin')).to.equal('0');
     });
 
     it('updates aria-valuemax when stepper is changed', async () => {
       const el = await fixture(inputStepperWithAttrs);
       const incrementButton = el.querySelector('[slot=suffix]');
       incrementButton?.dispatchEvent(new Event('click'));
-      expect(el).to.have.attribute('aria-valuemax', '200');
+      expect(el._inputNode.hasAttribute('aria-valuemax')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuemax')).to.equal('200');
 
       el.max = 1000;
       await el.updateComplete;
-      expect(el).to.have.attribute('aria-valuemax', '1000');
+      expect(el._inputNode.hasAttribute('aria-valuemax')).to.be.true;
+      expect(el._inputNode.getAttribute('aria-valuemax')).to.equal('1000');
+    });
+
+    it('when decrease button gets focus, it sets aria-live to input-stepper__value', async () => {
+      const el = await fixture(inputStepperWithAttrs);
+      const stepperValue = el.shadowRoot?.querySelector('.input-stepper__value');
+      const decrementButton = el.querySelector('[slot=prefix]');
+
+      decrementButton?.dispatchEvent(new Event('focus'));
+      expect(stepperValue?.hasAttribute('aria-live')).to.be.true;
+      expect(stepperValue?.getAttribute('aria-live')).to.equal('assertive');
+
+      decrementButton?.dispatchEvent(new Event('blur'));
+      expect(stepperValue?.hasAttribute('aria-live')).to.be.false;
+    });
+
+    it('when increase button gets focus, it sets aria-live to input-stepper__value', async () => {
+      const el = await fixture(inputStepperWithAttrs);
+      const stepperValue = el.shadowRoot?.querySelector('.input-stepper__value');
+      const incrementButton = el.querySelector('[slot=suffix]');
+
+      incrementButton?.dispatchEvent(new Event('focus'));
+      expect(stepperValue?.hasAttribute('aria-live')).to.be.true;
+      expect(stepperValue?.getAttribute('aria-live')).to.equal('assertive');
+
+      incrementButton?.dispatchEvent(new Event('blur'));
+      expect(stepperValue?.hasAttribute('aria-live')).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## What I did

1. To make input-stepper work with NVDA we move the `role="spinbutton"` to the inputNode.
2. To make the decrease & increase buttons announce the new value, a hidden value element was created.

**Before:**

https://github.com/user-attachments/assets/051d7efd-4e19-4ba9-abee-bc5199c0dcb5

**After:**

https://github.com/user-attachments/assets/d46c6cc5-7aa9-4c8f-a7b4-9c28b75c6ccc


