### PR TITLE
Fix casing in README: 'es' → 'ES'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ They provide an unopinionated, white-label layer that can be extended to your ow
 - **High Performance:** Focused on great performance in all relevant browsers with a minimal number of dependencies.
 - **Accessibility:** Aimed at compliance with the WCAG 2.2 AA standard to create components that are accessible for everybody.
 - **Flexibility:** Provides solutions through Web Components and JavaScript classes which can be used, adopted and extended to fit all needs.
-- **Modern Code:** Lion is distributed as pure es modules.
+- **Modern Code:** Lion is distributed as pure ES modules.
 - **Exposes functions/classes and Web Components:** Ships a functionality in its most appropriate form.
 
 > Note: Our demo examples might look simple and not very stylish. This is on purpose. They are designed to be basic so you can easily add your own styles to them to match your intended design, without dealing with styles that are already there.


### PR DESCRIPTION
### Summary

This PR corrects the casing of "es modules" to "ES modules" in the README to align with standard naming conventions.

No other changes were made.

### Additional Notes

Thanks for maintaining this project!

