### PR TITLE
chore: test for disconnected overlay

### DIFF
--- a/.changeset/brown-mirrors-admire-2.md
+++ b/.changeset/brown-mirrors-admire-2.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[form-core]: make focusableNode teardown defensive in case the node doesn't exist

--- a/.changeset/brown-mirrors-admire.md
+++ b/.changeset/brown-mirrors-admire.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[overlays]: make sure that edge cases where overlays are connected and immediately disconnected, are covered well


### PR DESCRIPTION
This failing test illustrates the problem that the PR of https://github.com/ing-bank/lion/pull/2530 solves.

After https://github.com/ing-bank/lion/pull/2530 is merged, we can merge this PR as well (as the test will succeed afterwards)

(also adds the changesets for https://github.com/ing-bank/lion/pull/2530)