### PR TITLE
Revert version package PR

### DIFF
--- a/.changeset/witty-oranges-lick.md
+++ b/.changeset/witty-oranges-lick.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[combobox] do not submit form if overlay of combobox is opened and ENTER is hit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching/v2
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -7,7 +7,7 @@ jobs:
     name: Verify changes
     runs-on: ubuntu-latest
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching/v2
       - uses: actions/checkout@v4
 
       - name: Sanity check
@@ -32,7 +32,7 @@ jobs:
     name: Browser tests
     runs-on: ubuntu-latest
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching/v2
       - uses: actions/checkout@v4
 
       - name: Setup Node 18.x
@@ -58,7 +58,7 @@ jobs:
         node-version: [16.x, 18.x]
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: google/wireit@setup-github-actions-caching/v2
       - uses: actions/checkout@v4
 
       - name: Setup Node ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "semver": "^7.6.3",
         "sinon": "^19.0.2",
         "typescript": "^4.9.5",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.12"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -27167,11 +27167,10 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.9.tgz",
-      "integrity": "sha512-hFc96BgyslfO1WGSzQqOVYd5N3TB+4u9w70L9GHR/T7SYjvFmeznkYMsRIjMLhPcVabCEYPW1vV66wmIVDs+dQ==",
+      "version": "0.14.12",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.12.tgz",
+      "integrity": "sha512-gNSd+nZmMo6cuICezYXRIayu6TSOeCSCDzjSF0q6g8FKDsRbdqrONrSZYzdk/uBISmRcv4vZtsno6GyGvdXwGA==",
       "dev": true,
-      "license": "Apache-2.0",
       "workspaces": [
         "vscode-extension",
         "website"
@@ -28128,7 +28127,7 @@
       "license": "MIT"
     },
     "packages-node/providence-analytics": {
-      "version": "0.18.4",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-node-resolve": "^16.0.1",
@@ -28912,7 +28911,7 @@
       }
     },
     "packages-node/remark-extend": {
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "not": "^0.1.0",
@@ -28935,7 +28934,7 @@
       }
     },
     "packages-node/rocket-preset-extend-lion-docs": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.10.1",
@@ -28944,7 +28943,7 @@
         "es-module-lexer": "^0.3.6",
         "glob": "^7.1.6",
         "plugins-manager": "^0.3.0",
-        "remark-extend": "^0.5.1",
+        "remark-extend": "^0.5.3",
         "unist-util-visit": "^2.0.2"
       }
     },
@@ -28965,7 +28964,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.11.1",
+      "version": "0.11.3",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.2.4",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "semver": "^7.6.3",
     "sinon": "^19.0.2",
     "typescript": "^4.9.5",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.12"
   },
   "bundlesize": [
     {

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @lion/ui
 
-## 0.11.3
-
-### Patch Changes
-
-- 23cd984: [combobox] do not submit form if overlay of combobox is opened and ENTER is hit
-
 ## 0.11.2
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lion/ui",
-  "version": "0.11.3",
+  "version": "0.11.2",
   "description": "A package of extendable web components",
   "license": "MIT",
   "author": "ing-bank",


### PR DESCRIPTION
The pipeline to release 0.11.3 was failed due to outdated dependency in pipeline.

In case we need create the version PR to run the release pipeline again, I created this PR to revert the previous version PR (#2508).
