### PR TITLE
feat(input-file): add wildcards support for file types declared using the accept attribute

### DIFF
--- a/.changeset/pretty-jeans-train.md
+++ b/.changeset/pretty-jeans-train.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+feat(input-file): add wildcards support for file types declared using the accept attribute

--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,5 @@ patches/
 /docs/_assets/scoped-custom-element-registry.min.js
 /docs/_assets/scoped-custom-element-registry.min.js.map
 /docs/_merged_assets/scoped-custom-element-registry.min.js
+
+/packages/ui/components/core/src/mime-types.js

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ yarn-error.log
 /build/
 /bundlesize/dist/
 **/custom-elements.json
+packages/ui/components/core/src/mime-types.js
 dist
 dist-types
 *.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -4147,6 +4147,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.4.0.tgz",
       "integrity": "sha512-Sj7gKl1TLcDbF7B6KUhtvr+1UCxdhMbNY5KxdU5IfMFWqL8oy1ZeAcCANjoB1TL0AJTcPmcCFsCbHf8X2jGDUA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@open-wc/eslint-config": {
@@ -4195,6 +4196,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.5.tgz",
       "integrity": "sha512-q4U+hFTQQRyorJILOpmBm6PY2hgjCnQe214nXJNjbJMQ9EvT55oyZ7C8BY5aFYJkytUyBoawlMpZt4F2xjdzHw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@open-wc/dedupe-mixin": "^1.4.0",
@@ -19660,6 +19662,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/mock-fs": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
+      "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/moo": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
@@ -28763,15 +28775,6 @@
         "node": ">=16.14"
       }
     },
-    "packages-node/providence-analytics/node_modules/mock-fs": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.4.1.tgz",
-      "integrity": "sha512-sz/Q8K1gXXXHR+qr0GZg2ysxCRr323kuN10O7CtQjraJsFDJ4SJ+0I5MzALz7aRp9lHk8Cc/YdsT95h9Ka1aFw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "packages-node/providence-analytics/node_modules/oxc-parser": {
       "version": "0.48.0",
       "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.48.0.tgz",
@@ -28965,24 +28968,53 @@
     },
     "packages/ui": {
       "name": "@lion/ui",
-      "version": "0.11.6",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@bundled-es-modules/message-format": "^6.2.4",
-        "@open-wc/dedupe-mixin": "^1.4.0",
-        "@open-wc/scoped-elements": "^3.0.5",
+        "@open-wc/dedupe-mixin": "^2.0.1",
+        "@open-wc/scoped-elements": "^3.0.6",
         "@popperjs/core": "^2.11.8",
         "autosize": "^6.0.0",
         "awesome-phonenumber": "^6.4.0",
         "ibantools": "^4.3.9",
         "lit": "^3.1.2",
         "singleton-manager": "^1.7.0"
+      },
+      "devDependencies": {
+        "mime-db": "^1.54.0"
       }
     },
     "packages/ui/node_modules/@bundled-es-modules/message-format": {
       "version": "6.2.4",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/message-format/-/message-format-6.2.4.tgz",
       "integrity": "sha512-NBaIEUCzSjLZjrsmSOh8PJLqQjSpXVuekIOuUT8tt4N/FdtAavWsC1YinIqIrbRnkBqV90OxgKzsxhFCzETQBw=="
+    },
+    "packages/ui/node_modules/@open-wc/dedupe-mixin": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-2.0.1.tgz",
+      "integrity": "sha512-+R4VxvceUxHAUJXJQipkkoV9fy10vNo+OnUnGKZnVmcwxMl460KLzytnUM4S35SI073R0yZQp9ra0MbPUwVcEA==",
+      "license": "MIT"
+    },
+    "packages/ui/node_modules/@open-wc/scoped-elements": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@open-wc/scoped-elements/-/scoped-elements-3.0.6.tgz",
+      "integrity": "sha512-w1ayJaUUmBw8tALtqQ6cBueld+op+bufujzbrOdH0uCTXnSQkONYZzOH+9jyQ8auVgKLqcxZ8oU6SzfqQhQkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@open-wc/dedupe-mixin": "^2.0.0",
+        "lit": "^3.0.0"
+      }
+    },
+    "packages/ui/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "format": "npm run format:eslint && npm run format:prettier",
     "format:eslint": "eslint --ext .js,.html . --fix",
     "format:prettier": "prettier \"**/*.{js,md}\" \"packages/*/package.json\" \"package.json\" --write",
-    "postinstall": "npx patch-package && npm run custom-elements-manifest",
+    "postinstall": "npx patch-package && npm run custom-elements-manifest && npm run generate-mime-types",
     "lint": "run-p lint:*",
     "lint:eslint": "eslint --ext .js,.html .",
     "lint:markdownlint": "git ls-files '*.md' | xargs markdownlint --ignore '{.github/**/*.md,.changeset/*.md,**/CHANGELOG.md,packages/ui/_legacy-changelogs/*.md}'",

