### PR TITLE
fix: remove unused typed method

### DIFF
--- a/packages/ui/components/localize/types/LocalizeMixinTypes.ts
+++ b/packages/ui/components/localize/types/LocalizeMixinTypes.ts
@@ -67,11 +67,6 @@ export declare class LocalizeMixinHost {
 
   public localizeNamespacesLoaded: Promise<Object> | undefined;
 
-  /**
-   * Hook into LitElement to only render once all translations are loaded
-   */
-  public performUpdate(): Promise<void>;
-
   public onLocaleReady(): void;
   public onLocaleChanged(newLocale: string, oldLocale: string): void;
   public onLocaleUpdated(): void;


### PR DESCRIPTION
## What I did

1. remove the performUpdate Method from the LocalizeMixinHost type as it as the wrong access modifier and is not used anymore.

See #2479 