### PR TITLE
Added utility method to resolve locale supplied and fallback

### DIFF
--- a/packages/ui/components/localize/src/utils/resolveLocaleConfig.js
+++ b/packages/ui/components/localize/src/utils/resolveLocaleConfig.js
@@ -1,0 +1,20 @@
+/**
+ *
+ * @param {string} namespace Namespace for the locale
+ * @param {any} localeDir Directory of the locale
+ * @returns Promise<LocaleConfig>
+ */
+export const resolveLocaleConfig = (namespace, localeDir) => ({
+  [namespace]: (locale = 'en') => {
+    const localePath = (/** @type {string} */ loc) => [localeDir, `${loc}.js`].join('/');
+
+    const fallbackLocale = localePath(locale.replace(/-\w+/, ''));
+
+    return import(localePath(locale)).catch(reason => {
+      console.warn(`
+        Locale ${locale} not found. Reason ${reason}.
+        Loading fallback locale ${fallbackLocale}`);
+      return import(fallbackLocale);
+    });
+  },
+});

--- a/packages/ui/components/localize/test/resolveLocaleConfig.test.js
+++ b/packages/ui/components/localize/test/resolveLocaleConfig.test.js
@@ -1,0 +1,19 @@
+import { expect } from '@open-wc/testing';
+import { resolveLocaleConfig } from '../src/utils/resolveLocaleConfig.js';
+
+describe('resolveLocaleConfig', () => {
+  it('works correctly', async () => {
+    const localePath = new URL('./translations', import.meta.url);
+    const localeConfig = await resolveLocaleConfig('demo', localePath);
+
+    // When no locale is supplied `en.js` is loaded
+    expect((await localeConfig.demo()).default.hello).to.equal('en.js loaded');
+
+    // When `de-DE` locale is supplied `de-DE.js` is loaded
+    expect((await localeConfig.demo('de-DE')).default.hello).to.equal('de-DE.js loaded');
+
+    // When `de-AB` locale is supplied and the file does not exists.
+    // Then everything from - is removed and `de.js` is loaded. Which is equivalent to the default case.
+    expect((await localeConfig.demo('de-AB')).default.hello).to.equal('de.js loaded');
+  });
+});

--- a/packages/ui/components/localize/test/translations/de-DE.js
+++ b/packages/ui/components/localize/test/translations/de-DE.js
@@ -1,0 +1,3 @@
+export default {
+  hello: 'de-DE.js loaded',
+};

--- a/packages/ui/components/localize/test/translations/de.js
+++ b/packages/ui/components/localize/test/translations/de.js
@@ -1,0 +1,3 @@
+export default {
+  hello: 'de.js loaded',
+};

--- a/packages/ui/components/localize/test/translations/en-GB.js
+++ b/packages/ui/components/localize/test/translations/en-GB.js
@@ -1,0 +1,3 @@
+export default {
+  hello: 'en-GB.js loaded',
+};

--- a/packages/ui/components/localize/test/translations/en.js
+++ b/packages/ui/components/localize/test/translations/en.js
@@ -1,0 +1,3 @@
+export default {
+  hello: 'en.js loaded',
+};


### PR DESCRIPTION
## What I did

1. Implemented utility method to resolve locale files. If supplied it loads the target locale file. If it doesn't find then it strips everything from - from the filename and loads it. 

ex supplied `de-DE` loads `de-DE.js` file
supplied `de-AB` tries to load `de-AB.js` since the file doesn't exists it loads `de.js` file 
