### PR TITLE
feat: adds display options configurability to the success validation

### DIFF
--- a/.changeset/serious-toys-hug.md
+++ b/.changeset/serious-toys-hug.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+adds configuration options to the success message validation

--- a/docs/fundamentals/systems/form/validate.md
+++ b/docs/fundamentals/systems/form/validate.md
@@ -692,16 +692,16 @@ So, an error validator going from invalid (true) state to invalid(false) state, 
 
 By default the success message will disappear, both the duration and the removal can be configured by passing `displayOptions` to the validator configuration:
 
-The `persistent` property allows the success message to stay on screen, like the behaviour of the other validation types' messages.
-
-```js
-new DefaultSuccess({}, { displayOptions: { persistent: true } });
-```
-
 The `duration` property overwrites the default 3000ms timer.
 
 ```js
 new DefaultSuccess({}, { displayOptions: { duration: 1000 } });
+```
+
+`Infinity` can be added to the `duration` property to allow the success message to stay on screen, like the behaviour of the other validation types' messages.
+
+```js
+new DefaultSuccess({}, { displayOptions: { duration: Infinity } });
 ```
 
 ## Asynchronous validation

--- a/docs/fundamentals/systems/form/validate.md
+++ b/docs/fundamentals/systems/form/validate.md
@@ -701,7 +701,7 @@ new DefaultSuccess({}, { visibilityDuration: 4000 });
 `Infinity` can be added to the `duration` property to allow the success message to stay on screen, like the behaviour of the other validation types' messages.
 
 ```js
-new DefaultSuccess({}, { displayOptions: { duration: Infinity } });
+new DefaultSuccess({}, visibilityDuration: Infinity });
 ```
 
 ## Asynchronous validation

--- a/docs/fundamentals/systems/form/validate.md
+++ b/docs/fundamentals/systems/form/validate.md
@@ -684,9 +684,25 @@ export const validationTypes = () => {
 };
 ```
 
+### Success
+
 Success validators work a bit differently. Their success state is defined by the lack of a previously existing erroneous state (which can be an error or warning state).
 
 So, an error validator going from invalid (true) state to invalid(false) state, will trigger the success validator.
+
+By default the success message will disappear, both the duration and the removal can be configured by passing `displayOptions` to the validator configuration:
+
+The `persistent` property allows the success message to stay on screen, like the behaviour of the other validation types' messages.
+
+```js
+new DefaultSuccess({}, { displayOptions: { persistent: true } });
+```
+
+The `duration` property overwrites the default 3000ms timer.
+
+```js
+new DefaultSuccess({}, { displayOptions: { duration: 1000 } });
+```
 
 ## Asynchronous validation
 
@@ -873,7 +889,7 @@ export const backendValidation = () => {
 
 ## Multiple field validation
 
-When validation is dependent on muliple fields, two approaches can be considered:
+When validation is dependent on multiple fields, two approaches can be considered:
 
 - Fieldset validation
 - Validators with knowledge about context

--- a/docs/fundamentals/systems/form/validate.md
+++ b/docs/fundamentals/systems/form/validate.md
@@ -695,7 +695,7 @@ By default the success message will disappear, both the duration and the removal
 The `duration` property overwrites the default 3000ms timer.
 
 ```js
