### PR TITLE
fix: add install playwright command for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,12 @@ npm run test
 npm run start
 ```
 
+_Note: **playwright** is required for running tests._
+
+```
+npx playwright install
+```
+
 Create a Pull Request:
 
 - At <https://github.com/ing-bank/lion> click on fork (at the right top)


### PR DESCRIPTION
## Add install playwright command for contributors


Issue:
After following steps in the `CONTRIBUTING.md` for contributors. I noted that test command it throwing an error.

Solution:
Installing **playwright** is required before running test. So, I added required command for contributors.

![image](https://github.com/user-attachments/assets/ec762add-32ed-45e5-89ba-94b5e4667ae4)
