### PR TITLE
feat(icon): add support for any type of slotted element

### DIFF
--- a/.changeset/short-spiders-lick.md
+++ b/.changeset/short-spiders-lick.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+feat(icon): add support for any type of slotted element

--- a/packages/ui/components/icon/src/LionIcon.js
+++ b/packages/ui/components/icon/src/LionIcon.js
@@ -84,7 +84,7 @@ export class LionIcon extends LitElement {
           margin-right: 0;
         }
 
-        ::slotted(svg) {
+        ::slotted(*) {
           display: block;
           width: 100%;
           height: 100%;


### PR DESCRIPTION
## What I did

1. added support for any type of element as a slotted element within LionIcon
