### PR TITLE
Fix/docs for light dom

### DIFF
--- a/.changeset/hip-nails-matter.md
+++ b/.changeset/hip-nails-matter.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[button] set the "aria-disabled" attribute to "true" when disabled and remove it when not disabled

--- a/docs/guides/how-to/create-a-form.md
+++ b/docs/guides/how-to/create-a-form.md
@@ -25,8 +25,13 @@ Large or complex forms might need to be split up into multiple files. This compo
 - shared templates
 - (web) components
 
-In the latter case: make sure that your components don't have a shadow root.
-This can be achieved in LitElement by providing the host as render root:
+In the latter case: make sure that your components don't have a shadow root. This can be achieved by rendering into Light DOM. The form registration mechanism relies on light dom by design: as soon as you do start to use shadow roots, you will notice that your form components won't register themselves anymore to their parents.
+
+> Today, rendering to light dom is the only way to [stay accessible](../../fundamentals/rationales/accessibility.md#shadow-roots-and-accessibility).
+
+### Example of a component that renders into Light DOM
+
+Rendering into Light DOM can be achieved in LitElement by providing the host as render root:
 
 ```js
 class MySubForm extends LitElement {
@@ -62,10 +67,6 @@ class MyForm extends LitElement {
   }
 }
 ```
-
-> Today, rendering to light dom is the only way to [stay accessible](../../fundamentals/rationales/accessibility.md#shadow-roots-and-accessibility).
-
-The registration mechanism relies on light dom by design: as soon as you do start to use shadow roots, you will notice that your form components won't register themselves anymore to their parents.
 
 ## Extending form components
 

--- a/docs/guides/how-to/create-a-form.md
+++ b/docs/guides/how-to/create-a-form.md
@@ -25,13 +25,8 @@ Large or complex forms might need to be split up into multiple files. This compo
 - shared templates
 - (web) components
 
-In the latter case: make sure that your components don't have a shadow root. This can be achieved by rendering into Light DOM. The form registration mechanism relies on light dom by design: as soon as you do start to use shadow roots, you will notice that your form components won't register themselves anymore to their parents.
-
-> Today, rendering to light dom is the only way to [stay accessible](../../fundamentals/rationales/accessibility.md#shadow-roots-and-accessibility).
-
-### Example of a component that renders into Light DOM
-
-Rendering into Light DOM can be achieved in LitElement by providing the host as render root:
+In the latter case: make sure that your components don't have a shadow root.
+This can be achieved in LitElement by providing the host as render root:
 
 ```js
 class MySubForm extends LitElement {
@@ -67,6 +62,10 @@ class MyForm extends LitElement {
   }
 }
 ```
+
+> Today, rendering to light dom is the only way to [stay accessible](../../fundamentals/rationales/accessibility.md#shadow-roots-and-accessibility).
+
+The registration mechanism relies on light dom by design: as soon as you do start to use shadow roots, you will notice that your form components won't register themselves anymore to their parents.
 
 ## Extending form components
 

--- a/packages/ui/components/button/src/LionButton.js
+++ b/packages/ui/components/button/src/LionButton.js
@@ -147,6 +147,7 @@ export class LionButton extends DisabledWithTabIndexMixin(LitElement) {
    */
   updated(changedProperties) {
     super.updated(changedProperties);
+
     if (changedProperties.has('disabled')) {
       if (this.disabled) {
         this.setAttribute('aria-disabled', 'true');

--- a/packages/ui/components/button/src/LionButton.js
+++ b/packages/ui/components/button/src/LionButton.js
@@ -147,9 +147,12 @@ export class LionButton extends DisabledWithTabIndexMixin(LitElement) {
    */
   updated(changedProperties) {
     super.updated(changedProperties);
-
     if (changedProperties.has('disabled')) {
-      this.setAttribute('aria-disabled', `${this.disabled}`); // create mixin if we need it in more places
+      if (this.disabled) {
+        this.setAttribute('aria-disabled', 'true');
+      } else if (this.getAttribute('aria-disabled') !== null) {
+        this.removeAttribute('aria-disabled');
+      }
     }
   }
 

--- a/packages/ui/components/button/test-suites/LionButton.suite.js
+++ b/packages/ui/components/button/test-suites/LionButton.suite.js
@@ -40,7 +40,7 @@ export function LionButtonSuite({ klass = LionButton } = {}) {
       el.disabled = false;
       await el.updateComplete;
       expect(el.getAttribute('tabindex')).to.equal('0');
-      expect(el.getAttribute('aria-disabled')).to.equal('false');
+      expect(el.getAttribute('aria-disabled')).to.not.exist;
       expect(el.hasAttribute('disabled')).to.equal(false);
 
       el.disabled = true;


### PR DESCRIPTION
Improve a11y. Some tools complain that an invoker button for a dialog should not have `aria-disabled="false"`