### PR TITLE
fix: allow pasting value with currency for input-amount

### DIFF
--- a/.changeset/slow-houses-notice.md
+++ b/.changeset/slow-houses-notice.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[input-amount] allow pasting value with currency correctly

--- a/packages/ui/components/input-amount/src/parsers.js
+++ b/packages/ui/components/input-amount/src/parsers.js
@@ -31,14 +31,15 @@ function round(value, decimals) {
  * @param {FormatNumberOptions} [givenOptions] Locale Options
  */
 export function parseAmount(value, givenOptions) {
-  const unmatchedInput = value.match(/[^0-9,.\-\u2212 ]/g);
+  const trimmedValue = value.trim();
+  const unmatchedInput = trimmedValue.match(/[^0-9,.\-\u2212 ]/g);
   // for the full paste behavior documentation:
   // ./docs/components/input-amount/use-cases.md#paste-behavior
   if (unmatchedInput && givenOptions?.mode !== 'pasted') {
     return undefined;
   }
 
-  const number = parseNumber(value, givenOptions);
+  const number = parseNumber(trimmedValue, givenOptions);
 
   if (typeof number !== 'number' || Number.isNaN(number)) {
     return undefined;

--- a/packages/ui/components/input-amount/test/parsers.test.js
+++ b/packages/ui/components/input-amount/test/parsers.test.js
@@ -61,6 +61,12 @@ describe('parseAmount()', async () => {
     expect(parseAmount('EUR 1,50', { mode: 'pasted' })).to.equal(1.5);
   });
 
+  it('trim spaces when "pasted" mode used', async () => {
+    // Use case: there is a cell in Excel which is formatted as Accounting, Currency: Zl, Decimal 2
+    // and the whole cell is copied
+    expect(parseAmount(' 1,00 zł ', { mode: 'pasted' })).to.equal(1);
+  });
+
   it('parses based on locale when "user-edited" mode used combined with viewValueStates "formatted"', async () => {
     expect(parseAmount('123,456.78', { mode: 'auto' })).to.equal(123456.78);
     expect(


### PR DESCRIPTION
Before the fix when there is a cell in Excel which is formatted as Accounting, Currency: Zl, Decimal 2 and the whole cell is copied/pasted, the input-amount shows `100`. After the fix the displayed value is `1` as expected