### PR TITLE
fix(overlays): don't call _setupOverlayCtrl() in OverlayMixin if the component is not connected

### DIFF
--- a/packages/ui/components/form-core/src/FocusMixin.js
+++ b/packages/ui/components/form-core/src/FocusMixin.js
@@ -198,6 +198,7 @@ const FocusMixinImplementation = superclass =>
      * @private
      */
     __teardownEventsForFocusMixin() {
+      if (!this._focusableNode) return;
       this._focusableNode?.removeEventListener(
         'focus',
         /** @type {EventListenerOrEventListenerObject} */ (this.__redispatchFocus),

--- a/packages/ui/components/overlays/src/OverlayMixin.js
+++ b/packages/ui/components/overlays/src/OverlayMixin.js
@@ -179,6 +179,7 @@ export const OverlayMixinImplementation = superclass =>
       super.connectedCallback();
 
       this.updateComplete.then(() => {
+        if (!this.isConnected) return;
         if (this.#hasSetup) return;
         this._setupOverlayCtrl();
         this.#hasSetup = true;


### PR DESCRIPTION
In our application, there is a very complicated logic that creates a bunch of form fields based on some data. It's very complicated, we hate that logic; but it exists, it works, and it is being used in production.

Somewhere in that logic, under a very specific case, a datepicker form field is created, connected, and then immediately disconnected. Don't ask me why, I said it is complicated.

This commit fixes a bug in OverlayMixin. The `connectedCallback` calls `_setupOverlayCtrl()` asynchronously, after a `Promise.then()`. Thus, by the time this setup function is called, the component has already been disconnected (and `disconnectedCallback()` has already been called).

The fix is simple: don't try to setup the overlay if the component is no longer connected.