### PR TITLE
Fix: Allow editing of negative numbers in LionInputAmount

### DIFF
--- a/.changeset/selfish-falcons-smoke.md
+++ b/.changeset/selfish-falcons-smoke.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Fix: Replace Unicode minus sign with standard dash in LionInputAmount to ensure correct parsing of negative values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28965,7 +28965,7 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.11.2",
+      "version": "0.11.4",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.2.4",

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-classes_-_importing-target-project_0.0.2-target-mock__1828311700.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-classes_-_importing-target-project_0.0.2-target-mock__1828311700.json
@@ -1,0 +1,220 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "find-classes",
+      "requiredAst": "oxc",
+      "identifier": "importing-target-project_0.0.2-target-mock__1828311700",
+      "targetProject": {
+        "mainEntry": "./target-src/match-imports/root-level-imports.js",
+        "name": "importing-target-project",
+        "version": "0.0.2-target-mock",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "gatherFilesConfig": {},
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "file": "./target-src/find-customelements/multiple.js",
+      "result": [
+        {
+          "name": null,
+          "isMixin": true,
+          "superClasses": [
+            {
+              "name": "HTMLElement",
+              "isMixin": false,
+              "rootFile": {
+                "file": "[current]",
+                "specifier": "HTMLElement"
+              }
+            }
+          ],
+          "members": {
+            "props": [],
+            "methods": []
+          }
+        },
+        {
+          "name": "ExtendedOnTheFly",
+          "isMixin": false,
+          "superClasses": [
+            {
+              "isMixin": true,
+              "rootFile": {
+                "file": "[current]"
+              }
+            },
+            {
+              "isMixin": false,
+              "rootFile": {
+                "file": "[current]"
+              }
+            }
+          ],
+          "members": {
+            "props": [],
+            "methods": []
+          }
+        }
+      ]
+    },
+    {
+      "file": "./target-src/match-subclasses/ExtendedComp.js",
+      "result": [
+        {
+          "name": "ExtendedComp",
+          "isMixin": false,
+          "superClasses": [
+            {
+              "name": "MyCompMixin",
+              "isMixin": true,
+              "rootFile": {
+                "file": "exporting-ref-project",
+                "specifier": "[default]"
+              }
+            },
+            {
+              "name": "RefClass",
+              "isMixin": false,
+              "rootFile": {
+                "file": "exporting-ref-project",
+                "specifier": "RefClass"
+              }
+            }
+          ],
+          "members": {
+            "props": [
+              {
+                "name": "getterSetter",
+                "accessType": "public",
+                "kind": [
+                  "get",
+                  "set"
+                ]
+              },
+              {
+                "name": "staticGetterSetter",
+                "accessType": "public",
+                "static": true,
+                "kind": [
+                  "get",
+                  "set"
+                ]
+              },
+              {
+                "name": "attributes",
+                "accessType": "public",
+                "static": true,
+                "kind": [
+                  "get"
+                ]
+              },
+              {
+                "name": "styles",
+                "accessType": "public",
+                "static": true,
+                "kind": [
+                  "get"
+                ]
+              },
+              {
+                "name": "updateComplete",
+                "accessType": "public",
+                "kind": [
+                  "get"
+                ]
+              },
+              {
+                "name": "localizeNamespaces",
+                "accessType": "public",
+                "static": true,
+                "kind": [
+                  "get"
+                ]
+              },
+              {
+                "name": "slots",
+                "accessType": "public",
+                "kind": [
+                  "get"
+                ]
+              }
+            ],
+            "methods": [
+              {
+                "name": "method",
+                "accessType": "public"
+              },
+              {
+                "name": "_protectedMethod",
+                "accessType": "protected"
+              },
+              {
+                "name": "__privateMethod",
+                "accessType": "private"
+              },
+              {
+                "name": "$protectedMethod",
+                "accessType": "protected"
+              },
+              {
+                "name": "$$privateMethod",
+                "accessType": "private"
+              },
+              {
+                "name": "constructor",
+                "accessType": "public"
+              },
+              {
+                "name": "connectedCallback",
+                "accessType": "public"
+              },
+              {
+                "name": "disconnectedCallback",
+                "accessType": "public"
+              },
+              {
+                "name": "requestUpdate",
+                "accessType": "public"
+              },
+              {
+                "name": "createRenderRoot",
+                "accessType": "public"
+              },
+              {
+                "name": "render",
+                "accessType": "public"
+              },
+              {
+                "name": "updated",
+                "accessType": "public"
+              },
+              {
+                "name": "firstUpdated",
+                "accessType": "public"
+              },
+              {
+                "name": "update",
+                "accessType": "public"
+              },
+              {
+                "name": "shouldUpdate",
+                "accessType": "public"
+              },
+              {
+                "name": "onLocaleUpdated",
+                "accessType": "public"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-customelements_-_importing-target-project_0.0.2-target-mock__-1799866936.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-customelements_-_importing-target-project_0.0.2-target-mock__-1799866936.json
@@ -1,0 +1,52 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "find-customelements",
+      "requiredAst": "oxc",
+      "identifier": "importing-target-project_0.0.2-target-mock__-1799866936",
+      "targetProject": {
+        "mainEntry": "./target-src/match-imports/root-level-imports.js",
+        "name": "importing-target-project",
+        "version": "0.0.2-target-mock",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "gatherFilesConfig": {},
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "file": "./target-src/find-customelements/multiple.js",
+      "result": [
+        {
+          "tagName": "ref-class",
+          "constructorIdentifier": "RefClass",
+          "rootFile": {
+            "file": "exporting-ref-project",
+            "specifier": "RefClass"
+          }
+        },
+        {
+          "tagName": "extended-comp",
+          "constructorIdentifier": "ExtendedComp",
+          "rootFile": {
+            "file": "./target-src/match-subclasses/ExtendedComp.js",
+            "specifier": "ExtendedComp"
+          }
+        },
+        {
+          "tagName": "on-the-fly",
+          "constructorIdentifier": "[inline]",
+          "rootFile": {
+            "file": "[current]",
+            "specifier": "[inline]"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-exports_-_exporting-ref-project_1.0.0__-1943175638.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-exports_-_exporting-ref-project_1.0.0__-1943175638.json
@@ -1,0 +1,194 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "find-exports",
+      "requiredAst": "oxc",
+      "identifier": "exporting-ref-project_1.0.0__-1943175638",
+      "targetProject": {
+        "mainEntry": "./index.js",
+        "name": "exporting-ref-project",
+        "version": "1.0.0",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "skipFileImports": false,
+        "gatherFilesConfig": {},
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "file": "./index.js",
+      "result": [
+        {
+          "exportSpecifiers": [
+            "[default]"
+          ],
+          "source": "./ref-src/core.js",
+          "normalizedSource": "./ref-src/core.js",
+          "rootFileMap": [
+            {
+              "currentFileSpecifier": "[default]",
+              "rootFile": {
+                "file": "./ref-src/core.js",
+                "specifier": "[default]"
+              }
+            }
+          ]
+        },
+        {
+          "exportSpecifiers": [
+            "RefClass",
+            "RefRenamedClass"
+          ],
+          "localMap": [
+            {
+              "local": "RefClass",
+              "exported": "RefRenamedClass"
+            }
+          ],
+          "source": "./ref-src/core.js",
+          "normalizedSource": "./ref-src/core.js",
+          "rootFileMap": [
+            {
+              "currentFileSpecifier": "RefClass",
+              "rootFile": {
+                "file": "./ref-src/core.js",
+                "specifier": "RefClass"
+              }
+            },
+            {
+              "currentFileSpecifier": "RefRenamedClass",
+              "rootFile": {
+                "file": "./ref-src/core.js",
+                "specifier": "RefClass"
+              }
+            }
+          ]
+        },
+        {
+          "exportSpecifiers": [
+            "[file]"
+          ],
+          "rootFileMap": [
+            null
+          ]
+        }
+      ]
+    },
+    {
+      "file": "./not-imported.js",
+      "result": [
+        {
+          "exportSpecifiers": [
+            "notImported"
+          ],
+          "localMap": [],
+          "rootFileMap": [
+            {
+              "currentFileSpecifier": "notImported",
+              "rootFile": {
+                "file": "[current]",
+                "specifier": "notImported"
+              }
+            }
+          ]
+        },
+        {
+          "exportSpecifiers": [
+            "[file]"
+          ],
+          "rootFileMap": [
+            null
+          ]
+        }
+      ]
+    },
+    {
+      "file": "./ref-component.js",
+      "result": [
+        {
+          "exportSpecifiers": [
+            "[file]"
+          ],
+          "rootFileMap": [
+            null
+          ]
+        }
+      ]
+    },
+    {
+      "file": "./ref-src/core.js",
+      "result": [
+        {
+          "exportSpecifiers": [
+            "RefClass"
+          ],
+          "localMap": [],
+          "rootFileMap": [
+            {
+              "currentFileSpecifier": "RefClass",
+              "rootFile": {
+                "file": "[current]",
+                "specifier": "RefClass"
+              }
+            }
+          ]
+        },
+        {
+          "exportSpecifiers": [
+            "[default]"
+          ],
+          "rootFileMap": [
+            {
+              "currentFileSpecifier": "[default]",
+              "rootFile": {
+                "file": "[current]",
+                "specifier": "[default]"
+              }
+            }
+          ]
+        },
+        {
+          "exportSpecifiers": [
+            "[file]"
+          ],
+          "rootFileMap": [
+            null
+          ]
+        }
+      ]
+    },
+    {
+      "file": "./ref-src/folder/index.js",
+      "result": [
+        {
+          "exportSpecifiers": [
+            "resolvePathCorrect"
+          ],
+          "localMap": [],
+          "rootFileMap": [
+            {
+              "currentFileSpecifier": "resolvePathCorrect",
+              "rootFile": {
+                "file": "[current]",
+                "specifier": "resolvePathCorrect"
+              }
+            }
+          ]
+        },
+        {
+          "exportSpecifiers": [
+            "[file]"
+          ],
+          "rootFileMap": [
+            null
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-imports_-_importing-target-project_0.0.2-target-mock__-1204665763.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/find-imports_-_importing-target-project_0.0.2-target-mock__-1204665763.json
@@ -1,0 +1,204 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "find-imports",
+      "requiredAst": "oxc",
+      "identifier": "importing-target-project_0.0.2-target-mock__-1204665763",
+      "targetProject": {
+        "mainEntry": "./target-src/match-imports/root-level-imports.js",
+        "name": "importing-target-project",
+        "version": "0.0.2-target-mock",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "keepInternalSources": false,
+        "gatherFilesConfig": {},
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "file": "./target-src/find-customelements/multiple.js",
+      "result": [
+        {
+          "importSpecifiers": [
+            "RefClass"
+          ],
+          "source": "exporting-ref-project",
+          "normalizedSource": "exporting-ref-project"
+        }
+      ]
+    },
+    {
+      "file": "./target-src/find-imports/all-notations.js",
+      "result": [
+        {
+          "importSpecifiers": [
+            "[file]"
+          ],
+          "source": "imported/source",
+          "normalizedSource": "imported/source"
+        },
+        {
+          "importSpecifiers": [
+            "[default]"
+          ],
+          "source": "imported/source-a",
+          "normalizedSource": "imported/source-a"
+        },
+        {
+          "importSpecifiers": [
+            "b"
+          ],
+          "source": "imported/source-b",
+          "normalizedSource": "imported/source-b"
+        },
+        {
+          "importSpecifiers": [
+            "c",
+            "d"
+          ],
+          "source": "imported/source-c",
+          "normalizedSource": "imported/source-c"
+        },
+        {
+          "importSpecifiers": [
+            "[default]",
+            "f",
+            "g"
+          ],
+          "source": "imported/source-d",
+          "normalizedSource": "imported/source-d"
+        },
+        {
+          "importSpecifiers": [
+            "[default]"
+          ],
+          "source": "my/source-e",
+          "normalizedSource": "my/source-e"
+        },
+        {
+          "importSpecifiers": [
+            "[default]"
+          ],
+          "source": "[variable]",
+          "normalizedSource": "[variable]"
+        },
+        {
+          "importSpecifiers": [
+            "[*]"
+          ],
+          "source": "imported/source-g",
+          "normalizedSource": "imported/source-g"
+        }
+      ]
+    },
+    {
+      "file": "./target-src/match-imports/deep-imports.js",
+      "result": [
+        {
+          "importSpecifiers": [
+            "RefClass"
+          ],
+          "source": "exporting-ref-project/ref-src/core.js",
+          "normalizedSource": "exporting-ref-project/ref-src/core.js"
+        },
+        {
+          "importSpecifiers": [
+            "[default]"
+          ],
+          "source": "exporting-ref-project/ref-src/core.js",
+          "normalizedSource": "exporting-ref-project/ref-src/core.js"
+        },
+        {
+          "importSpecifiers": [
+            "nonMatched"
+          ],
+          "source": "unknown-project/xyz.js",
+          "normalizedSource": "unknown-project/xyz.js"
+        },
+        {
+          "importSpecifiers": [
+            "[file]"
+          ],
+          "source": "exporting-ref-project/ref-component",
+          "normalizedSource": "exporting-ref-project/ref-component"
+        },
+        {
+          "importSpecifiers": [
+            "resolvePathCorrect"
+          ],
+          "source": "exporting-ref-project/ref-src/folder",
+          "normalizedSource": "exporting-ref-project/ref-src/folder"
+        },
+        {
+          "importSpecifiers": [
+            "[*]"
+          ],
+          "source": "exporting-ref-project/ref-src/core.js",
+          "normalizedSource": "exporting-ref-project/ref-src/core.js"
+        }
+      ]
+    },
+    {
+      "file": "./target-src/match-imports/root-level-imports.js",
+      "result": [
+        {
+          "importSpecifiers": [
+            "RefClass"
+          ],
+          "source": "exporting-ref-project",
+          "normalizedSource": "exporting-ref-project"
+        },
+        {
+          "importSpecifiers": [
+            "RefRenamedClass"
+          ],
+          "source": "exporting-ref-project",
+          "normalizedSource": "exporting-ref-project"
+        },
+        {
+          "importSpecifiers": [
+            "[default]"
+          ],
+          "source": "exporting-ref-project",
+          "normalizedSource": "exporting-ref-project"
+        },
+        {
+          "importSpecifiers": [
+            "nonMatched"
+          ],
+          "source": "unknown-project",
+          "normalizedSource": "unknown-project"
+        }
+      ]
+    },
+    {
+      "file": "./target-src/match-subclasses/ExtendedComp.js",
+      "result": [
+        {
+          "importSpecifiers": [
+            "RefClass"
+          ],
+          "source": "exporting-ref-project",
+          "normalizedSource": "exporting-ref-project"
+        }
+      ]
+    },
+    {
+      "file": "./target-src/match-subclasses/internalProxy.js",
+      "result": [
+        {
+          "importSpecifiers": [
+            "[default]"
+          ],
+          "source": "exporting-ref-project",
+          "normalizedSource": "exporting-ref-project"
+        }
+      ]
+    }
+  ]
+}

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/match-imports_-_importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__2104309550.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/match-imports_-_importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__2104309550.json
@@ -1,0 +1,162 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "match-imports",
+      "requiredAst": "oxc",
+      "identifier": "importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__2104309550",
+      "targetProject": {
+        "mainEntry": "./target-src/match-imports/root-level-imports.js",
+        "name": "importing-target-project",
+        "version": "0.0.2-target-mock",
+        "commitHash": "[not-a-git-root]"
+      },
+      "referenceProject": {
+        "mainEntry": "./index.js",
+        "name": "exporting-ref-project",
+        "version": "1.0.0",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "gatherFilesConfig": {},
+        "targetProjectResult": null,
+        "referenceProjectResult": null,
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "exportSpecifier": {
+        "id": "[default]::./index.js::exporting-ref-project",
+        "name": "[default]",
+        "filePath": "./index.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/root-level-imports.js",
+            "./target-src/match-subclasses/internalProxy.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "RefClass::./index.js::exporting-ref-project",
+        "name": "RefClass",
+        "filePath": "./index.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/find-customelements/multiple.js",
+            "./target-src/match-imports/root-level-imports.js",
+            "./target-src/match-subclasses/ExtendedComp.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "RefRenamedClass::./index.js::exporting-ref-project",
+        "name": "RefRenamedClass",
+        "filePath": "./index.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/root-level-imports.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "[file]::./ref-component.js::exporting-ref-project",
+        "name": "[file]",
+        "filePath": "./ref-component.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/deep-imports.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "RefClass::./ref-src/core.js::exporting-ref-project",
+        "name": "RefClass",
+        "filePath": "./ref-src/core.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/deep-imports.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "[default]::./ref-src/core.js::exporting-ref-project",
+        "name": "[default]",
+        "filePath": "./ref-src/core.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/deep-imports.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "[file]::./ref-src/core.js::exporting-ref-project",
+        "name": "[file]",
+        "filePath": "./ref-src/core.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/deep-imports.js"
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "id": "resolvePathCorrect::./ref-src/folder/index.js::exporting-ref-project",
+        "name": "resolvePathCorrect",
+        "filePath": "./ref-src/folder/index.js",
+        "project": "exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            "./target-src/match-imports/deep-imports.js"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/match-paths_-_importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__-1953433647.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/match-paths_-_importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__-1953433647.json
@@ -1,0 +1,94 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "match-paths",
+      "requiredAst": "babel",
+      "identifier": "importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__-1953433647",
+      "targetProject": {
+        "mainEntry": "./target-src/match-imports/root-level-imports.js",
+        "name": "importing-target-project",
+        "version": "0.0.2-target-mock",
+        "commitHash": "[not-a-git-root]"
+      },
+      "referenceProject": {
+        "mainEntry": "./index.js",
+        "name": "exporting-ref-project",
+        "version": "1.0.0",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "gatherFilesConfig": {},
+        "prefix": null,
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "name": "[default]",
+      "variable": {
+        "from": "[default]",
+        "to": "ExtendedComp",
+        "paths": [
+          {
+            "from": "./index.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          },
+          {
+            "from": "./ref-src/core.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          },
+          {
+            "from": "exporting-ref-project/index.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          },
+          {
+            "from": "exporting-ref-project/ref-src/core.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          }
+        ]
+      }
+    },
+    {
+      "name": "RefClass",
+      "variable": {
+        "from": "RefClass",
+        "to": "ExtendedComp",
+        "paths": [
+          {
+            "from": "./index.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          },
+          {
+            "from": "./ref-src/core.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          },
+          {
+            "from": "exporting-ref-project/index.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          },
+          {
+            "from": "exporting-ref-project/ref-src/core.js",
+            "to": "./target-src/match-subclasses/ExtendedComp.js"
+          }
+        ]
+      },
+      "tag": {
+        "from": "ref-component",
+        "to": "extended-comp",
+        "paths": [
+          {
+            "from": "./ref-component.js",
+            "to": "./target-src/find-customelements/multiple.js"
+          },
+          {
+            "from": "exporting-ref-project/ref-component.js",
+            "to": "./target-src/find-customelements/multiple.js"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages-node/providence-analytics/test-node/program/analyzers/e2e/match-subclasses_-_importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__-326888278.json
+++ b/packages-node/providence-analytics/test-node/program/analyzers/e2e/match-subclasses_-_importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__-326888278.json
@@ -1,0 +1,67 @@
+{
+  "meta": {
+    "searchType": "ast-analyzer",
+    "analyzerMeta": {
+      "name": "match-subclasses",
+      "requiredAst": "oxc",
+      "identifier": "importing-target-project_0.0.2-target-mock_+_exporting-ref-project_1.0.0__-326888278",
+      "targetProject": {
+        "mainEntry": "./target-src/match-imports/root-level-imports.js",
+        "name": "importing-target-project",
+        "version": "0.0.2-target-mock",
+        "commitHash": "[not-a-git-root]"
+      },
+      "referenceProject": {
+        "mainEntry": "./index.js",
+        "name": "exporting-ref-project",
+        "version": "1.0.0",
+        "commitHash": "[not-a-git-root]"
+      },
+      "configuration": {
+        "gatherFilesConfig": {},
+        "skipCheckMatchCompatibility": false,
+        "addSystemPathsInResult": false
+      }
+    }
+  },
+  "queryOutput": [
+    {
+      "exportSpecifier": {
+        "name": "[default]",
+        "project": "exporting-ref-project",
+        "filePath": "./index.js",
+        "id": "[default]::./index.js::exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            {
+              "file": "./target-src/match-subclasses/ExtendedComp.js",
+              "identifier": "ExtendedComp"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "exportSpecifier": {
+        "name": "RefClass",
+        "project": "exporting-ref-project",
+        "filePath": "./index.js",
+        "id": "RefClass::./index.js::exporting-ref-project"
+      },
+      "matchesPerProject": [
+        {
+          "project": "importing-target-project",
+          "files": [
+            {
+              "file": "./target-src/match-subclasses/ExtendedComp.js",
+              "identifier": "ExtendedComp"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/ui/components/input-amount/src/formatters.js
+++ b/packages/ui/components/input-amount/src/formatters.js
@@ -27,8 +27,10 @@ export function formatAmount(modelValue, givenOptions) {
   if (typeof options.maximumFractionDigits === 'undefined') {
     options.maximumFractionDigits = getFractionDigits(options.currency);
   }
+  const formatted = formatNumber(modelValue, options);
 
-  return formatNumber(modelValue, options);
+  // ✅ // Convert Unicode minus to normal minus for consistency
+  return formatted.replace(/\u2212/g, '-');
 }
 
 /**

--- a/packages/ui/components/input-amount/src/parsers.js
+++ b/packages/ui/components/input-amount/src/parsers.js
@@ -31,14 +31,17 @@ function round(value, decimals) {
  * @param {FormatNumberOptions} [givenOptions] Locale Options
  */
 export function parseAmount(value, givenOptions) {
-  const unmatchedInput = value.match(/[^0-9,.\- ]/g);
+  // Replace Unicode minus with normal minus before parsing
+  const sanitizedValue = value.replace(/\u2212/g, '-');
+
+  const unmatchedInput = sanitizedValue.match(/[^0-9,.\- ]/g);
   // for the full paste behavior documentation:
   // ./docs/components/input-amount/use-cases.md#paste-behavior
   if (unmatchedInput && givenOptions?.mode !== 'pasted') {
     return undefined;
   }
 
-  const number = parseNumber(value, givenOptions);
+  const number = parseNumber(sanitizedValue, givenOptions);
 
   if (typeof number !== 'number' || Number.isNaN(number)) {
     return undefined;

--- a/packages/ui/components/input-amount/test/formatters.test.js
+++ b/packages/ui/components/input-amount/test/formatters.test.js
@@ -85,4 +85,14 @@ describe('formatAmount()', () => {
       '12,345,678,987,654,321.42',
     );
   });
+
+  // Ensures formatter uses a normal dash (-) instead of unicode minus (\u2212)
+  it('does not return unicode minus sign in formatted output', async () => {
+    const result = formatAmount(-123.45, {
+      locale: 'en-GB',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    });
+    expect(result).to.equal('-123.45'); // Should be a normal dash
+  });
 });

--- a/packages/ui/components/input-amount/test/parsers.test.js
+++ b/packages/ui/components/input-amount/test/parsers.test.js
@@ -71,4 +71,10 @@ describe('parseAmount()', async () => {
       parseAmount('123.456,78', { mode: 'user-edited', viewValueStates: ['formatted'] }),
     ).to.equal(123456.78);
   });
+
+  // Tests parsing of negative numbers with both normal dash and unicode minus
+  it('parses negative numbers with unicode minus sign and normal dash', async () => {
+    expect(parseAmount('−123')).to.equal(-123); // Unicode minus: \u2212
+    expect(parseAmount('-123')).to.equal(-123); // Normal dash
+  });
 });


### PR DESCRIPTION
### What was the problem?

After entering a negative number into the `LionInputAmount` component, the dash character was converted into a Unicode minus sign (`\u2212`) during formatting. This caused the `unmatchedInput` regex in `parsers.js` to fail, making it impossible to edit the number later without triggering an error.

### What did I change?

- Replaced the Unicode minus sign (`\u2212`) with a standard dash (`-`) before parsing input, using a new variable to avoid mutating function parameters (ESLint rule).
- Updated `unmatchedInput` logic in `parsers.js` to handle sanitized input.
- Minor adjustment in `formatters.js` to prevent reintroducing Unicode minus during formatting.

### Testing

- ✅ Manually tested with positive and negative numbers.
- ✅ Switching focus works without triggering errors.
- ✅ Editing negative values now behaves as expected.
- ✅ Ran `npm run lint` and `npm run test` — all passed.

---

Let me know if any changes or improvements are needed. Thanks for reviewing!
