### PR TITLE
fix(overlayShadowDomStyle): when reduced animatiopn is not applying a…

### DIFF
--- a/.changeset/smooth-pants-occur.md
+++ b/.changeset/smooth-pants-occur.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(overlayShadowDomStyle): when reduced animatiopn is not applying animation duration properly

--- a/packages/ui/components/overlays/src/overlayShadowDomStyle.js
+++ b/packages/ui/components/overlays/src/overlayShadowDomStyle.js
@@ -113,11 +113,11 @@ export const overlayShadowDomStyle = css`
   }
 
   @media screen and (prefers-reduced-motion: reduce) {
-    .overlays .overlays__backdrop--animation-in {
+    .overlays__backdrop--animation-in {
       animation: overlays-backdrop-fade-in 1ms;
     }
 
-    .overlays .overlays__backdrop--animation-out {
+    .overlays__backdrop--animation-out {
       animation: overlays-backdrop-fade-out 1ms;
     }
   }


### PR DESCRIPTION
## What I did

1. At our visual tests we tried to open a tooltip and we realized that even if we enable reduced animation, we had to wait 300ms for animation finish. Checking styles we found out that is disabling animation under "overlays" parent class which didn´t exist so this reduced animation was not appliying properly
