### PR TITLE
fix(input-tel): use full locale to translate country names in dropdown

### DIFF
--- a/.changeset/witty-geese-exercise.md
+++ b/.changeset/witty-geese-exercise.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(input-tel): use full locale to translate country names in dropdown

--- a/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -4,6 +4,7 @@ import { ref, createRef } from 'lit/directives/ref.js';
 import { LionInputTel } from '@lion/ui/input-tel.js';
 import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 import { getFlagSymbol } from './getFlagSymbol.js';
+import { regionCodeToLocale } from './regionCodeToLocale.js';
 
 /**
  * Note: one could consider to implement LionInputTelDropdown as a
@@ -193,8 +194,7 @@ export class LionInputTelDropdown extends LionInputTel {
   onLocaleUpdated() {
     super.onLocaleUpdated();
 
-    // @ts-expect-error relatively new platform api
-    this.__namesForLocale = new Intl.DisplayNames([this._langIso], {
+    this.__namesForLocale = new Intl.DisplayNames([this._localizeManager.locale], {
       type: 'region',
     });
     this.__createRegionMeta();
@@ -408,7 +408,7 @@ export class LionInputTelDropdown extends LionInputTel {
     this.__regionMetaListPreferred = [];
     this._allowedOrAllRegions.forEach(regionCode => {
       // @ts-ignore relatively new platform api
-      const namesForRegion = new Intl.DisplayNames([regionCode.toLowerCase()], {
+      const namesForRegion = new Intl.DisplayNames([regionCodeToLocale(regionCode)], {
         type: 'region',
       });
       const countryCode =

--- a/packages/ui/components/input-tel-dropdown/src/regionCodeToLocale.js
+++ b/packages/ui/components/input-tel-dropdown/src/regionCodeToLocale.js
@@ -1,0 +1,10 @@
+/**
+ * Get the full locale for a region.
+ * As we don't know the language for that region, we first set it as 'und', which stands for 'undetermined'.
+ * @param {string} regionCode
+ */
+export function regionCodeToLocale(regionCode) {
+  const locale = new Intl.Locale('und', { region: regionCode }); // Set language as undetermined.
+  const maximizedLocale = locale.maximize(); // Determine the most likely full locale for a region with an undetermined language.
+  return maximizedLocale.baseName;
+}

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
@@ -253,7 +253,7 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
         // @ts-ignore
         const originalLocale = el._localizeManager.locale;
         // @ts-ignore
