### PR TITLE
fix(overlays): fix flaky test

### DIFF
--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -812,8 +812,7 @@ describe('OverlayController', () => {
           const { parentOverlay, childOverlay } = await createNestedEscControllers(parentContent);
           await mimicEscapePress(childOverlay.contentNode);
 
-          // without this line, the test is unstable on FF sometimes
-          await aTimeout(100);
+          await parentOverlay._hideComplete;
 
           expect(parentOverlay.isShown).to.be.false;
           expect(childOverlay.isShown).to.be.true;


### PR DESCRIPTION
## What I did

1. make sure `_hideComplete` has been called, instead of awaiting for a random timeout, as i saw that kept still failing once in a while.

fix again: https://github.com/ing-bank/lion/issues/2631
