### PR TITLE
chore: prep Astro cname (for removal of rocket)

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+lion.js.org


### PR DESCRIPTION
## What I did

1. add cname to astro's `/public` directory as preparation for the removal of the rocket site
