### PR TITLE
docs(radio/checkbox): replace demo links with <strong> labels

### DIFF
--- a/docs/components/checkbox-group/use-cases.md
+++ b/docs/components/checkbox-group/use-cases.md
@@ -81,19 +81,13 @@ You can use `slot="label"` instead of the `label` attribute for defining more co
 ```html preview-story
 <lion-checkbox-group name="scientists[]" label="Favorite scientists">
   <lion-checkbox .choiceValue="${'Archimedes'}">
-    <label slot="label"
-      ><a href="https://wikipedia.org/wiki/Archimedes" target="_blank">Archimedes</a></label
-    >
+    <label slot="label"><strong>Archimedes</strong></label>
   </lion-checkbox>
   <lion-checkbox .choiceValue="${'Francis Bacon'}">
-    <label slot="label"
-      ><a href="https://wikipedia.org/wiki/Francis_Bacon" target="_blank">Francis Bacon</a></label
-    >
+    <label slot="label"><strong>Francis Bacon</strong></label>
   </lion-checkbox>
   <lion-checkbox .choiceValue="${'Marie Curie'}">
-    <label slot="label"
-      ><a href="https://wikipedia.org/wiki/Marie_Curie" target="_blank">Marie Curie</a></label
-    >
+    <label slot="label"><strong>Marie Curie</strong></label>
   </lion-checkbox>
 </lion-checkbox-group>
 ```

--- a/docs/components/radio-group/use-cases.md
+++ b/docs/components/radio-group/use-cases.md
@@ -86,19 +86,13 @@ You can use `slot="label"` instead of the `label` attribute for defining more co
 export const label = () => html`
   <lion-radio-group name="dinos_7" label="Favourite dinosaur">
     <lion-radio .choiceValue="${'allosaurus'}">
-      <label slot="label"
-        ><a href="https://wikipedia.org/wiki/allosaurus" target="_blank">allosaurus</a></label
-      >
+      <label slot="label"><strong>allosaurus</strong></label>
     </lion-radio>
     <lion-radio .choiceValue="${'brontosaurus'}">
-      <label slot="label"
-        ><a href="https://wikipedia.org/wiki/brontosaurus" target="_blank">brontosaurus</a></label
-      >
+      <label slot="label"><strong>brontosaurus</strong></label>
     </lion-radio>
     <lion-radio .choiceValue="${'diplodocus'}">
-      <label slot="label"
-        ><a href="https://wikipedia.org/wiki/diplodocus" target="_blank">diplodocus</a></label
-      >
+      <label slot="label"><strong>diplodocus</strong></label>
     </lion-radio>
   </lion-radio-group>
 `;


### PR DESCRIPTION
##What I did
1. Replaced demo anchor links with bold text in label slots:

  lion/docs/components/checkbox-group/use-cases.md

  lion/docs/components/radio-group/use-cases.md

2. Updated examples to use `<label slot="label"><strong>…</strong></label>` so demos show realistic labels instead of external URLs.

3. Kept the examples behavior unchanged — this is a docs-only change.