-        el._localizeManager.locale = 'nl-NL';
+        el._localizeManager.locale = 'fr-BE';
         await el.updateComplete;
         const dropdownNode = el.refs.dropdown.value;
         const templateDataForDropdown = /** @type {TemplateDataForDropdownInputTel} */ (
@@ -267,7 +267,7 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
                 {
                   countryCode: 31,
                   flagSymbol: '🇳🇱',
-                  nameForLocale: 'Nederland',
+                  nameForLocale: 'Pays-Bas',
                   nameForRegion: 'Nederland',
                   regionCode: 'NL',
                 },
@@ -276,7 +276,7 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
                 {
                   countryCode: 63,
                   flagSymbol: '🇵🇭',
-                  nameForLocale: 'Filipijnen',
+                  nameForLocale: 'Philippines',
                   nameForRegion: 'Pilipinas',
                   regionCode: 'PH',
                 },
@@ -285,9 +285,9 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
             refs: {
               dropdown: {
                 labels: {
-                  allCountries: 'Alle landen',
-                  preferredCountries: 'Voor gestelde landen',
-                  selectCountry: 'Selecteer land',
+                  allCountries: 'Tous les pays',
+                  preferredCountries: 'Pays suggérés',
+                  selectCountry: 'Sélectionnez un pays',
                 },
                 listeners: {
                   // @ts-expect-error [allow-protected]

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
@@ -133,7 +133,7 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
                   countryCode: 63,
                   flagSymbol: '🇵🇭',
                   nameForLocale: 'Philippines',
-                  nameForRegion: 'Philippines',
+                  nameForRegion: 'Pilipinas',
                   regionCode: 'PH',
                 },
               ],

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js
@@ -239,6 +239,74 @@ export function runInputTelDropdownSuite({ klass } = { klass: LionInputTelDropdo
         restorePhoneUtilManager();
         spy.restore();
       });
+
+      it('has the correct nameForLocale, based on browser language', async () => {
+        const el = fixtureSync(html` <${tag}
+          .modelValue="${'+31612345678'}"
+          .allowedRegions="${['NL', 'PH']}"
+          .preferredRegions="${['PH']}"
+          ></${tag}> `);
+        const spy = sinon.spy(
+          /** @type {typeof LionInputTelDropdown} */ (el.constructor).templates,
+          'dropdown',
+        );
+        // @ts-ignore
+        const originalLocale = el._localizeManager.locale;
+        // @ts-ignore
+        el._localizeManager.locale = 'nl-NL';
+        await el.updateComplete;
+        const dropdownNode = el.refs.dropdown.value;
+        const templateDataForDropdown = /** @type {TemplateDataForDropdownInputTel} */ (
+          spy.args[0][0]
+        );
+        expect(templateDataForDropdown).to.eql(
+          /** @type {TemplateDataForDropdownInputTel} */ ({
+            data: {
+              activeRegion: 'NL',
+              regionMetaList: [
+                {
+                  countryCode: 31,
+                  flagSymbol: '🇳🇱',
+                  nameForLocale: 'Nederland',
+                  nameForRegion: 'Nederland',
+                  regionCode: 'NL',
+                },
+              ],
+              regionMetaListPreferred: [
+                {
+                  countryCode: 63,
+                  flagSymbol: '🇵🇭',
+                  nameForLocale: 'Filipijnen',
+                  nameForRegion: 'Pilipinas',
+                  regionCode: 'PH',
+                },
+              ],
+            },
+            refs: {
+              dropdown: {
+                labels: {
+                  allCountries: 'Alle landen',
+                  preferredCountries: 'Voor gestelde landen',
+                  selectCountry: 'Selecteer land',
+                },
+                listeners: {
+                  // @ts-expect-error [allow-protected]
+                  change: el._onDropdownValueChange,
+                  // @ts-expect-error [allow-protected]
+                  'model-value-changed': el._onDropdownValueChange,
+                },
+                props: { style: 'height: 100%;' },
+                ref: { value: dropdownNode },
+              },
+              // @ts-expect-error [allow-protected]
+              input: el._inputNode,
+            },
+          }),
+        );
+        spy.restore();
+        // @ts-ignore
+        el._localizeManager.locale = originalLocale; // restore the locale back to original
+      });
     });
 
     describe('On dropdown value change', () => {

--- a/packages/ui/components/input-tel-dropdown/test/regionCodeToLocale.test.js
+++ b/packages/ui/components/input-tel-dropdown/test/regionCodeToLocale.test.js
@@ -1,0 +1,10 @@
+import { expect } from '@open-wc/testing';
+import { regionCodeToLocale } from '../src/regionCodeToLocale.js';
+
+describe('regionCodeToLocale', () => {
+  it('returns the most likely locale basename for a region', () => {
+    expect(regionCodeToLocale('NL')).to.equal('nl-Latn-NL');
+    expect(regionCodeToLocale('FR')).to.equal('fr-Latn-FR');
+    expect(regionCodeToLocale('DE')).to.equal('de-Latn-DE');
+  });
+});


### PR DESCRIPTION
## What I did

1. Pass full locale to `new Intl.DisplayNames` constructor.

## Issue

The constructor accepts either a language (e.g. `en`, `nl`, ...) or the full locale (e.g. `en-GB`, `nl-BE`, ...).
Instead, we're passing only the region (e.g. `GB`, `BE`, ...), which is not a valid param for the constructor.
Sometimes that works because language and region are the same (e.g. `fr-FR`, `de-DE`), but that is not always the case.

- [Intl locales argument](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#locales_argument)
- [Intl.Locale](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale)

If the specified locale is not recognized, the translations default to English.

## Reproduce

1. Go to the demo of [input-tel-dropdown extension](https://lion.js.org/components/input-tel-dropdown/extensions/)
2. Open the dropdown and check the translations.
3. Open the browser dev tools to change the `lang` of the html tag to `nl-BE`.
4. Open the dropdown again.
5. The countries are shown in English.
6. Change the `lang` attribute to `fr-FR`
7. Open the dropdown again
8. The countries are shown in French

![image](https://github.com/user-attachments/assets/569b40a1-5d77-49a5-9168-6d156085cd43)

## Fix

By using the full locale in the constructor for `Intl.DisplayNames`, the countries are translated correctly to the browser language:

![image](https://github.com/user-attachments/assets/30f77b64-5a8a-4115-91e6-4b7714dc803e)

