### PR TITLE
docs: refine orange nutrition description

### DIFF
--- a/docs/components/accordion/overview.md
+++ b/docs/components/accordion/overview.md
@@ -132,10 +132,9 @@ class MyComponent extends ScopedElementsMixin(LitElement) {
     <button>Nutritional value</button>
   </h3>
   <p slot="content">
-    Orange flesh is 87% water, 12% carbohydrates, 1% protein, and contains negligible fat (table).
-    In a 100 gram reference amount, orange flesh provides 47 calories, and is a rich source of
-    vitamin C, providing 64% of the Daily Value. No other micronutrients are present in significant
-    amounts (table).
+   Orange flesh is composed of approximately 87% water, 12% carbohydrates, 1% protein, and contains negligible fat.
+   In a 100-gram serving, orange flesh provides 47 calories and is a rich source of vitamin C, supplying about 64% of the Daily Value.
+   No other micronutrients are present in significant amounts.
   </p>
 </lion-accordion>
 ```


### PR DESCRIPTION
## What I did
•	Improved the wording and readability of the orange nutrition description.
•	Removed unnecessary table references.
•	Clarified serving size and nutritional values for better consistency.
•	Preserved the original nutritional accuracy while enhancing clarity.