### PR TITLE
fix(parseDate): Prevents 3-digit year from being accepted as valid (#2483)

### DIFF
--- a/packages/ui/components/localize/src/date/parseDate.js
+++ b/packages/ui/components/localize/src/date/parseDate.js
@@ -64,6 +64,12 @@ export function parseDate(dateString, options) {
 
   const [year, month, day] = parsedString.split('/').map(Number);
   let correctedYear = year;
+
+  // Invalidate 3-digit years
+  if (year < 1000) {
+    return undefined;
+  }
+
   if (year < 50) {
     correctedYear = 2000 + year;
   }


### PR DESCRIPTION
## What I did

1. Fixed an issue where 3-digit years (e.g., `27/12/202`) were incorrectly parsed as valid dates.
2. Ensured that years below `1000` are treated as invalid.
3. Added a check to return `undefined` for such cases.

@tlouisse Please review and verify.
