### PR TITLE
fix: remove unnecessary _showOverlayCondition

### DIFF
--- a/packages/ui/components/combobox/src/LionCombobox.js
+++ b/packages/ui/components/combobox/src/LionCombobox.js
@@ -709,7 +709,6 @@ export class LionCombobox extends LocalizeMixin(OverlayMixin(CustomChoiceGroupMi
   // eslint-disable-next-line no-unused-vars
   _textboxOnInput(ev) {
     this.__shouldAutocompleteNextUpdate = true;
-    this.opened = this._showOverlayCondition({});
   }
 
   /**


### PR DESCRIPTION
Found a behavior that seems unintended. As far as I can say from code comments and overall familiarity with logic, `_showOnverlayCondition` is intended to be called only on `keyUp`. Looks like calling it in a `_textboxOnInput` is unnecessary and it will cause some weird edge-cases when subclassers overrive `_showOnverlayCondition`. This is due to difference in how `_showOnverlayCondition` is parametrized when called on `keyUp` (with an `ev` keyboard event) and in `_textboxOnInput` (with `{}`). 

Scenario which breaks without the proposed change:
A subclasser wants to implement a functionatily when overlay will only show if input length is >= 3.
They would override a method like this:
```js
_showOverlayCondition(options) {
    const hideOnKeys = ['Tab', 'Escape', 'Enter'];
    if (this.minSearchChars && !hideOnKeys.includes(options.lastKey)) {
      return options.currentValue?.length >= this.minSearchChars;
    } else {
      return super._showOverlayCondition(options);
    }
  }
```

`_showOverlayCondition` method would be called seemingly on `keyDown` here, but upon closer look the call comes from `_textboxOnInput`. `_showOverlayCondition` in this case would be called twice, first time `options` will equal `{ }` and it will close overlay and set input value of textbox to `''`.

It looks logical to me to get rid of this line. Tests pass.