### PR TITLE
Fix wrong property in docs

### DIFF
--- a/docs/components/dialog/use-cases.md
+++ b/docs/components/dialog/use-cases.md
@@ -162,7 +162,7 @@ No backdrop, hides on escape, prevents scrolling while opened, and focuses the b
 export const otherOverrides = () => {
   const cfg = {
     hasBackdrop: false,
-    hidesOnEscape: true,
+    hidesOnEsc: true,
     preventsScroll: true,
     elementToFocusAfterHide: document.body,
   };
@@ -192,7 +192,7 @@ Configuration passed to `config` property:
 ```js
 {
   hasBackdrop: false,
-  hidesOnEscape: true,
+  hidesOnEsc: true,
   preventsScroll: true,
   elementToFocusAfterHide: document.body
 }


### PR DESCRIPTION
## What I did

1. I changed `hidesOnEscape` to `hidesOnEsc` in the docs - now, you can't close the overlay with escape if you set this property to false
