### PR TITLE
fix: editing negative numbers

### DIFF
--- a/packages/ui/components/input-amount/src/parsers.js
+++ b/packages/ui/components/input-amount/src/parsers.js
@@ -31,7 +31,7 @@ function round(value, decimals) {
  * @param {FormatNumberOptions} [givenOptions] Locale Options
  */
 export function parseAmount(value, givenOptions) {
-  const unmatchedInput = value.match(/[^0-9,.\- ]/g);
+  const unmatchedInput = value.match(/[^0-9,.\-\u2212 ]/g);
   // for the full paste behavior documentation:
   // ./docs/components/input-amount/use-cases.md#paste-behavior
   if (unmatchedInput && givenOptions?.mode !== 'pasted') {

--- a/packages/ui/components/input-amount/test/parsers.test.js
+++ b/packages/ui/components/input-amount/test/parsers.test.js
@@ -71,4 +71,9 @@ describe('parseAmount()', async () => {
       parseAmount('123.456,78', { mode: 'user-edited', viewValueStates: ['formatted'] }),
     ).to.equal(123456.78);
   });
+
+  it('parses negative numbers', async () => {
+    expect(parseAmount('−15.00')).to.equal(-15);
+    expect(parseAmount('-333.33')).to.equal(-333.33);
+  });
 });


### PR DESCRIPTION
## What I did

1. fixed the 'editing negative number' problem by adding (\u2212) to unmatchedInput regex inside parseAmount function. 
2. added test for the negative numbers both with \u2212 and '-'.

issue: #2492