### PR TITLE
fix(tests): increase timeout for OverlayController test to improve stability

### DIFF
--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -800,7 +800,7 @@ describe('OverlayController', () => {
           await mimicEscapePress(childOverlay.contentNode);
 
           // without this line, the test is unstable on FF sometimes
-          await aTimeout(0);
+          await aTimeout(20);
 
           expect(parentOverlay.isShown).to.be.false;
           expect(childOverlay.isShown).to.be.true;


### PR DESCRIPTION
Refs: #2631

1. Increased the timeout in the `OverlayController` test from 0ms to 20ms to address intermittent instability in Firefox.

