### PR TITLE
fix(ajax): add query params to fetch method

### DIFF
--- a/packages/ajax/src/Ajax.js
+++ b/packages/ajax/src/Ajax.js
@@ -144,7 +144,15 @@ export class Ajax {
    * @returns {Promise<Response>}
    */
   async fetch(info, init, parseErrorResponse = false) {
-    const request = /** @type {CacheRequest} */ (new Request(info, { ...init }));
+    const baseUrl = typeof info === 'string' ? info : /** @type {Request} */ (info).url;
+    const url = `${baseUrl}${init?.params ? `?${new URLSearchParams(init.params)}` : ''}`;
+
+    const request = /** @type {CacheRequest} */ (
+      typeof info === 'string'
+        ? new Request(url, { ...init })
+        : new Request({ ...info, url }, { ...init })
+    );
+
     request.cacheOptions = init?.cacheOptions;
     request.params = init?.params;
 

--- a/packages/ajax/test/Ajax.test.js
+++ b/packages/ajax/test/Ajax.test.js
@@ -110,6 +110,15 @@ describe('Ajax', () => {
       expect(response.headers.get('X-Custom-Header')).to.equal('y-custom-value');
     });
 
+    it('calls fetch with the given query params', async () => {
+      await ajax.fetch('/foo', { params: { query: 'param', intValue: 1 } });
+
+      expect(fetchStub).to.have.been.calledOnce;
+      const request = fetchStub.getCall(0).args[0];
+
+      expect(request.url).to.equal(`${window.location.origin}/foo?query=param&intValue=1`);
+    });
+
     it('throws on 4xx responses', async () => {
       fetchStub.returns(Promise.resolve(new Response('', { status: 400 })));
 


### PR DESCRIPTION
## What is this for
In the `CacheRequest` object in the `Ajax` file the properties `params` are set, meaning that the `init` argument that gets passed to the `fetch()` method allows for the usage of the `params` property. This creates an illusion that the `fetch()` method automatically adds parameters to the request, resulting in query parameters being passed to the final URL that the `Request` is going to.

However, both the definition of `Request` and `CacheRequest` both miss the `params` property, so they won't be used. In the `cacheManager` there is a method that interacts with the `params` property of cached requests.

If this was intended behavior, then I can rebrand this PR as a `feat` instead, as this allows for extra easy usability of the `fetch` wrapper in the lion package.

## Is this breaking
No, this only adds functionality, leaving the standard workflow intact.

## What does this solve
My issue that has been open for a while: #2363 
