### PR TITLE
chore: expose missing types in core and form-core modules

### DIFF
--- a/packages/ui/exports/core.js
+++ b/packages/ui/exports/core.js
@@ -5,3 +5,9 @@ export { SlotMixin } from '../components/core/src/SlotMixin.js';
 export { browserDetection } from '../components/core/src/browserDetection.js';
 export { EventTargetShim } from '../components/core/src/EventTargetShim.js';
 export { uuid } from '../components/core/src/uuid.js';
+
+/**
+ * Re-export types for JavaScript/JSDoc and TypeScript consumers.
+ * Allows importing types from the same path as runtime exports.
+ * @typedef {import('../components/core/types/SlotMixinTypes.js').SlotHost} SlotHost
+ */

--- a/packages/ui/exports/form-core.js
+++ b/packages/ui/exports/form-core.js
@@ -51,3 +51,10 @@ export { ChoiceGroupMixin } from '../components/form-core/src/choice-group/Choic
 export { ChoiceInputMixin } from '../components/form-core/src/choice-group/ChoiceInputMixin.js';
 
 export { FormGroupMixin } from '../components/form-core/src/form-group/FormGroupMixin.js';
+
+/**
+ * Re-export types for JavaScript/JSDoc and TypeScript consumers.
+ * Allows importing types from the same path as runtime exports.
+ * @typedef {import('../components/form-core/types/FormControlMixinTypes.js').FormControlHost} FormControlHost
+ * @typedef {import('../components/form-core/types/validate/ValidateMixinTypes.js').ValidateHost} ValidateHost
+ */

--- a/packages/ui/exports/input-tel-dropdown.js
+++ b/packages/ui/exports/input-tel-dropdown.js
@@ -1,2 +1,9 @@
 export { getFlagSymbol } from '../components/input-tel-dropdown/src/getFlagSymbol.js';
 export { LionInputTelDropdown } from '../components/input-tel-dropdown/src/LionInputTelDropdown.js';
+
+/**
+ * Re-export types for JavaScript/JSDoc and TypeScript consumers.
+ * Allows importing types from the same path as runtime exports.
+ * @typedef {import('../components/input-tel-dropdown/types/index.js').RegionMeta} RegionMeta
+ * @typedef {import('../components/input-tel-dropdown/types/index.js').TemplateDataForDropdownInputTel} TemplateDataForDropdownInputTel
+ */

--- a/packages/ui/exports/input-tel.js
+++ b/packages/ui/exports/input-tel.js
@@ -3,3 +3,9 @@ export { LionInputTel } from '../components/input-tel/src/LionInputTel.js';
 export { PhoneNumber } from '../components/input-tel/src/validators.js';
 export { PhoneUtilManager } from '../components/input-tel/src/PhoneUtilManager.js';
 export { liveFormatPhoneNumber } from '../components/input-tel/src/preprocessors.js';
+
+/**
+ * Re-export types for JavaScript/JSDoc and TypeScript consumers.
+ * Allows importing types from the same path as runtime exports.
+ * @typedef {import('../components/input-tel/types/index.js').RegionCode} RegionCode
+ */

--- a/packages/ui/exports/localize.js
+++ b/packages/ui/exports/localize.js
@@ -19,3 +19,19 @@ export { parseNumber } from '../components/localize/src/number/parseNumber.js';
 export { getLocale } from '../components/localize/src/utils/getLocale.js';
 
 export { localize } from '../components/localize/src/singleton.js';
+
+/**
+ * Re-export types for JavaScript/JSDoc and TypeScript consumers.
+ * These are type-only exports that don't exist at runtime.
+ * Allows importing types from the same path as runtime exports.
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').LocalizeMixinHost} LocalizeMixinHost
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').FormatNumberOptions} FormatNumberOptions
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').FormatDateOptions} FormatDateOptions
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').FormatNumberPart} FormatNumberPart
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').DatePostProcessor} DatePostProcessor
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').NumberPostProcessor} NumberPostProcessor
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').msgOptions} msgOptions
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').msgVariables} msgVariables
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').NamespaceObject} NamespaceObject
+ * @typedef {import('../components/localize/types/LocalizeMixinTypes.js').StringToFunctionMap} StringToFunctionMap
+ */

--- a/packages/ui/exports/overlays.js
+++ b/packages/ui/exports/overlays.js
@@ -20,3 +20,12 @@ export {
 } from '../components/overlays/src/utils/inert-siblings.js';
 
 export { overlays } from '../components/overlays/src/singleton.js';
