### PR TITLE
chore: ignore portal build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,13 @@ __output
 packages/ui/new-exports/
 packages/ui/test-exports/
 
+## Astro
+
 src/content/docs
+src/pages/**/_demos/
+
+## Rocket ignore files (need to be the full relative path to the folders)
+docs/_merged_data/
+docs/_merged_assets/
+docs/_merged_includes/
+docs/**/api-table.md


### PR DESCRIPTION
Bring back .gitignore entries that got lost