### PR TITLE
fix(calendar): remove duplicate information for screen-reader user

### DIFF
--- a/.changeset/nasty-numbers-destroy.md
+++ b/.changeset/nasty-numbers-destroy.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[calendar] remove duplicate information for screen-reader user

--- a/packages/ui/components/calendar/src/calendarStyle.js
+++ b/packages/ui/components/calendar/src/calendarStyle.js
@@ -95,7 +95,6 @@ export const calendarStyle = css`
 
   .u-sr-only {
     position: absolute;
-    top: 0;
     width: 1px;
     height: 1px;
     overflow: hidden;

--- a/packages/ui/components/calendar/src/utils/dataTemplate.js
+++ b/packages/ui/components/calendar/src/utils/dataTemplate.js
@@ -15,10 +15,15 @@ export function dataTemplate(
         month => html`
           <table role="grid" data-wrap-cols aria-readonly="true" class="calendar__grid">
             <thead>
-              <tr>
+              <tr role="row">
                 ${weekdaysShort.map(
                   (header, i) => html`
-                    <th class="calendar__weekday-header" scope="col" aria-label="${weekdays[i]}">
+                    <th
+                      role="columnheader"
+                      class="calendar__weekday-header"
+                      scope="col"
+                      aria-label="${weekdays[i]}"
+                    >
                       ${header}
                     </th>
                   `,
@@ -28,7 +33,7 @@ export function dataTemplate(
             <tbody>
               ${month.weeks.map(
                 week => html`
-                  <tr>
+                  <tr role="row">
                     ${week.days.map(day =>
                       dayTemplate(day, { weekdaysShort, weekdays, monthsLabels }),
                     )}

--- a/packages/ui/components/calendar/src/utils/dataTemplate.js
+++ b/packages/ui/components/calendar/src/utils/dataTemplate.js
@@ -13,23 +13,12 @@ export function dataTemplate(
     <div id="js-content-wrapper">
       ${data.months.map(
         month => html`
-          <table
-            role="grid"
-            data-wrap-cols
-            aria-readonly="true"
-            class="calendar__grid"
-            aria-labelledby="month year"
-          >
+          <table role="grid" data-wrap-cols aria-readonly="true" class="calendar__grid">
             <thead>
-              <tr role="row">
+              <tr>
                 ${weekdaysShort.map(
                   (header, i) => html`
-                    <th
-                      role="columnheader"
-                      class="calendar__weekday-header"
-                      scope="col"
-                      aria-label="${weekdays[i]}"
-                    >
+                    <th class="calendar__weekday-header" scope="col" aria-label="${weekdays[i]}">
                       ${header}
                     </th>
                   `,
@@ -39,7 +28,7 @@ export function dataTemplate(
             <tbody>
               ${month.weeks.map(
                 week => html`
-                  <tr role="row">
+                  <tr>
                     ${week.days.map(day =>
                       dayTemplate(day, { weekdaysShort, weekdays, monthsLabels }),
                     )}

--- a/packages/ui/components/calendar/src/utils/dayTemplate.js
+++ b/packages/ui/components/calendar/src/utils/dayTemplate.js
@@ -11,10 +11,10 @@ const lastDaysOfYear = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
  * @param {{ weekdays: string[], monthsLabels?: string[] }} opts
  */
 export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }) {
-  const { dayNumber, monthName, year, weekdayName } = getDayMonthYear(day, weekdays, monthsLabels);
+  const { dayNumber, monthName, year } = getDayMonthYear(day, weekdays, monthsLabels);
 
   function __getFullDate() {
-    return `${monthName} ${year} ${weekdayName}`;
+    return `${monthName} ${year}.`;
   }
 
   function __getAccessibleMessage() {
@@ -39,7 +39,6 @@ export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }
 
   return html`
     <td
-      role="gridcell"
       class="calendar__day-cell"
       ?current-month=${day.currentMonth}
       ?first-day=${firstDay}

--- a/packages/ui/components/calendar/src/utils/dayTemplate.js
+++ b/packages/ui/components/calendar/src/utils/dayTemplate.js
@@ -13,12 +13,12 @@ const lastDaysOfYear = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }) {
   const { dayNumber, monthName, year } = getDayMonthYear(day, weekdays, monthsLabels);
 
-  function __getFullDate() {
+  function __getMonthAndYear() {
     return `${monthName} ${year}.`;
   }
 
   function __getAccessibleMessage() {
-    return `${day.disabledInfo}`;
+    return ` ${day.disabledInfo}`;
   }
 
   const firstDay = dayNumber === 1;
@@ -39,6 +39,7 @@ export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }
 
   return html`
     <td
+      role="gridcell"
       class="calendar__day-cell"
       ?current-month=${day.currentMonth}
       ?first-day=${firstDay}
@@ -65,7 +66,7 @@ export function dayTemplate(day, { weekdays, monthsLabels = defaultMonthLabels }
         ?next-month=${day.nextMonth}
       >
         <span class="calendar__day-button__text">${dayNumber}</span>
-        <span class="u-sr-only">${__getFullDate()} ${__getAccessibleMessage()}</span>
+        <span class="u-sr-only">${__getMonthAndYear()}${__getAccessibleMessage()}</span>
       </div>
     </td>
   `;

--- a/packages/ui/components/calendar/test/lion-calendar.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar.test.js
@@ -934,7 +934,7 @@ describe('<lion-calendar>', () => {
                 15
               </span>
               <span class="u-sr-only">
-                December 2000.&nbsp;This date is unavailable. Please choose another date.
+                December 2000. This date is unavailable. Please choose another date.
               </span>
             </div>
           `);
@@ -963,7 +963,7 @@ describe('<lion-calendar>', () => {
                 1
               </span>
               <span class="u-sr-only">
-                December 2000.&nbsp;This date is unavailable. Earliest available date is 9 December 2000. Please choose another date.
+                December 2000. This date is unavailable. Earliest available date is 9 December 2000. Please choose another date.
               </span>
             </div>
           `);
@@ -992,7 +992,7 @@ describe('<lion-calendar>', () => {
                 30
               </span>
               <span class="u-sr-only">
-                December 2000.&nbsp;This date is unavailable. Latest available date is 9 December 2000. Please choose another date.
+                December 2000. This date is unavailable. Latest available date is 9 December 2000. Please choose another date.
               </span>
             </div>
           `);

--- a/packages/ui/components/calendar/test/lion-calendar.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar.test.js
@@ -870,7 +870,7 @@ describe('<lion-calendar>', () => {
                 30
               </span>
               <span class="u-sr-only">
-                September 2019 Monday
+                September 2019.
               </span>
             </div>
           `);
@@ -934,7 +934,7 @@ describe('<lion-calendar>', () => {
                 15
               </span>
               <span class="u-sr-only">
-                December 2000 Friday This date is unavailable. Please choose another date.
+                December 2000.&nbsp;This date is unavailable. Please choose another date.
               </span>
             </div>
           `);
@@ -963,7 +963,7 @@ describe('<lion-calendar>', () => {
                 1
               </span>
               <span class="u-sr-only">
-                December 2000 Friday This date is unavailable. Earliest available date is 9 December 2000. Please choose another date.
+                December 2000.&nbsp;This date is unavailable. Earliest available date is 9 December 2000. Please choose another date.
               </span>
             </div>
           `);
@@ -992,7 +992,7 @@ describe('<lion-calendar>', () => {
                 30
               </span>
               <span class="u-sr-only">
-                December 2000 Saturday This date is unavailable. Latest available date is 9 December 2000. Please choose another date.
+                December 2000.&nbsp;This date is unavailable. Latest available date is 9 December 2000. Please choose another date.
               </span>
             </div>
           `);

--- a/packages/ui/components/calendar/test/utils/dataTemplate.test.js
+++ b/packages/ui/components/calendar/test/utils/dataTemplate.test.js
@@ -9,6 +9,56 @@ import { dataTemplate } from '../../src/utils/dataTemplate.js';
 import snapshot_enGB_Sunday_201812 from './snapshots/monthTemplate_en-GB_Sunday_2018-12.js';
 
 describe('dataTemplate', () => {
+  it('table row has role="row" to allow users to extend without breaking the accessibility', async () => {
+    // The reason is: lion is made with extending it in mind. That means overriding css.
+    // If you change the display prop of tables, it loses its semantics
+    const date = new Date('2018/12/01');
+    const month = createMultipleMonth(date, { firstDayOfWeek: 0 });
+    const el = await fixture(
+      dataTemplate(month, {
+        weekdaysShort: weekdayNames['en-GB'].Sunday.short,
+        weekdays: weekdayNames['en-GB'].Sunday.long,
+      }),
+    );
+    const tableRows = el.querySelectorAll('tr');
+    expect(tableRows[0].hasAttribute('role')).to.be.true;
+    expect(tableRows[0].getAttribute('role')).to.equal('row', 'inside thead');
+    expect(tableRows[1].hasAttribute('role')).to.be.true;
+    expect(tableRows[1].getAttribute('role')).to.equal('row', 'inside tbody');
+  });
+
+  it('table header has role="columnheader" to allow users to extend without breaking the accessibility', async () => {
+    // The reason is: lion is made with extending it in mind. That means overriding css.
+    // If you change the display prop of tables, it loses its semantics
+    const date = new Date('2018/12/01');
+    const month = createMultipleMonth(date, { firstDayOfWeek: 0 });
+    const el = await fixture(
+      dataTemplate(month, {
+        weekdaysShort: weekdayNames['en-GB'].Sunday.short,
+        weekdays: weekdayNames['en-GB'].Sunday.long,
+      }),
+    );
+    const tableRows = el.querySelectorAll('th');
+    expect(tableRows[0].hasAttribute('role')).to.be.true;
+    expect(tableRows[0].getAttribute('role')).to.equal('columnheader');
+  });
+
+  it('table cell has role="gridcell" to allow users to extend without breaking the accessibility', async () => {
+    // The reason is: lion is made with extending it in mind. That means overriding css.
+    // If you change the display prop of tables, it loses its semantics
+    const date = new Date('2018/12/01');
+    const month = createMultipleMonth(date, { firstDayOfWeek: 0 });
+    const el = await fixture(
+      dataTemplate(month, {
+        weekdaysShort: weekdayNames['en-GB'].Sunday.short,
+        weekdays: weekdayNames['en-GB'].Sunday.long,
+      }),
+    );
+    const tableRows = el.querySelectorAll('td');
+    expect(tableRows[0].hasAttribute('role')).to.be.true;
+    expect(tableRows[0].getAttribute('role')).to.equal('gridcell');
+  });
+
   it('renders one month table', async () => {
     const date = new Date('2018/12/01');
     const month = createMultipleMonth(date, { firstDayOfWeek: 0 });

--- a/packages/ui/components/calendar/test/utils/dayTemplate.test.js
+++ b/packages/ui/components/calendar/test/utils/dayTemplate.test.js
@@ -20,7 +20,7 @@ describe('dayTemplate', () => {
         >
           <span class="calendar__day-button__text">19</span>
           <span class="u-sr-only">
-            April 2019 Friday
+            April 2019.
           </span>
         </div>
       </td>

--- a/packages/ui/components/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
+++ b/packages/ui/components/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
@@ -4,19 +4,48 @@ export default html`
   <div id="js-content-wrapper">
     <table aria-readonly="true" class="calendar__grid" data-wrap-cols="" role="grid">
       <thead>
-        <tr>
-          <th class="calendar__weekday-header" aria-label="Sunday" scope="col">Sun</th>
-          <th class="calendar__weekday-header" aria-label="Monday" scope="col">Mon</th>
-          <th class="calendar__weekday-header" aria-label="Tuesday" scope="col">Tue</th>
-          <th class="calendar__weekday-header" aria-label="Wednesday" scope="col">Wed</th>
-          <th class="calendar__weekday-header" aria-label="Thursday" scope="col">Thu</th>
-          <th class="calendar__weekday-header" aria-label="Friday" scope="col">Fri</th>
-          <th class="calendar__weekday-header" aria-label="Saturday" scope="col">Sat</th>
+        <tr role="row">
+          <th class="calendar__weekday-header" aria-label="Sunday" scope="col" role="columnheader">
+            Sun
+          </th>
+          <th class="calendar__weekday-header" aria-label="Monday" scope="col" role="columnheader">
+            Mon
+          </th>
+          <th class="calendar__weekday-header" aria-label="Tuesday" scope="col" role="columnheader">
+            Tue
+          </th>
+          <th
+            class="calendar__weekday-header"
+            aria-label="Wednesday"
+            scope="col"
+            role="columnheader"
+          >
+            Wed
+          </th>
+          <th
+            class="calendar__weekday-header"
+            aria-label="Thursday"
+            scope="col"
+            role="columnheader"
+          >
+            Thu
+          </th>
+          <th class="calendar__weekday-header" aria-label="Friday" scope="col" role="columnheader">
+            Fri
+          </th>
+          <th
+            class="calendar__weekday-header"
+            aria-label="Saturday"
+            scope="col"
+            role="columnheader"
+          >
+            Sat
+          </th>
         </tr>
       </thead>
       <tbody>
-        <tr>
-          <td class="calendar__day-cell" start-of-last-week>
+        <tr role="row">
+          <td class="calendar__day-cell" role="gridcell" start-of-last-week>
             <div
               role="button"
               aria-disabled="false"
@@ -28,7 +57,7 @@ export default html`
               <span class="u-sr-only"> November 2018.</span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -40,7 +69,7 @@ export default html`
               <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -52,7 +81,7 @@ export default html`
               <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -64,7 +93,7 @@ export default html`
               <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -76,7 +105,7 @@ export default html`
               <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" last-day>
+          <td class="calendar__day-cell" role="gridcell" last-day>
             <div
               role="button"
               aria-disabled="false"
@@ -88,7 +117,7 @@ export default html`
               <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" end-of-first-week first-day>
+          <td class="calendar__day-cell" role="gridcell" end-of-first-week first-day>
             <div
               role="button"
               aria-disabled="false"
@@ -101,8 +130,8 @@ export default html`
             </div>
           </td>
         </tr>
-        <tr>
-          <td class="calendar__day-cell" start-of-first-full-week>
+        <tr role="row">
+          <td class="calendar__day-cell" role="gridcell" start-of-first-full-week>
             <div
               role="button"
               aria-disabled="false"
@@ -114,7 +143,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -126,7 +155,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -138,7 +167,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -150,7 +179,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -162,7 +191,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -174,7 +203,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -187,8 +216,8 @@ export default html`
             </div>
           </td>
         </tr>
-        <tr>
-          <td class="calendar__day-cell">
+        <tr role="row">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -200,7 +229,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -212,7 +241,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -224,7 +253,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -236,7 +265,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -248,7 +277,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -260,7 +289,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -273,8 +302,8 @@ export default html`
             </div>
           </td>
         </tr>
-        <tr>
-          <td class="calendar__day-cell">
+        <tr role="row">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -286,7 +315,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -298,7 +327,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -310,7 +339,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -322,7 +351,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -334,7 +363,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -346,7 +375,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -359,8 +388,8 @@ export default html`
             </div>
           </td>
         </tr>
-        <tr>
-          <td class="calendar__day-cell">
+        <tr role="row">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -372,7 +401,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -384,7 +413,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -396,7 +425,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -408,7 +437,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -420,7 +449,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -432,7 +461,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" end-of-last-full-week>
+          <td class="calendar__day-cell" role="gridcell" end-of-last-full-week>
             <div
               role="button"
               aria-disabled="false"
@@ -445,8 +474,8 @@ export default html`
             </div>
           </td>
         </tr>
-        <tr>
-          <td class="calendar__day-cell" start-of-last-week>
+        <tr role="row">
+          <td class="calendar__day-cell" role="gridcell" start-of-last-week>
             <div
               role="button"
               aria-disabled="false"
@@ -458,7 +487,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" last-day>
+          <td class="calendar__day-cell" role="gridcell" last-day>
             <div
               role="button"
               aria-disabled="false"
@@ -470,7 +499,7 @@ export default html`
               <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" first-day>
+          <td class="calendar__day-cell" role="gridcell" first-day>
             <div
               role="button"
               aria-disabled="false"
@@ -482,7 +511,7 @@ export default html`
               <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -494,7 +523,7 @@ export default html`
               <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -506,7 +535,7 @@ export default html`
               <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell">
+          <td class="calendar__day-cell" role="gridcell">
             <div
               role="button"
               aria-disabled="false"
@@ -518,7 +547,7 @@ export default html`
               <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" end-of-first-week>
+          <td class="calendar__day-cell" role="gridcell" end-of-first-week>
             <div
               role="button"
               aria-disabled="false"

--- a/packages/ui/components/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
+++ b/packages/ui/components/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
@@ -2,56 +2,21 @@ const html = /** @param {TemplateStringsArray} strings */ strings => strings[0];
 
 export default html`
   <div id="js-content-wrapper">
-    <table
-      aria-labelledby="month year"
-      aria-readonly="true"
-      class="calendar__grid"
-      data-wrap-cols=""
-      role="grid"
-    >
+    <table aria-readonly="true" class="calendar__grid" data-wrap-cols="" role="grid">
       <thead>
-        <tr role="row">
-          <th class="calendar__weekday-header" aria-label="Sunday" scope="col" role="columnheader">
-            Sun
-          </th>
-          <th class="calendar__weekday-header" aria-label="Monday" scope="col" role="columnheader">
-            Mon
-          </th>
-          <th class="calendar__weekday-header" aria-label="Tuesday" scope="col" role="columnheader">
-            Tue
-          </th>
-          <th
-            class="calendar__weekday-header"
-            aria-label="Wednesday"
-            scope="col"
-            role="columnheader"
-          >
-            Wed
-          </th>
-          <th
-            class="calendar__weekday-header"
-            aria-label="Thursday"
-            scope="col"
-            role="columnheader"
-          >
-            Thu
-          </th>
-          <th class="calendar__weekday-header" aria-label="Friday" scope="col" role="columnheader">
-            Fri
-          </th>
-          <th
-            class="calendar__weekday-header"
-            aria-label="Saturday"
-            scope="col"
-            role="columnheader"
-          >
-            Sat
-          </th>
+        <tr>
+          <th class="calendar__weekday-header" aria-label="Sunday" scope="col">Sun</th>
+          <th class="calendar__weekday-header" aria-label="Monday" scope="col">Mon</th>
+          <th class="calendar__weekday-header" aria-label="Tuesday" scope="col">Tue</th>
+          <th class="calendar__weekday-header" aria-label="Wednesday" scope="col">Wed</th>
+          <th class="calendar__weekday-header" aria-label="Thursday" scope="col">Thu</th>
+          <th class="calendar__weekday-header" aria-label="Friday" scope="col">Fri</th>
+          <th class="calendar__weekday-header" aria-label="Saturday" scope="col">Sat</th>
         </tr>
       </thead>
       <tbody>
-        <tr role="row">
-          <td class="calendar__day-cell" role="gridcell" start-of-last-week>
+        <tr>
+          <td class="calendar__day-cell" start-of-last-week>
             <div
               role="button"
               aria-disabled="false"
@@ -60,10 +25,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">25</span>
-              <span class="u-sr-only"> November 2018 Sunday</span>
+              <span class="u-sr-only"> November 2018.</span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -72,10 +37,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">26</span>
-              <span class="u-sr-only"> November 2018 Monday </span>
+              <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -84,10 +49,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">27</span>
-              <span class="u-sr-only"> November 2018 Tuesday </span>
+              <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -96,10 +61,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">28</span>
-              <span class="u-sr-only"> November 2018 Wednesday </span>
+              <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -108,10 +73,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">29</span>
-              <span class="u-sr-only"> November 2018 Thursday </span>
+              <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell" last-day>
+          <td class="calendar__day-cell" last-day>
             <div
               role="button"
               aria-disabled="false"
@@ -120,10 +85,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">30</span>
-              <span class="u-sr-only"> November 2018 Friday </span>
+              <span class="u-sr-only"> November 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell" end-of-first-week first-day>
+          <td class="calendar__day-cell" end-of-first-week first-day>
             <div
               role="button"
               aria-disabled="false"
@@ -132,12 +97,12 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">1</span>
-              <span class="u-sr-only"> December 2018 Saturday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
         </tr>
-        <tr role="row">
-          <td class="calendar__day-cell" role="gridcell" start-of-first-full-week>
+        <tr>
+          <td class="calendar__day-cell" start-of-first-full-week>
             <div
               role="button"
               aria-disabled="false"
@@ -146,10 +111,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">2</span>
-              <span class="u-sr-only"> December 2018 Sunday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -158,10 +123,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">3</span>
-              <span class="u-sr-only"> December 2018 Monday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -170,10 +135,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">4</span>
-              <span class="u-sr-only"> December 2018 Tuesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -182,10 +147,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">5</span>
-              <span class="u-sr-only"> December 2018 Wednesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -194,10 +159,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">6</span>
-              <span class="u-sr-only"> December 2018 Thursday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -206,10 +171,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">7</span>
-              <span class="u-sr-only"> December 2018 Friday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -218,12 +183,12 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">8</span>
-              <span class="u-sr-only"> December 2018 Saturday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
         </tr>
-        <tr role="row">
-          <td class="calendar__day-cell" role="gridcell">
+        <tr>
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -232,10 +197,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">9</span>
-              <span class="u-sr-only"> December 2018 Sunday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -244,10 +209,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">10</span>
-              <span class="u-sr-only"> December 2018 Monday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -256,10 +221,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">11</span>
-              <span class="u-sr-only"> December 2018 Tuesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -268,10 +233,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">12</span>
-              <span class="u-sr-only"> December 2018 Wednesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -280,10 +245,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">13</span>
-              <span class="u-sr-only"> December 2018 Thursday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -292,10 +257,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">14</span>
-              <span class="u-sr-only"> December 2018 Friday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -304,12 +269,12 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">15</span>
-              <span class="u-sr-only"> December 2018 Saturday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
         </tr>
-        <tr role="row">
-          <td class="calendar__day-cell" role="gridcell">
+        <tr>
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -318,10 +283,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">16</span>
-              <span class="u-sr-only"> December 2018 Sunday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -330,10 +295,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">17</span>
-              <span class="u-sr-only"> December 2018 Monday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -342,10 +307,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">18</span>
-              <span class="u-sr-only"> December 2018 Tuesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -354,10 +319,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">19</span>
-              <span class="u-sr-only"> December 2018 Wednesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -366,10 +331,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">20</span>
-              <span class="u-sr-only"> December 2018 Thursday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -378,10 +343,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">21</span>
-              <span class="u-sr-only"> December 2018 Friday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -390,12 +355,12 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">22</span>
-              <span class="u-sr-only"> December 2018 Saturday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
         </tr>
-        <tr role="row">
-          <td class="calendar__day-cell" role="gridcell">
+        <tr>
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -404,10 +369,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">23</span>
-              <span class="u-sr-only"> December 2018 Sunday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -416,10 +381,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">24</span>
-              <span class="u-sr-only"> December 2018 Monday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -428,10 +393,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">25</span>
-              <span class="u-sr-only"> December 2018 Tuesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -440,10 +405,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">26</span>
-              <span class="u-sr-only"> December 2018 Wednesday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -452,10 +417,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">27</span>
-              <span class="u-sr-only"> December 2018 Thursday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -464,10 +429,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">28</span>
-              <span class="u-sr-only"> December 2018 Friday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell" end-of-last-full-week>
+          <td class="calendar__day-cell" end-of-last-full-week>
             <div
               role="button"
               aria-disabled="false"
@@ -476,12 +441,12 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">29</span>
-              <span class="u-sr-only"> December 2018 Saturday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
         </tr>
-        <tr role="row">
-          <td class="calendar__day-cell" role="gridcell" start-of-last-week>
+        <tr>
+          <td class="calendar__day-cell" start-of-last-week>
             <div
               role="button"
               aria-disabled="false"
@@ -490,10 +455,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">30</span>
-              <span class="u-sr-only"> December 2018 Sunday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" last-day role="gridcell">
+          <td class="calendar__day-cell" last-day>
             <div
               role="button"
               aria-disabled="false"
@@ -502,10 +467,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">31</span>
-              <span class="u-sr-only"> December 2018 Monday </span>
+              <span class="u-sr-only"> December 2018. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell" first-day>
+          <td class="calendar__day-cell" first-day>
             <div
               role="button"
               aria-disabled="false"
@@ -514,10 +479,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">1</span>
-              <span class="u-sr-only"> January 2019 Tuesday </span>
+              <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -526,10 +491,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">2</span>
-              <span class="u-sr-only"> January 2019 Wednesday </span>
+              <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -538,10 +503,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">3</span>
-              <span class="u-sr-only"> January 2019 Thursday </span>
+              <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell">
+          <td class="calendar__day-cell">
             <div
               role="button"
               aria-disabled="false"
@@ -550,10 +515,10 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">4</span>
-              <span class="u-sr-only"> January 2019 Friday </span>
+              <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
-          <td class="calendar__day-cell" role="gridcell" end-of-first-week>
+          <td class="calendar__day-cell" end-of-first-week>
             <div
               role="button"
               aria-disabled="false"
@@ -562,7 +527,7 @@ export default html`
               tabindex="-1"
             >
               <span class="calendar__day-button__text">5</span>
-              <span class="u-sr-only"> January 2019 Saturday </span>
+              <span class="u-sr-only"> January 2019. </span>
             </div>
           </td>
         </tr>


### PR DESCRIPTION
## What I did

1.  Remove `aria-labelledby="month year"` from table. Each day already announces the month and year in the dayTemplate. So it got announced double.
2. Remove `weekdayName` from dayTemplate - The weekday is also the table header, so if you move from one text element to another while using the screen-reader, you already hear the weekday announced. 
3. Added a "." to dayTemplate message, to make the message more clear.
