### PR TITLE
chore: add CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+lion.js.org

--- a/rocket.config.mjs
+++ b/rocket.config.mjs
@@ -32,6 +32,7 @@ export default {
   presets: [rocketLaunch(), rocketBlog()],
   eleventy(eleventyConfig) {
     eleventyConfig.setUseGitIgnore(false);
+    eleventyConfig.addPassthroughCopy('CNAME');
   },
   absoluteBaseUrl: absoluteBaseUrlNetlify('http://localhost:8080'),
   setupUnifiedPlugins: [


### PR DESCRIPTION
## What I did

1. add CNAME file and use [eleventy passthrough copy](https://www.11ty.dev/docs/copy/) to the output files

Not sure if there's a better way to do it in our setup, but this fixes the [custom domain being reset on deploy](https://github.com/orgs/community/discussions/22366).