+
+/**
+ * Re-export types for JavaScript/JSDoc and TypeScript consumers.
+ * Allows importing types from the same path as runtime exports.
+ * @typedef {import('../components/overlays/types/OverlayConfig.js').OverlayConfig} OverlayConfig
+ * @typedef {import('../components/overlays/types/OverlayMixinTypes.js').DefineOverlayConfig} DefineOverlayConfig
+ * @typedef {import('../components/overlays/types/OverlayMixinTypes.js').OverlayHost} OverlayHost
+ * @typedef {import('../components/overlays/types/ArrowMixinTypes.js').ArrowHost} ArrowHost
+ */

--- a/packages/ui/exports/types/core.ts
+++ b/packages/ui/exports/types/core.ts
@@ -1,6 +1,3 @@
-export { DisabledHost } from '../../components/core/types/DisabledMixinTypes.js';
-export { DisabledWithTabIndexHost } from '../../components/core/types/DisabledWithTabIndexMixinTypes.js';
-export { SlotHost } from '../../components/core/types/SlotMixinTypes.js';
-export { SlotsMap } from '../../components/core/types/SlotMixinTypes.js';
-export { SlotFunctionResult } from '../../components/core/types/SlotMixinTypes.js';
-export { SlotRerenderObject } from '../../components/core/types/SlotMixinTypes.js';
+export { DisabledHost, DisabledMixin } from '../../components/core/types/DisabledMixinTypes.js';
+export { DisabledWithTabIndexHost, DisabledWithTabIndexMixin } from '../../components/core/types/DisabledWithTabIndexMixinTypes.js';
+export { SlotHost, SlotMixin, SlotsMap, SlotFunctionResult, SlotRerenderObject } from '../../components/core/types/SlotMixinTypes.js';

--- a/packages/ui/exports/types/form-core.ts
+++ b/packages/ui/exports/types/form-core.ts
@@ -1,22 +1,49 @@
-export { ChoiceGroupHost } from '../../components/form-core/types/choice-group/ChoiceGroupMixinTypes.js';
-export { ChoiceInputHost } from '../../components/form-core/types/choice-group/ChoiceInputMixinTypes.js';
-export { FocusHost } from '../../components/form-core/types/FocusMixinTypes.js';
-export { FormControlHost } from '../../components/form-core/types/FormControlMixinTypes.js';
-export { HTMLElementWithValue } from '../../components/form-core/types/FormControlMixinTypes.js';
-export { FormGroupHost } from '../../components/form-core/types/form-group/FormGroupMixinTypes.js';
-export { FormControl } from '../../components/form-core/types/form-group/FormGroupMixinTypes.js';
-export { FormatHost } from '../../components/form-core/types/FormatMixinTypes.js';
-export { FormatOptions } from '../../components/form-core/types/FormatMixinTypes.js';
-export { InteractionStateHost } from '../../components/form-core/types/InteractionStateMixinTypes.js';
-export { InteractionStates } from '../../components/form-core/types/InteractionStateMixinTypes.js';
-export { NativeTextFieldHost } from '../../components/form-core/types/NativeTextFieldMixinTypes.js';
-export { FormRegisteringHost } from '../../components/form-core/types/registration/FormRegisteringMixinTypes.js';
-export { FormRegistrarHost } from '../../components/form-core/types/registration/FormRegistrarMixinTypes.js';
-export { ElementWithParentFormGroup } from '../../components/form-core/types/registration/FormRegistrarMixinTypes.js';
-export { FormRegistrarPortalHost } from '../../components/form-core/types/registration/FormRegistrarPortalMixinTypes.js';
-export { SyncUpdatableHost } from '../../components/form-core/types/utils/SyncUpdatableMixinTypes.js';
+// Choice Group
+export { ChoiceGroupHost, ChoiceGroupMixin } from '../../components/form-core/types/choice-group/ChoiceGroupMixinTypes.js';
+export { ChoiceInputHost, ChoiceInputMixin, ChoiceInputModelValue, ChoiceInputSerializedValue } from '../../components/form-core/types/choice-group/ChoiceInputMixinTypes.js';
+export { CustomChoiceGroupHost, CustomChoiceGroupMixin } from '../../components/form-core/types/choice-group/CustomChoiceGroupMixinTypes.js';
+
+// Focus
+export { FocusHost, FocusMixin } from '../../components/form-core/types/FocusMixinTypes.js';
+
+// Form Control
+export { FormControlHost, FormControlMixin, HTMLElementWithValue, ModelValueEventDetails } from '../../components/form-core/types/FormControlMixinTypes.js';
+
+// Form Group
+export { FormGroupHost, FormGroupMixin, FormControl } from '../../components/form-core/types/form-group/FormGroupMixinTypes.js';
+
+// Format
+export { FormatHost, FormatMixin, FormatOptions } from '../../components/form-core/types/FormatMixinTypes.js';
+
+// Interaction State
+export { InteractionStateHost, InteractionStateMixin, InteractionStates } from '../../components/form-core/types/InteractionStateMixinTypes.js';
+
+// Native Text Field
+export { NativeTextFieldHost, NativeTextFieldMixin } from '../../components/form-core/types/NativeTextFieldMixinTypes.js';
+
+// Registration
+export { FormRegisteringHost, FormRegisteringMixin } from '../../components/form-core/types/registration/FormRegisteringMixinTypes.js';
+export { FormRegistrarHost, FormRegistrarMixin, ElementWithParentFormGroup } from '../../components/form-core/types/registration/FormRegistrarMixinTypes.js';
+export { FormRegistrarPortalHost, FormRegistrarPortalMixin } from '../../components/form-core/types/registration/FormRegistrarPortalMixinTypes.js';
+
+// Utils
+export { SyncUpdatableHost, SyncUpdatableHostType, SyncUpdatableMixin, SyncUpdatableNamespace } from '../../components/form-core/types/utils/SyncUpdatableMixinTypes.js';
+
+// Validate
 export {
   ValidateHost,
+  ValidateMixin,
   ValidationType,
   FeedbackMessage,
+  OperationMode,
+  ScopedElementsMap,
+  ScopedElementsHost,
 } from '../../components/form-core/types/validate/ValidateMixinTypes.js';
