### PR TITLE
Fix/parse number locale

### DIFF
--- a/.changeset/early-turkeys-applaud.md
+++ b/.changeset/early-turkeys-applaud.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[localize] parseNumbers as withLocale if locale was passed as the option

--- a/packages/ui/components/localize/src/number/parseNumber.js
+++ b/packages/ui/components/localize/src/number/parseNumber.js
@@ -16,17 +16,19 @@ import { getDecimalSeparator } from './getDecimalSeparator.js';
  * parseNumber('1,234.56'); // method: heuristic => 1234.56
  *
  * @param {string} value Clean number (only [0-9 ,.]) to be parsed
- * @param {object} options
- * @param {string?} [options.mode] auto|pasted
+ * @param {import('../../types/LocalizeMixinTypes.js').FormatNumberOptions} [options] Locale Options
  * @return {string} unparseable|withLocale|heuristic
  */
-function getParseMode(value, { mode = 'auto' } = {}) {
+function getParseMode(value, options = { mode: 'auto' }) {
   const separators = value.match(/[., ]/g);
 
   if (!separators) {
     return 'withLocale';
   }
-  if (mode === 'auto' && separators.length === 1) {
+  if (options.locale) {
+    return 'withLocale';
+  }
+  if (options.mode === 'auto' && separators.length === 1) {
     const decimalLength = value.split(`${separators}`)[1].length;
     if (decimalLength >= 3) {
       return 'withLocale';

--- a/packages/ui/components/localize/src/number/parseNumber.js
+++ b/packages/ui/components/localize/src/number/parseNumber.js
@@ -16,19 +16,19 @@ import { getDecimalSeparator } from './getDecimalSeparator.js';
  * parseNumber('1,234.56'); // method: heuristic => 1234.56
  *
  * @param {string} value Clean number (only [0-9 ,.]) to be parsed
- * @param {import('../../types/LocalizeMixinTypes.js').FormatNumberOptions} options Locale Options
+ * @param {import('../../types/LocalizeMixinTypes.js').FormatNumberOptions} [options] Locale Options
  * @return {string} unparseable|withLocale|heuristic
  */
-function getParseMode(value, { mode = 'auto', locale }) {
+function getParseMode(value, options = { mode: 'auto' }) {
   const separators = value.match(/[., ]/g);
 
   if (!separators) {
     return 'withLocale';
   }
-  if (locale) {
+  if (options.locale) {
     return 'withLocale';
   }
-  if (mode === 'auto' && separators.length === 1) {
+  if (options.mode === 'auto' && separators.length === 1) {
     const decimalLength = value.split(`${separators}`)[1].length;
     if (decimalLength >= 3) {
       return 'withLocale';

--- a/packages/ui/components/localize/src/number/parseNumber.js
+++ b/packages/ui/components/localize/src/number/parseNumber.js
@@ -16,19 +16,19 @@ import { getDecimalSeparator } from './getDecimalSeparator.js';
  * parseNumber('1,234.56'); // method: heuristic => 1234.56
  *
  * @param {string} value Clean number (only [0-9 ,.]) to be parsed
- * @param {import('../../types/LocalizeMixinTypes.js').FormatNumberOptions} [options] Locale Options
+ * @param {import('../../types/LocalizeMixinTypes.js').FormatNumberOptions} options Locale Options
  * @return {string} unparseable|withLocale|heuristic
  */
-function getParseMode(value, options = { mode: 'auto' }) {
+function getParseMode(value, { mode = 'auto', locale }) {
   const separators = value.match(/[., ]/g);
 
   if (!separators) {
     return 'withLocale';
   }
-  if (options.locale) {
+  if (locale) {
     return 'withLocale';
   }
-  if (options.mode === 'auto' && separators.length === 1) {
+  if (mode === 'auto' && separators.length === 1) {
     const decimalLength = value.split(`${separators}`)[1].length;
     if (decimalLength >= 3) {
       return 'withLocale';

--- a/packages/ui/components/localize/test/number/parseNumber.test.js
+++ b/packages/ui/components/localize/test/number/parseNumber.test.js
@@ -106,12 +106,6 @@ describe('parseNumber()', () => {
     expect(parseNumber('1,234')).to.equal(1.234);
     expect(parseNumber('1.2345')).to.equal(12345);
     expect(parseNumber('1,2345')).to.equal(1.2345);
-
-    localizeManager.locale = 'de-DE';
-    expect(parseNumber('1.234')).to.equal(1234);
-    expect(parseNumber('1,234')).to.equal(1.234);
-    expect(parseNumber('1.2345')).to.equal(12345);
-    expect(parseNumber('1,2345')).to.equal(1.2345);
   });
 
   it('returns numbers only if it can not be interpreted e.g. 1.234.567', () => {

--- a/packages/ui/components/localize/test/number/parseNumber.test.js
+++ b/packages/ui/components/localize/test/number/parseNumber.test.js
@@ -94,14 +94,24 @@ describe('parseNumber()', () => {
     expect(parseNumber('12,34')).to.equal(12.34);
   });
 
-  it('uses locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
+  it('uses english locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
     localizeManager.locale = 'en-GB';
     expect(parseNumber('1.234')).to.equal(1.234);
     expect(parseNumber('1,234')).to.equal(1234);
     expect(parseNumber('1.2345')).to.equal(1.2345);
     expect(parseNumber('1,2345')).to.equal(12345);
+  });
 
+  it('uses dutch locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
     localizeManager.locale = 'nl-NL';
+    expect(parseNumber('1.234')).to.equal(1234);
+    expect(parseNumber('1,234')).to.equal(1.234);
+    expect(parseNumber('1.2345')).to.equal(12345);
+    expect(parseNumber('1,2345')).to.equal(1.2345);
+  });
+
+  it('uses german locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
+    localizeManager.locale = 'de-DE';
     expect(parseNumber('1.234')).to.equal(1234);
     expect(parseNumber('1,234')).to.equal(1.234);
     expect(parseNumber('1.2345')).to.equal(12345);
@@ -182,5 +192,74 @@ describe('parseNumber()', () => {
         locale: 'es-ES',
       }),
     ).to.equal(6000);
+  });
+
+  it('with english locale and english number format', () => {
+    expect(
+      parseNumber('1,00', {
+        locale: 'en-GB',
+      }),
+    ).to.equal(100);
+    expect(
+      parseNumber('55,55', {
+        locale: 'en-GB',
+      }),
+    ).to.equal(5555);
+    expect(
+      parseNumber('1.00', {
+        locale: 'en-GB',
+      }),
+    ).to.equal(1.0);
+    expect(
+      parseNumber('55.55', {
+        locale: 'en-GB',
+      }),
+    ).to.equal(55.55);
+  });
+
+  it('with dutch locale and dutch number format', () => {
+    expect(
+      parseNumber('1,00', {
+        locale: 'nl-NL',
+      }),
+    ).to.equal(1);
+    expect(
+      parseNumber('55,55', {
+        locale: 'nl-NL',
+      }),
+    ).to.equal(55.55);
+    expect(
+      parseNumber('1.00', {
+        locale: 'nl-NL',
+      }),
+    ).to.equal(100);
+    expect(
+      parseNumber('55.55', {
+        locale: 'nl-NL',
+      }),
+    ).to.equal(5555);
+  });
+
+  it('with german locale and german number format', () => {
+    expect(
+      parseNumber('1,00', {
+        locale: 'de-DE',
+      }),
+    ).to.equal(1);
+    expect(
+      parseNumber('55,55', {
+        locale: 'de-DE',
+      }),
+    ).to.equal(55.55);
+    expect(
+      parseNumber('1.00', {
+        locale: 'de-DE',
+      }),
+    ).to.equal(100);
+    expect(
+      parseNumber('55.55', {
+        locale: 'de-DE',
+      }),
+    ).to.equal(5555);
   });
 });

--- a/packages/ui/components/localize/test/number/parseNumber.test.js
+++ b/packages/ui/components/localize/test/number/parseNumber.test.js
@@ -94,23 +94,19 @@ describe('parseNumber()', () => {
     expect(parseNumber('12,34')).to.equal(12.34);
   });
 
-  it('uses english locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
+  it('uses locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
     localizeManager.locale = 'en-GB';
     expect(parseNumber('1.234')).to.equal(1.234);
     expect(parseNumber('1,234')).to.equal(1234);
     expect(parseNumber('1.2345')).to.equal(1.2345);
     expect(parseNumber('1,2345')).to.equal(12345);
-  });
 
-  it('uses dutch locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
     localizeManager.locale = 'nl-NL';
     expect(parseNumber('1.234')).to.equal(1234);
     expect(parseNumber('1,234')).to.equal(1.234);
     expect(parseNumber('1.2345')).to.equal(12345);
     expect(parseNumber('1,2345')).to.equal(1.2345);
-  });
 
-  it('uses german locale to parse amount if there is only one separator e.g. 1.234 and amount of decimals is bigger then 2', () => {
     localizeManager.locale = 'de-DE';
     expect(parseNumber('1.234')).to.equal(1234);
     expect(parseNumber('1,234')).to.equal(1.234);
@@ -194,7 +190,8 @@ describe('parseNumber()', () => {
     ).to.equal(6000);
   });
 
-  it('with english locale and english number format', () => {
+  it('should use locale to parse numbers when locale was passed as the option', () => {
+    // Locale: en-GB
     expect(
       parseNumber('1,00', {
         locale: 'en-GB',
@@ -217,49 +214,25 @@ describe('parseNumber()', () => {
     ).to.equal(55.55);
   });
 
-  it('with dutch locale and dutch number format', () => {
-    expect(
-      parseNumber('1,00', {
-        locale: 'nl-NL',
-      }),
-    ).to.equal(1);
-    expect(
-      parseNumber('55,55', {
-        locale: 'nl-NL',
-      }),
-    ).to.equal(55.55);
-    expect(
-      parseNumber('1.00', {
-        locale: 'nl-NL',
-      }),
-    ).to.equal(100);
-    expect(
-      parseNumber('55.55', {
-        locale: 'nl-NL',
-      }),
-    ).to.equal(5555);
-  });
-
-  it('with german locale and german number format', () => {
-    expect(
-      parseNumber('1,00', {
-        locale: 'de-DE',
-      }),
-    ).to.equal(1);
-    expect(
-      parseNumber('55,55', {
-        locale: 'de-DE',
-      }),
-    ).to.equal(55.55);
-    expect(
-      parseNumber('1.00', {
-        locale: 'de-DE',
-      }),
-    ).to.equal(100);
-    expect(
-      parseNumber('55.55', {
-        locale: 'de-DE',
-      }),
-    ).to.equal(5555);
-  });
+  // Locale: nl-NL
+  expect(
+    parseNumber('1,00', {
+      locale: 'nl-NL',
+    }),
+  ).to.equal(1);
+  expect(
+    parseNumber('55,55', {
+      locale: 'nl-NL',
+    }),
+  ).to.equal(55.55);
+  expect(
+    parseNumber('1.00', {
+      locale: 'nl-NL',
+    }),
+  ).to.equal(100);
+  expect(
+    parseNumber('55.55', {
+      locale: 'nl-NL',
+    }),
+  ).to.equal(5555);
 });


### PR DESCRIPTION
## What I did

1. Pass the options object to the getParseMode function.
2. Check the locale option and return 'withLocale' if its not undefined.
3. Update current unit tests, add new to check different local options.
