### PR TITLE
fix: ignore disabled form elements when navigating options of Select Rich

### DIFF
--- a/packages/ui/components/listbox/src/ListboxMixin.js
+++ b/packages/ui/components/listbox/src/ListboxMixin.js
@@ -869,7 +869,11 @@ const ListboxMixinImplementation = superclass =>
 
       // Try to find the next / previous option
       for (let i = currentIndex + offset; until(i); i += offset) {
-        if (this.formElements[i] && !this.formElements[i].hasAttribute('aria-hidden')) {
+        if (
+          this.formElements[i] &&
+          !this.formElements[i].hasAttribute('aria-hidden') &&
+          !this.formElements[i].disabled
+        ) {
           return i;
         }
       }
@@ -879,7 +883,11 @@ const ListboxMixinImplementation = superclass =>
       if (this.rotateKeyboardNavigation) {
         const startIndex = offset === -1 ? this.formElements.length - 1 : 0;
         for (let i = startIndex; until(i); i += offset) {
-          if (this.formElements[i] && !this.formElements[i].hasAttribute('aria-hidden')) {
+          if (
+            this.formElements[i] &&
+            !this.formElements[i].hasAttribute('aria-hidden') &&
+            !this.formElements[i].disabled
+          ) {
             return i;
           }
         }


### PR DESCRIPTION
…Select Rich (fix issue #2529: [LionSelectRich] disabled options should not get focus bug)

## What I did

1. I added !this.formElements[i].disabled to skip disabled elements when moving with arrows or cursor in the function __getEnabledOption of ListboxMixin inherited by LionSelectRich.
2. I tested locally editing the overview.md (not included in this PR) in select-rich inside docs > components > select-rich.