--- a/packages/ui/components/input-file/test/lion-input-file.test.js
+++ b/packages/ui/components/input-file/test/lion-input-file.test.js
@@ -698,6 +698,43 @@ describe('lion-input-file', () => {
     });
   });
 
+  it('should be able to add any image, video or audio file', async () => {
+    const videoFile = /** @type {InputFile} */ (
+      new File(['file'], 'file.mp4', {
+        type: 'video/mp4',
+      })
+    );
+
+    const audioFile = /** @type {InputFile} */ (
+      new File(['file'], 'file.mp3', {
+        type: 'audio/mp3',
+      })
+    );
+
+    const imageFile = /** @type {InputFile} */ (
+      new File(['file'], 'file.png', {
+        type: 'image/png',
+      })
+    );
+
+    const el = await fixture(html`
+      <lion-input-file multiple accept="image/*, AUDIO/*, video/*"></lion-input-file>
+    `);
+
+    setTimeout(() => {
+      mimicSelectFile(el, [imageFile, audioFile, videoFile]);
+    });
+
+    const fileListChangedEvent = await oneEvent(el, 'file-list-changed');
+    // @ts-expect-error [allow-protected-in-test]
+    expect(el._selectedFilesMetaData.length).to.equal(3);
+    expect(fileListChangedEvent).to.exist;
+    expect(fileListChangedEvent.detail.newFiles.length).to.equal(3);
+    expect(fileListChangedEvent.detail.newFiles[0].name).to.equal('file.png');
+    expect(fileListChangedEvent.detail.newFiles[1].name).to.equal('file.mp3');
+    expect(fileListChangedEvent.detail.newFiles[2].name).to.equal('file.mp4');
+  });
+
   describe('status and error', () => {
     /**
      * @type {LionInputFile}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,7 +47,8 @@
     "debug:firefox": "cd ../../ && npm run debug:firefox",
     "debug:webkit": "cd ../../ && npm run debug:webkit",
     "generate-lion-exports": "node ./scripts/generate-lion-exports.js",
-    "prepublishOnly": "npm run types && npm run create-npm-publish-docs && npm run publish-docs && npm run custom-elements-manifest && npm run generate-lion-exports",
+    "generate-mime-types": "node ./scripts/generate-mime-types.js",
+    "prepublishOnly": "npm run types && npm run create-npm-publish-docs && npm run publish-docs && npm run custom-elements-manifest && npm run generate-mime-types && npm run generate-lion-exports",
     "publish-docs": "node ../../packages-node/publish-docs/src/cli.js --github-url https://github.com/ing-bank/lion/ --git-root-dir ../../",
     "test": "cd ../../ && npm run test:browser",
     "types": "wireit",
@@ -71,6 +72,9 @@
     "ibantools": "^4.3.9",
     "lit": "^3.1.2",
     "singleton-manager": "^1.7.0"
+  },
+  "devDependencies": {
+    "mime-db": "^1.54.0"
   },
   "keywords": [
     "design-system",

--- a/packages/ui/scripts/generate-mime-types.js
+++ b/packages/ui/scripts/generate-mime-types.js
@@ -1,0 +1,30 @@
+import fs from 'fs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import db from 'mime-db';
+
+function generateMimeTypes() {
+  const mimeTypes = {
+    'image/*': [],
+    'audio/*': [],
+    'video/*': [],
+  };
+
+  for (const type of Object.keys(db)) {
+    if (type.startsWith('image/')) {
+      mimeTypes['image/*'].push(type);
+    } else if (type.startsWith('audio/')) {
+      mimeTypes['audio/*'].push(type);
+    } else if (type.startsWith('video/')) {
+      mimeTypes['video/*'].push(type);
+    }
+  }
+
+  const content = `
+    /** @type {Record<string, string[]>} */
+    export const mimeTypes = ${JSON.stringify(mimeTypes, null, 2)};
+`;
+
+  fs.writeFileSync('./components/core/src/mime-types.js', content);
+}
+
+generateMimeTypes();


### PR DESCRIPTION
## What is this PR for?
This PR adds support for wildcards (e.g., image/* , video/* , audio/*) in the accept attribute of the input file component.

To implement this, I created a script that uses the [mime-db](https://github.com/jshttp/mime-db) npm package to generate an object where:

Keys are the wildcard MIME types (image/* , video/* , audio/*)

Values are arrays of specific MIME types that fall under each category

This object is then used in the LionInputFileJs component to enhance its functionality.

## Is this breaking?
No. This change is backward-compatible and does not affect the existing workflow. It only adds new functionality.

## What problem does this solve?
Closes #2469.