### PR TITLE
fix(dedupe-mixin): resolve version conflict between v1 and v2 - fixes (#2535)

### DIFF
--- a/.changeset/brown-shirts-count.md
+++ b/.changeset/brown-shirts-count.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Fix @open-wc/dedupe-mixin version conflict

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -63,8 +63,8 @@
   ],
   "dependencies": {
     "@bundled-es-modules/message-format": "^6.2.4",
-    "@open-wc/dedupe-mixin": "^1.4.0",
-    "@open-wc/scoped-elements": "^3.0.5",
+    "@open-wc/dedupe-mixin": "^2.0.1",
+    "@open-wc/scoped-elements": "^3.0.6",
     "@popperjs/core": "^2.11.8",
     "autosize": "^6.0.0",
     "awesome-phonenumber": "^6.4.0",


### PR DESCRIPTION
## What I did

1. Updated the `@open-wc/scoped-elements` dependency to start from `3.0.6` as it transitively depends on the v2 version of the `@open-wc/dedupe-mixin`
2. Updated the `@open-wc/dedupe-mixin` direct dependency to use the latest, v2 version

## Why?

Currently, there is a dependency version conflict in `@lion/ui` hindering component packs that build on top of it. In the current version of `@lion/ui`, the package explicitly depends on the v1 version of the `@open-wc/dedupe-mixin`. However, since it allows patch versions of the `@open-wc/scoped-elements` newer than `3.0.5`, recent npm installs will resolve the transitive `@open-wc/dedupe-mixin` to become v2.

## How is this a problem?

Building component packs on top of `@lion/ui` typically involves generating type definitions for those components. When a more strict bundler, like the latest Vite is used, with its TypeScript plugin (to generate the type definitions) it gets into an import conflict problem. The issue is not limited to this bundler, but it's a general one:

- when `@lion/ui` code directly imports the `@open-wc/dedupe-mixin` it refers to the v1 according the the package.json
- when `@open-wc/scoped-elements` imports the `@open-wc/dedupe-mixin`, it needs to be v1 if its version is outdated, or v2 if it's the latest one.

In the event the build detects a v1 and v2 mismatch, the type generation fails, as there is no way to clearly interpret what the type import hoised to the Lion-dependent component pack's own type definition means when it says it refers to the `@open-wc/scoped-elements`. The result is a build failure.

## Context of the major version bump

There is no significant behavior change between the v1 and v2 version of the `@open-wc/dedupe-mixin`. The major version change comes from the fact that the package.json delcaration were adjusted to fix the invalid setup of the v1.