### PR TITLE
feat(input-tel): use first preferred region to set a default region

### DIFF
--- a/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
+++ b/packages/ui/components/input-tel-dropdown/src/LionInputTelDropdown.js
@@ -42,14 +42,6 @@ import { regionCodeToLocale } from './regionCodeToLocale.js';
  * `e164` format that contains all info (both region code and national phone number).
  */
 export class LionInputTelDropdown extends LionInputTel {
-  /**
-   * @configure LitElement
-   * @type {any}
-   */
-  static properties = {
-    preferredRegions: { type: Array },
-  };
-
   refs = {
     /** @type {DropdownRef} */
     dropdown: /** @type {DropdownRef} */ (createRef()),
@@ -214,11 +206,6 @@ export class LionInputTelDropdown extends LionInputTel {
   constructor() {
     super();
 
-    /**
-     * Regions that will be shown on top of the dropdown
-     * @type {string[]}
-     */
-    this.preferredRegions = [];
     /**
      * Group label for all countries, when preferredCountries are shown
      * @protected

--- a/packages/ui/components/input-tel/src/LionInputTel.js
+++ b/packages/ui/components/input-tel/src/LionInputTel.js
@@ -27,6 +27,7 @@ export class LionInputTel extends LocalizeMixin(LionInput) {
     formatStrategy: { type: String, attribute: 'format-strategy' },
     formatCountryCodeStyle: { type: String, attribute: 'format-country-code-style' },
     activeRegion: { type: String },
+    preferredRegions: { type: Array },
     _phoneUtil: { type: Object, state: true },
   };
 
@@ -155,6 +156,12 @@ export class LionInputTel extends LocalizeMixin(LionInput) {
      * @type {RegionCode[]}
      */
     this.allowedRegions = [];
+
+    /**
+     * Regions that will be shown on top of the dropdown
+     * @type {RegionCode[]}
+     */
+    this.preferredRegions = [];
 
     /** @private */
     this.__isPhoneNumberValidatorInstance = new PhoneNumber();
@@ -326,13 +333,19 @@ export class LionInputTel extends LocalizeMixin(LionInput) {
       return;
     }
 
-    // 3. Try to get the region from locale
+    // 3. Get the first region in the list of preferred regions
+    if (this.preferredRegions?.length > 0) {
+      this._setActiveRegion(this.preferredRegions[0]);
+      return;
+    }
+
+    // 4. Try to get the region from locale
     if (this._langIso && this._allowedOrAllRegions.includes(this._langIso)) {
       this._setActiveRegion(this._langIso);
       return;
     }
 
-    // 4. Not derivable
+    // 5. Not derivable
     this._setActiveRegion(undefined);
   }
 }

--- a/packages/ui/components/input-tel/test-suites/LionInputTel.suite.js
+++ b/packages/ui/components/input-tel/test-suites/LionInputTel.suite.js
@@ -100,6 +100,20 @@ function runActiveRegionTests({ tag, phoneUtilLoadedAfterInit }) {
       expect(el.activeRegion).to.equal('NL');
     });
 
+    it('.modelValue takes precedence over .preferredRegions when both preconfigured and .modelValue updated', async () => {
+      const el = await fixture(
+        html` <${tag} .preferredRegions="${[
+          'DE',
+          'BE',
+        ]}" .modelValue="${'+31612345678'}" ></${tag}> `,
+      );
+      if (resolvePhoneUtilLoaded) {
+        resolvePhoneUtilLoaded(undefined);
+        await el.updateComplete;
+      }
+      expect(el.activeRegion).to.equal('NL');
+    });
+
     it('deducts it from value when modelValue is unparseable', async () => {
       const modelValue = new Unparseable('+316');
       const el = await fixture(html` <${tag} .modelValue=${modelValue}></${tag}> `);
@@ -122,7 +136,18 @@ function runActiveRegionTests({ tag, phoneUtilLoadedAfterInit }) {
       expect(el.activeRegion).to.equal('NL');
     });
 
-    // 3. **locale**: try to get the region from locale (`html[lang]` attribute)
+    // 3. **preferred-region**: get the first element in the preferred regions list
+    it('deducts it from the .preferredRegions when provided', async () => {
+      const el = await fixture(html` <${tag} .preferredRegions="${['DE', 'NL']}"></${tag}> `);
+      if (resolvePhoneUtilLoaded) {
+        resolvePhoneUtilLoaded(undefined);
+        await el.updateComplete;
+      }
+      // Region code for country code '+49' is 'DE'
+      expect(el.activeRegion).to.equal('DE');
+    });
+
+    // 4. **locale**: try to get the region from locale (`html[lang]` attribute)
     it('automatically bases it on current locale when nothing preconfigured', async () => {
       const el = await fixture(html` <${tag}></${tag}> `);
       if (resolvePhoneUtilLoaded) {


### PR DESCRIPTION
## What I did

1. Move the `preferredRegions` property from LionInputTelDropdown to LionInputTel
2. In the `__calculateActiveRegion`, check if `preferredRegions` exist and if so, take the first value in that list and set it as the active region. It comes in 3rd place in order of priority, after user input and before Locale.

## Issue

There is no way of passing a default region to the input-tel.

## Reproduce

1. Go to the demo of [input-tel-dropdown preferred regions](https://lion.js.org/components/input-tel-dropdown/use-cases/#preferred-regions)
2. Clear the input
3. The active region is now based on the locale (for me that was en-GB), while the preferred regions are NL and DE

![image](https://github.com/user-attachments/assets/d9b2f8fb-cdcd-4878-a42e-f150c03a8f4d)
![image](https://github.com/user-attachments/assets/e476e926-e3ca-4e48-a8fc-bc67ed777580)

## Fix

By using the preferred regions, a default is set which will be more in line with expected user input.

![image](https://github.com/user-attachments/assets/41f065eb-5761-4cd9-be1f-64b879101691)
![image](https://github.com/user-attachments/assets/2f16fafd-d004-462e-9631-c6150e56a608)
