### PR TITLE
fix(validate-mixin): determine required or result validators based on characteristics

### DIFF
--- a/.changeset/tall-doors-smoke.md
+++ b/.changeset/tall-doors-smoke.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[validate-mixin] determine if a required validator or result validator has been registered based on characteristics

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -8,10 +8,10 @@ import { AsyncQueue } from '../utils/AsyncQueue.js';
 import { pascalCase } from '../utils/pascalCase.js';
 import { SyncUpdatableMixin } from '../utils/SyncUpdatableMixin.js';
 import { LionValidationFeedback } from './LionValidationFeedback.js';
-import { ResultValidator as MetaValidator } from './ResultValidator.js';
 import { Unparseable } from './Unparseable.js';
-import { Required } from './validators/Required.js';
 import { FormControlMixin } from '../FormControlMixin.js';
+// eslint-disable-next-line no-unused-vars
+import { ResultValidator as MetaValidator } from './ResultValidator.js';
 // eslint-disable-next-line no-unused-vars
 import { Validator } from './Validator.js';
 // TODO: [v1] make all @readOnly => @readonly and actually make sure those values cannot be set
@@ -134,7 +134,7 @@ export const ValidateMixinImplementation = superclass =>
 
     /**
      * Combination of validators provided by Application Developer and the default validators
-     * @type {Validator[]}
+     * @type {(Validator | MetaValidator)[]}
      * @protected
      */
     get _allValidators() {
@@ -480,9 +480,9 @@ export const ValidateMixinImplementation = superclass =>
       const asyncValidators = /** @type {Validator[]} */ [];
 
       for (const v of this._allValidators) {
-        if (v instanceof MetaValidator) {
-          metaValidators.push(v);
-        } else if (v instanceof Required) {
+        if (/** @type {MetaValidator} */ (v)?.executeOnResults) {
+          metaValidators.push(/** @type {MetaValidator} */ (v));
+        } else if (/** @type {typeof Validator} */ (v.constructor)?.validatorName === 'Required') {
           // Required validator was already handled
         } else if (/** @type {typeof Validator} */ (v.constructor).async) {
           asyncValidators.push(v);


### PR DESCRIPTION
## Problem

In `ValidateMixin.js` a combination of approaches was used to determine if a `Required` validator is a `Required` validator, so that the validation routines can be executed accordingly. This involved:
- an `instanceof` approach (initial, changed later by #2397)
- a characteristics approach: by looking at `.validatorName` (introduced by #2397)

However, an `instanceof` check still remained in the `__executeValidators` function. This PR aims to unify the approach in `ValidateMixin.js`.

## What I did

1. When classifying the passed validators (in `MetaValidators`, `AsyncValidators`, `SyncValidators`), both the `Required` check and the `MetaValidator` checks are now done via characteristics of each:
   - the `Required` validator should have `.validatorName === 'Required'`
   - the `MetaValidator` should present a `.executeOnResults` function

2. Improved some JSDOC type annotations

3. Added 2 new test cases in `ValidateMixin.suite.js`:
   - registering a `Required` validator which is bundled (as an example) should keep working, while with an `instanceof` check, the test would fail in this case
   - same for a `ResultValidator` (in this case `DefaultSuccess`)