+
+export {
+  ValidatorName,
+  ValidatorParam,
+  ValidatorConfig,
+  ValidatorOutcome,
+  FeedbackMessageData,
+} from '../../components/form-core/types/validate/validate.js';

--- a/packages/ui/exports/types/input-amount-dropdown.ts
+++ b/packages/ui/exports/types/input-amount-dropdown.ts
@@ -1,9 +1,11 @@
 export {
   RegionMeta,
+  OnDropdownChangeEvent,
+  DropdownRef,
   TemplateDataForDropdownInputAmount,
   AmountDropdownModelValue,
   CurrencyCode,
   countryToCurrencyList,
   RegionToCurrencyMap,
-  AllCurrenciesSet
+  AllCurrenciesSet,
 } from '../../components/input-amount-dropdown/types/index.js';

--- a/packages/ui/exports/types/input-file.ts
+++ b/packages/ui/exports/types/input-file.ts
@@ -1,1 +1,1 @@
-export { InputFile, SystemFile } from '../../components/input-file/types/input-file.js'
+export { InputFile, SystemFile, FileBasics, UploadResponse } from '../../components/input-file/types/input-file.js';

--- a/packages/ui/exports/types/input-tel-dropdown.ts
+++ b/packages/ui/exports/types/input-tel-dropdown.ts
@@ -1,2 +1,6 @@
-export { RegionMeta } from '../../components/input-tel-dropdown/types/index.js';
-export { TemplateDataForDropdownInputTel } from '../../components/input-tel-dropdown/types/index.js';
+export {
+  RegionMeta,
+  OnDropdownChangeEvent,
+  DropdownRef,
+  TemplateDataForDropdownInputTel,
+} from '../../components/input-tel-dropdown/types/index.js';

--- a/packages/ui/exports/types/overlays.ts
+++ b/packages/ui/exports/types/overlays.ts
@@ -1,6 +1,3 @@
-export { OverlayConfig } from '../../components/overlays/types/OverlayConfig.js';
-export { ViewportConfig } from '../../components/overlays/types/OverlayConfig.js';
-export { ViewportPlacement } from '../../components/overlays/types/OverlayConfig.js';
-export { DefineOverlayConfig } from '../../components/overlays/types/OverlayMixinTypes.js';
-export { OverlayHost } from '../../components/overlays/types/OverlayMixinTypes.js';
-export { ArrowHost } from '../../components/overlays/types/ArrowMixinTypes.js';
+export { OverlayConfig, ViewportConfig, ViewportPlacement } from '../../components/overlays/types/OverlayConfig.js';
+export { DefineOverlayConfig, OverlayHost, OverlayMixin } from '../../components/overlays/types/OverlayMixinTypes.js';
+export { ArrowHost, ArrowMixin } from '../../components/overlays/types/ArrowMixinTypes.js';


### PR DESCRIPTION
## What I did

1.Rexport missing types
core.d.ts - SlotHost
form-core.d.ts - FormControlHost, ValidateHost
overlays.d.ts - OverlayConfig, DefineOverlayConfig, OverlayHost, ArrowHost
input-tel.d.ts - RegionCode
input-tel-dropdown.d.ts - RegionMeta, TemplateDataForDropdownInputTel
localize.d.ts - FormatNumberOptions, FormatDateOptions, FormatNumberPart, 
