### PR TITLE
Change currency code for Bulgaria from BGN to EUR

### DIFF
--- a/packages/ui/components/input-amount-dropdown/src/currencyUtil.js
+++ b/packages/ui/components/input-amount-dropdown/src/currencyUtil.js
@@ -55,7 +55,7 @@ const countryToCurrencyList = {
   BD: 'BDT',
   BE: 'EUR',
   BF: 'XOF',
-  BG: 'BGN',
+  BG: 'EUR',
   BH: 'BHD',
   BI: 'BIF',
   BJ: 'XOF',


### PR DESCRIPTION
## What I did

This pull request makes a small update to the currency mapping for Bulgaria in the `currencyUtil.js` file. The currency for Bulgaria (`BG`) is now set to Euro (`EUR`) instead of Bulgarian Lev (`BGN`).