### PR TITLE
fix(ui/core): rerender direct host child with right slot attr when root is switched

### DIFF
--- a/.changeset/great-pumas-rush.md
+++ b/.changeset/great-pumas-rush.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[core] rerender direct host child with right slot attr when root is switched

--- a/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -181,7 +181,7 @@ export class LionInputTelDropdown extends LionInputTel {
 
         return {
           template: templates.dropdown(this._templateDataDropdown),
-          renderAsDirectHostChild: Boolean,
+          renderAsDirectHostChild: true,
         };
       },
     };


### PR DESCRIPTION
      // Assume we had: { template: myBool ? html`<div id=a></div>` : html`<span id=b></span>`, renderAsDirectHostChild: true }
      // If myBool started as true, <div id=a></div> would be rendered in first render above, A slot would be applied...
      // However, when myBool changes to false, the <span id=b></span> would be rendered instead...
      // We need to make sure that this "replaced root" gets the slot applied as well