-new DefaultSuccess({}, { displayOptions: { duration: 1000 } });
+new DefaultSuccess({}, { visibilityDuration: 4000 });
 ```
 
 `Infinity` can be added to the `duration` property to allow the success message to stay on screen, like the behaviour of the other validation types' messages.

--- a/packages/ui/components/form-core/src/validate/LionValidationFeedback.js
+++ b/packages/ui/components/form-core/src/validate/LionValidationFeedback.js
@@ -51,9 +51,9 @@ export class LionValidationFeedback extends LocalizeMixin(LitElement) {
   constructor() {
     super();
     /**
-     * @type {FeedbackMessage[]}
+     * @type {FeedbackMessage[] | undefined}
      */
-    this.feedbackData = [];
+    this.feedbackData = undefined;
   }
 
   /**

--- a/packages/ui/components/form-core/src/validate/LionValidationFeedback.js
+++ b/packages/ui/components/form-core/src/validate/LionValidationFeedback.js
@@ -48,6 +48,14 @@ export class LionValidationFeedback extends LocalizeMixin(LitElement) {
     ];
   }
 
+  constructor() {
+    super();
+    /**
+     * @type {FeedbackMessage[]}
+     */
+    this.feedbackData = [];
+  }
+
   /**
    * @overridable
    * @param {Object} opts
@@ -69,16 +77,6 @@ export class LionValidationFeedback extends LocalizeMixin(LitElement) {
     if (this.feedbackData && this.feedbackData[0]) {
       this.setAttribute('type', this.feedbackData[0].type);
       this.currentType = this.feedbackData[0].type;
-      window.clearTimeout(this.removeMessage);
-      // TODO: this logic should be in ValidateMixin, so that [show-feedback-for] is in sync,
-      // plus duration should be configurable
-      if (this.currentType === 'success') {
-        this.removeMessage = window.setTimeout(() => {
-          this.removeAttribute('type');
-          /** @type {FeedbackMessage[]} */
-          this.feedbackData = [];
-        }, 3000);
-      }
     } else if (this.currentType !== 'success') {
       this.removeAttribute('type');
     }

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -747,7 +747,7 @@ export const ValidateMixinImplementation = superclass =>
      * @property {string} type will be 'error' for messages from default Validators. Could be
      * 'warning', 'info' etc. for Validators with custom types. Needed as a directive for
      * feedbackNode how to render a message of a certain type
-     * @property {Number} visibilityDuration duration in ms for how long the message should be shown
+     * @property {number} visibilityDuration duration in ms for how long the message should be shown
      * @property {Validator} [validator] when the message is directly coupled to a Validator
      * (in most cases), this property is filled. When a message is not coupled to a Validator
      * (in case of success feedback which is based on a diff or current and previous validation

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -748,7 +748,6 @@ export const ValidateMixinImplementation = superclass =>
      * 'warning', 'info' etc. for Validators with custom types. Needed as a directive for
      * feedbackNode how to render a message of a certain type
      * @property {object} displayOptions
-     * @property {Boolean} [displayOptions.persistent] to overwrite the disappearing of a message
      * @property {Number} displayOptions.duration duration in ms for how long the message should be shown
      * @property {Validator} [validator] when the message is directly coupled to a Validator
      * (in most cases), this property is filled. When a message is not coupled to a Validator
@@ -838,7 +837,7 @@ export const ValidateMixinImplementation = superclass =>
           if (
             messageMap?.[0] &&
             messageMap[0].type === 'success' &&
-            messageMap[0].displayOptions?.persistent !== true
+            messageMap[0].displayOptions?.duration !== Infinity
           ) {
             this.removeMessage = window.setTimeout(() => {
               _feedbackNode.removeAttribute('type');

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -836,6 +836,7 @@ export const ValidateMixinImplementation = superclass =>
           _feedbackNode.feedbackData = messageMap || [];
 
           if (
+            messageMap?.[0] &&
             messageMap[0].type === 'success' &&
             messageMap[0].displayOptions?.persistent !== true
           ) {

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -574,7 +574,7 @@ export const ValidateMixinImplementation = superclass =>
         return [];
       }
 
-      // If empty, do not show the ResulValidation message (e.g. Correct!)
+      // If empty, do not show the ResultValidation message (e.g. Correct!)
       if (this._isEmpty(this.modelValue)) {
         this.__prevShownValidationResult = [];
         return [];
@@ -603,7 +603,7 @@ export const ValidateMixinImplementation = superclass =>
      * - on sync validation
      * - on async validation (can depend on server response)
      *
-     * This method inishes a pass by adding the properties to the instance:
+     * This method finishes a pass by adding the properties to the instance:
      * - validationStates
      * - hasFeedbackFor
      *

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -747,8 +747,7 @@ export const ValidateMixinImplementation = superclass =>
      * @property {string} type will be 'error' for messages from default Validators. Could be
      * 'warning', 'info' etc. for Validators with custom types. Needed as a directive for
      * feedbackNode how to render a message of a certain type
-     * @property {object} displayOptions
-     * @property {Number} displayOptions.duration duration in ms for how long the message should be shown
+     * @property {Number} visibilityDuration duration in ms for how long the message should be shown
      * @property {Validator} [validator] when the message is directly coupled to a Validator
      * (in most cases), this property is filled. When a message is not coupled to a Validator
      * (in case of success feedback which is based on a diff or current and previous validation
@@ -778,7 +777,7 @@ export const ValidateMixinImplementation = superclass =>
             message,
             type: validator.type,
             validator,
-            displayOptions: { duration: 3000, ...validator.config?.displayOptions },
+            visibilityDuration: validator.config?.visibilityDuration || 3000,
           };
         }),
       );
@@ -837,13 +836,13 @@ export const ValidateMixinImplementation = superclass =>
           if (
             messageMap?.[0] &&
             messageMap[0].type === 'success' &&
-            messageMap[0].displayOptions?.duration !== Infinity
+            messageMap[0].visibilityDuration !== Infinity
           ) {
             this.removeMessage = window.setTimeout(() => {
               _feedbackNode.removeAttribute('type');
               /** @type {FeedbackMessage[]} */
               _feedbackNode.feedbackData = [];
-            }, messageMap[0].displayOptions?.duration);
+            }, messageMap[0].visibilityDuration);
           }
         });
       } else {

--- a/packages/ui/components/form-core/src/validate/ValidateMixin.js
+++ b/packages/ui/components/form-core/src/validate/ValidateMixin.js
@@ -747,6 +747,9 @@ export const ValidateMixinImplementation = superclass =>
      * @property {string} type will be 'error' for messages from default Validators. Could be
      * 'warning', 'info' etc. for Validators with custom types. Needed as a directive for
      * feedbackNode how to render a message of a certain type
+     * @property {object} displayOptions
+     * @property {Boolean} [displayOptions.persistent] to overwrite the disappearing of a message
+     * @property {Number} displayOptions.duration duration in ms for how long the message should be shown
      * @property {Validator} [validator] when the message is directly coupled to a Validator
      * (in most cases), this property is filled. When a message is not coupled to a Validator
      * (in case of success feedback which is based on a diff or current and previous validation
@@ -772,7 +775,12 @@ export const ValidateMixinImplementation = superclass =>
             fieldName,
             outcome,
           });
-          return { message, type: validator.type, validator };
+          return {
+            message,
+            type: validator.type,
+            validator,
+            displayOptions: { duration: 3000, ...validator.config?.displayOptions },
+          };
         }),
       );
     }
@@ -793,6 +801,8 @@ export const ValidateMixinImplementation = superclass =>
      * @protected
      */
     _updateFeedbackComponent() {
+      window.clearTimeout(this.removeMessage);
+
       const { _feedbackNode } = this;
       if (!_feedbackNode) {
         return;
@@ -824,6 +834,17 @@ export const ValidateMixinImplementation = superclass =>
 
           const messageMap = await this.__getFeedbackMessages(this.__prioritizedResult);
           _feedbackNode.feedbackData = messageMap || [];
+
+          if (
+            messageMap[0].type === 'success' &&
+            messageMap[0].displayOptions?.persistent !== true
+          ) {
+            this.removeMessage = window.setTimeout(() => {
+              _feedbackNode.removeAttribute('type');
+              /** @type {FeedbackMessage[]} */
+              _feedbackNode.feedbackData = [];
+            }, messageMap[0].displayOptions?.duration);
+          }
         });
       } else {
         this.__feedbackQueue.add(async () => {

--- a/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -403,7 +403,7 @@ export function runValidateMixinFeedbackPart() {
             new MinLength(3),
             new DefaultSuccess(null, {
               getMessage: () => 'This is a success message',
-              displayOptions: { duration: 6000 },
+              visibilityDuration: 6000,
             }),
           ]}
         >${lightDom}</${elTag}>
@@ -443,7 +443,7 @@ export function runValidateMixinFeedbackPart() {
             new MinLength(3),
             new DefaultSuccess(null, {
               getMessage: () => 'This is a success message',
-              displayOptions: { duration: Infinity },
+              visibilityDuration: Infinity,
             }),
           ]}
         >${lightDom}</${elTag}>

--- a/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -349,6 +349,125 @@ export function runValidateMixinFeedbackPart() {
       expect(_feedbackNode.feedbackData?.[0].message).to.equal('Nachricht für MinLength');
     });
 
+    it('shows success message and clears after 3s', async () => {
+      class ValidateElementCustomTypes extends ValidateMixin(LitElement) {
+        static get validationTypes() {
+          return ['error', 'success'];
+        }
+      }
+      const clock = sinon.useFakeTimers();
+      const elTagString = defineCE(ValidateElementCustomTypes);
+      const elTag = unsafeStatic(elTagString);
+      const el = /** @type {ValidateElementCustomTypes} */ (
+        await fixture(html`
+        <${elTag}
+          .submitted=${true}
+          .validators=${[
+            new MinLength(3),
+            new DefaultSuccess(null, { getMessage: () => 'This is a success message' }),
+          ]}
+        >${lightDom}</${elTag}>
+      `)
+      );
+      const { _feedbackNode } = getFormControlMembers(el);
+
+      el.modelValue = 'a';
+      await el.updateComplete;
+      await el.feedbackComplete;
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('Message for MinLength');
+
+      el.modelValue = 'abcd';
+      await el.updateComplete;
+      await el.feedbackComplete;
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(2900);
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(200);
+      expect(_feedbackNode.feedbackData).to.be.empty;
+    });
+
+    it('shows success message and clears after configured time', async () => {
+      class ValidateElementCustomTypes extends ValidateMixin(LitElement) {
+        static get validationTypes() {
+          return ['error', 'success'];
+        }
+      }
+      const clock = sinon.useFakeTimers();
+      const elTagString = defineCE(ValidateElementCustomTypes);
+      const elTag = unsafeStatic(elTagString);
+      const el = /** @type {ValidateElementCustomTypes} */ (
+        await fixture(html`
+        <${elTag}
+          .submitted=${true}
+          .validators=${[
+            new MinLength(3),
+            new DefaultSuccess(null, {
+              getMessage: () => 'This is a success message',
+              displayOptions: { duration: 6000 },
+            }),
+          ]}
+        >${lightDom}</${elTag}>
+      `)
+      );
+      const { _feedbackNode } = getFormControlMembers(el);
+
+      el.modelValue = 'a';
+      await el.updateComplete;
+      await el.feedbackComplete;
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('Message for MinLength');
+
+      el.modelValue = 'abcd';
+      await el.updateComplete;
+      await el.feedbackComplete;
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(5900);
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(200);
+      expect(_feedbackNode.feedbackData).to.be.empty;
+    });
+
+    it('shows success message and stays persistent', async () => {
+      class ValidateElementCustomTypes extends ValidateMixin(LitElement) {
+        static get validationTypes() {
+          return ['error', 'success'];
+        }
+      }
+      const clock = sinon.useFakeTimers();
+      const elTagString = defineCE(ValidateElementCustomTypes);
+      const elTag = unsafeStatic(elTagString);
+      const el = /** @type {ValidateElementCustomTypes} */ (
+        await fixture(html`
+        <${elTag}
+          .submitted=${true}
+          .validators=${[
+            new MinLength(3),
+            new DefaultSuccess(null, {
+              getMessage: () => 'This is a success message',
+              displayOptions: { persistent: true },
+            }),
+          ]}
+        >${lightDom}</${elTag}>
+      `)
+      );
+      const { _feedbackNode } = getFormControlMembers(el);
+
+      el.modelValue = 'a';
+      await el.updateComplete;
+      await el.feedbackComplete;
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('Message for MinLength');
+
+      el.modelValue = 'abcd';
+      await el.updateComplete;
+      await el.feedbackComplete;
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(2900);
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(200);
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+      clock.tick(20000);
+      expect(_feedbackNode.feedbackData?.[0].message).to.equal('This is a success message');
+    });
+
     it('shows success message after fixing an error', async () => {
       class ValidateElementCustomTypes extends ValidateMixin(LitElement) {
         static get validationTypes() {

--- a/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
+++ b/packages/ui/components/form-core/test-suites/ValidateMixinFeedbackPart.suite.js
@@ -443,7 +443,7 @@ export function runValidateMixinFeedbackPart() {
             new MinLength(3),
             new DefaultSuccess(null, {
               getMessage: () => 'This is a success message',
-              displayOptions: { persistent: true },
+              displayOptions: { duration: Infinity },
             }),
           ]}
         >${lightDom}</${elTag}>

--- a/packages/ui/components/form-core/test/validate/lion-validation-feedback.test.js
+++ b/packages/ui/components/form-core/test/validate/lion-validation-feedback.test.js
@@ -33,28 +33,6 @@ describe('lion-validation-feedback', () => {
     expect(el.getAttribute('type')).to.equal('warning');
   });
 
-  it('success message clears after 3s', async () => {
-    const el = /** @type {LionValidationFeedback} */ (
-      await fixture(html`<lion-validation-feedback></lion-validation-feedback>`)
-    );
-
-    const clock = sinon.useFakeTimers();
-
-    el.feedbackData = [{ message: 'hello', type: 'success', validator: new AlwaysValid() }];
-    await el.updateComplete;
-    expect(el.getAttribute('type')).to.equal('success');
-
-    clock.tick(2900);
-
-    expect(el.getAttribute('type')).to.equal('success');
-
-    clock.tick(200);
-
-    expect(el).to.not.have.attribute('type');
-
-    clock.restore();
-  });
-
   it('does not clear error messages', async () => {
     const el = /** @type {LionValidationFeedback} */ (
       await fixture(html`<lion-validation-feedback></lion-validation-feedback>`)

--- a/packages/ui/components/form-core/types/validate/validate.ts
+++ b/packages/ui/components/form-core/types/validate/validate.ts
@@ -31,6 +31,10 @@ export type ValidatorConfig = {
   type?: ValidationType;
   node?: FormControlHost;
   fieldName?: string | Promise<string>;
+  displayOptions?: {
+    duration?: number;
+    persistent?: boolean;
+  };
 };
 
 /**

--- a/packages/ui/components/form-core/types/validate/validate.ts
+++ b/packages/ui/components/form-core/types/validate/validate.ts
@@ -33,7 +33,6 @@ export type ValidatorConfig = {
   fieldName?: string | Promise<string>;
   displayOptions?: {
     duration?: number;
-    persistent?: boolean;
   };
 };
 

--- a/packages/ui/components/form-core/types/validate/validate.ts
+++ b/packages/ui/components/form-core/types/validate/validate.ts
@@ -31,9 +31,7 @@ export type ValidatorConfig = {
   type?: ValidationType;
   node?: FormControlHost;
   fieldName?: string | Promise<string>;
-  displayOptions?: {
-    duration?: number;
-  };
+  visibilityDuration?: number;
 };
 
 /**


### PR DESCRIPTION
## What I did

1. added the option to keep the `success` type validator persistent on screen
2. moved the removal of the success message from the `LionValidateFeedback` into the `ValidateMixin`, per a TODO. 
3. added the option to configure the duration of the success message on screen, per a TODO
4. added documentation on the `success` type 
5. fixed small typos 
 