### PR TITLE
Fix indeterminate checkbox edge cases

### DIFF
--- a/.changeset/good-squids-love.md
+++ b/.changeset/good-squids-love.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[lion-checkbox-indeterminate] Fix bugs regarding disabled and pre-checked children

--- a/packages/ui/components/checkbox-group/src/LionCheckboxIndeterminate.js
+++ b/packages/ui/components/checkbox-group/src/LionCheckboxIndeterminate.js
@@ -89,9 +89,11 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
         break;
       default: {
         this.indeterminate = true;
-        const disabledElements = subCheckboxes.filter(checkbox => checkbox.disabled);
+        const disabledUncheckedElements = subCheckboxes.filter(
+          checkbox => checkbox.disabled && checkbox.checked === false,
+        );
         this.checked =
-          subCheckboxes.length - checkedElements.length - disabledElements.length === 0;
+          subCheckboxes.length - checkedElements.length - disabledUncheckedElements.length === 0;
       }
     }
     this.updateComplete.then(() => {

--- a/packages/ui/components/checkbox-group/src/LionCheckboxIndeterminate.js
+++ b/packages/ui/components/checkbox-group/src/LionCheckboxIndeterminate.js
@@ -96,8 +96,6 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
     this.__settingOwnChecked = true;
     const checkedElements = subCheckboxes.filter(checkbox => checkbox.checked);
 
-    const disabledElements = subCheckboxes.filter(checkbox => checkbox.disabled);
-
     switch (subCheckboxes.length - checkedElements.length) {
       // all checked
       case 0:
@@ -109,7 +107,7 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
         this.indeterminate = false;
         this.checked = false;
         break;
-      default:
+      default: {
         this.indeterminate = true;
 
         // When 1. sub checkboxes have disabled elements and 2. one or more elements are checked
@@ -119,8 +117,11 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
         // when updated callback is called because it hasn't updated (true -> true).
         // Hence we have to force syncing the indeterminate state between the properties and the DOM's attribute.
         this.forceSyncIndeterminate += 1;
+
+        const disabledElements = subCheckboxes.filter(checkbox => checkbox.disabled);
         this.checked =
           subCheckboxes.length - checkedElements.length - disabledElements.length === 0;
+      }
     }
     this.updateComplete.then(() => {
       this.__settingOwnChecked = false;
@@ -176,7 +177,6 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
         subCheckboxes.length > 0 && subCheckboxes.length === checkedElements.length;
       const allDisabled =
         subCheckboxes.length > 0 && subCheckboxes.length === disabledElements.length;
-      // const hasDisabledElements = disabledElements.length > 0;
 
       if (allDisabled) {
         this.checked = allChecked;

--- a/packages/ui/components/checkbox-group/src/LionCheckboxIndeterminate.js
+++ b/packages/ui/components/checkbox-group/src/LionCheckboxIndeterminate.js
@@ -225,7 +225,7 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
   }
 
   /**
-   * @param {CustomEvent} ev
+   * @param {Event} ev
    * @protected
    */
   _onRequestToAddFormElement(ev) {
@@ -236,7 +236,7 @@ export class LionCheckboxIndeterminate extends LionCheckbox {
     // hence its formElements doesn't include the element that was just registered.
     // We save the element in a temporary variable to help _subCheckboxes to include the element
     // and _setOwnCheckedState works as expected.
-    this.__temporaryRegisteredElement = ev.detail.element;
+    this.__temporaryRegisteredElement = /** @type {CustomEvent} */ (ev).detail.element;
     this._setOwnCheckedState();
   }
 

--- a/packages/ui/components/checkbox-group/test-suites/CheckboxIndeterminate.suite.js
+++ b/packages/ui/components/checkbox-group/test-suites/CheckboxIndeterminate.suite.js
@@ -205,7 +205,65 @@ export function runCheckboxIndeterminateSuite(customConfig) {
 
       // Assert
       expect(elIndeterminate?.hasAttribute('indeterminate')).to.be.true;
-      expect(elIndeterminate?.checked).to.be.false;
+      expect(elIndeterminate?.checked).to.be.true;
+    });
+
+    it('should be checked when all children are prechecked', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ await fixture(html`
+      <${groupTag} name="scientists[]">
+        <${tag} label="Favorite scientists">
+          <${childTag} checked label="Archimedes"></${childTag}>
+          <${childTag} checked label="Francis Bacon"></${childTag}>
+          <${childTag} checked label="Marie Curie"></${childTag}>
+        </${tag}>
+      </${groupTag}>
+    `);
+
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+
+      // Assert
+      expect(elIndeterminate?.hasAttribute('checked')).to.be.true;
+    });
+
+    it('should be checked when it has one prechecked child', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ await fixture(html`
+      <${groupTag} name="scientists[]">
+        <${tag} label="Favorite scientists">
+          <${childTag} checked label="Archimedes"></${childTag}>
+        </${tag}>
+      </${groupTag}>
+    `);
+
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+
+      // Assert
+      expect(elIndeterminate?.hasAttribute('checked')).to.be.true;
+    });
+
+    it('should be indeterminated when some of the children are prechecked', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ await fixture(html`
+      <${groupTag} name="scientists[]">
+        <${tag} label="Favorite scientists">
+          <${childTag} checked label="Archimedes"></${childTag}>
+          <${childTag} checked label="Francis Bacon"></${childTag}>
+          <${childTag} label="Marie Curie"></${childTag}>
+        </${tag}>
+      </${groupTag}>
+    `);
+
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+
+      // Assert
+      expect(elIndeterminate.hasAttribute('indeterminate')).to.be.true;
     });
 
     it('should sync all children when parent is checked (from indeterminate to checked)', async () => {
@@ -382,6 +440,65 @@ export function runCheckboxIndeterminateSuite(customConfig) {
       expect(_subCheckboxes[0].hasAttribute('checked')).to.be.false;
       expect(_subCheckboxes[1].hasAttribute('checked')).to.be.false;
       expect(_subCheckboxes[2].hasAttribute('checked')).to.be.false;
+    });
+
+    it('should sync all prechecked children when parent is indeterminate and some of the children are disabled (from checked to unchecked)', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ (
+        await fixture(html`
+        <${groupTag} name="scientists[]">
+          <${tag} label="Favorite scientists">
+            <${childTag} checked label="Archimedes"></${childTag}>
+            <${childTag} disabled label="Francis Bacon"></${childTag}>
+            <${childTag} checked label="Marie Curie"></${childTag}>
+          </${tag}>
+        </${groupTag}>
+      `)
+      );
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+      const { _subCheckboxes, _inputNode } = getCheckboxIndeterminateMembers(elIndeterminate);
+
+      // Act
+      _inputNode.click();
+      await elIndeterminate.updateComplete;
+
+      // Assert
+      expect(elIndeterminate?.hasAttribute('indeterminate')).to.be.false;
+      expect(_inputNode?.hasAttribute('indeterminate')).to.be.false;
+      expect(_subCheckboxes[0].hasAttribute('checked')).to.be.false;
+      expect(_subCheckboxes[1].hasAttribute('checked')).to.be.false;
+      expect(_subCheckboxes[2].hasAttribute('checked')).to.be.false;
+    });
+
+    it('should stay as indeterminated after it is clicked, when it is interminated already and some children are disabled', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ (
+        await fixture(html`
+        <${groupTag} name="scientists[]">
+          <${tag} label="Favorite scientists">
+            <${childTag} checked label="Archimedes"></${childTag}>
+            <${childTag} disabled label="Francis Bacon"></${childTag}>
+            <${childTag} label="Marie Curie"></${childTag}>
+          </${tag}>
+        </${groupTag}>
+      `)
+      );
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+      const { _subCheckboxes, _inputNode } = getCheckboxIndeterminateMembers(elIndeterminate);
+
+      // Act
+      _inputNode.click();
+      await elIndeterminate.updateComplete;
+
+      // Assert
+      expect(elIndeterminate.hasAttribute('indeterminate')).to.be.true;
+      expect(_inputNode.indeterminate).to.be.true;
+      expect(_subCheckboxes[0].hasAttribute('checked')).to.be.true;
+      expect(_subCheckboxes[2].hasAttribute('checked')).to.be.true;
     });
 
     it('should work as expected with siblings checkbox-indeterminate', async () => {

--- a/packages/ui/components/checkbox-group/test-suites/CheckboxIndeterminate.suite.js
+++ b/packages/ui/components/checkbox-group/test-suites/CheckboxIndeterminate.suite.js
@@ -586,6 +586,58 @@ export function runCheckboxIndeterminateSuite(customConfig) {
       expect(elSecondSubCheckboxes._subCheckboxes[1].hasAttribute('checked')).to.be.false;
     });
 
+    it('should work as expected when new checkbox was added', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ await fixture(html`
+      <${groupTag} name="scientists[]">
+        <${tag} label="Favorite scientists">
+          <${childTag} checked label="Archimedes"></${childTag}>
+          <${childTag} checked label="Francis Bacon" checked></${childTag}>
+          <${childTag} checked label="Marie Curie"></${childTag}>
+        </${tag}>
+      </${groupTag}>
+    `);
+
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+      expect(elIndeterminate.hasAttribute('indeterminate')).to.be.false;
+
+      // Act
+      const newChild = document.createElement(/** @type {string} */ (cfg.childTagString));
+      elIndeterminate.appendChild(newChild);
+      await elIndeterminate.updateComplete;
+
+      // Assert
+      expect(elIndeterminate.hasAttribute('indeterminate')).to.be.true;
+    });
+
+    it('should work as expected when an existing checkbox was removed', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ await fixture(html`
+      <${groupTag} name="scientists[]">
+        <${tag} label="Favorite scientists">
+          <${childTag} checked label="Archimedes"></${childTag}>
+          <${childTag} checked label="Francis Bacon" checked></${childTag}>
+          <${childTag} label="Marie Curie"></${childTag}>
+        </${tag}>
+      </${groupTag}>
+    `);
+
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+      expect(elIndeterminate.hasAttribute('indeterminate')).to.be.true;
+      expect(elIndeterminate.checked).to.be.false;
+
+      // Act
+      elIndeterminate.removeChild(/** @type {ChildNode} */ (elIndeterminate.lastChild));
+      await elIndeterminate.updateComplete;
+
+      // Assert
+      expect(elIndeterminate?.hasAttribute('indeterminate')).to.be.true;
+    });
+
     it('should work as expected with nested indeterminate checkboxes', async () => {
       // Arrange
       const el = /**  @type {LionCheckboxGroup} */ (

--- a/packages/ui/components/checkbox-group/test-suites/CheckboxIndeterminate.suite.js
+++ b/packages/ui/components/checkbox-group/test-suites/CheckboxIndeterminate.suite.js
@@ -246,6 +246,25 @@ export function runCheckboxIndeterminateSuite(customConfig) {
       expect(elIndeterminate?.hasAttribute('checked')).to.be.true;
     });
 
+    it('should be unchecked when it has an disabled checked child and an unchecked child', async () => {
+      // Arrange
+      const el = /**  @type {LionCheckboxGroup} */ await fixture(html`
+      <${groupTag} name="scientists[]">
+        <${tag} label="Favorite scientists">
+          <${childTag} disabled checked label="Archimedes"></${childTag}>
+          <${childTag} label="Francis Bacon"></${childTag}>
+        </${tag}>
+      </${groupTag}>
+    `);
+
+      const elIndeterminate = /**  @type {LionCheckboxIndeterminate} */ (
+        el.querySelector(`${cfg.tagString}`)
+      );
+
+      // Assert
+      expect(elIndeterminate?.hasAttribute('checked')).to.be.false;
+    });
+
     it('should be indeterminated when some of the children are prechecked', async () => {
       // Arrange
       const el = /**  @type {LionCheckboxGroup} */ await fixture(html`

--- a/packages/ui/components/form-core/src/FocusMixin.js
+++ b/packages/ui/components/form-core/src/FocusMixin.js
@@ -198,19 +198,19 @@ const FocusMixinImplementation = superclass =>
      * @private
      */
     __teardownEventsForFocusMixin() {
-      this._focusableNode.removeEventListener(
+      this._focusableNode?.removeEventListener(
         'focus',
         /** @type {EventListenerOrEventListenerObject} */ (this.__redispatchFocus),
       );
-      this._focusableNode.removeEventListener(
+      this._focusableNode?.removeEventListener(
         'blur',
         /** @type {EventListenerOrEventListenerObject} */ (this.__redispatchBlur),
       );
-      this._focusableNode.removeEventListener(
+      this._focusableNode?.removeEventListener(
         'focusin',
         /** @type {EventListenerOrEventListenerObject} */ (this.__redispatchFocusin),
       );
-      this._focusableNode.removeEventListener(
+      this._focusableNode?.removeEventListener(
         'focusout',
         /** @type {EventListenerOrEventListenerObject} */ (this.__redispatchFocusout),
       );

--- a/packages/ui/components/form-core/src/LionField.js
+++ b/packages/ui/components/form-core/src/LionField.js
@@ -44,7 +44,7 @@ export class LionField extends FormControlMixin(
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    this._inputNode.removeEventListener('change', this._onChange);
+    this._inputNode?.removeEventListener('change', this._onChange);
   }
 
   resetInteractionState() {


### PR DESCRIPTION
## What I did

There were a few problems in the LionCheckboxIndeterminate:
1. When the element was connected, the last child was ignored because the `_setOwnCheckedState()` was called by `form-element-register` event **before** the same event was handled by the checkbox group which adds the element emitting the event to the `formElements`
2. When it had disabled child and all the other children were checked, clicking the indeterminate checkbox didn't respond, because the checked state was `false` although, in practice, it was fully checked
3. When the custom element's `indeterminate` property was `true` and the same property of the input node was also `true`, and clicking it should keep it indeterminated (like when one of the children is disabled and the others are mixed with checked and unchecked), the `indeterminate` property of the custom element doesn't change but the same property of the input node changes to `false` (seems like browser's default behavior) because no syncing could happen without the custome element's `indeteminate` property changing.

This PR fixes those issues.