### PR TITLE
fix: fixed a deployment of Astro to GH pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug:no-scoped-registries-polyfill": "npm run debug -- --no-scoped-registries-polyfill",
     "debug:webkit": "web-test-runner --watch --config web-test-runner-webkit.config.mjs",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d _site -r git@github.com:ing-bank/lion",
+    "deploy": "gh-pages -d _site -r git@github.com:ing-bank/lion --nojekyll",
     "dev": "astro dev --force",
     "format": "npm run format:eslint && npm run format:prettier",
     "format:eslint": "eslint --ext .js,.html . --fix",


### PR DESCRIPTION
## What I did

1. Fixed a deployment of Astro to GitHub pages (https://github.blog/news-insights/the-library/bypassing-jekyll-on-github-pages/)
