### PR TITLE
fix(LionInputStepper): prevent click on increase/decrease buttons whe…

### DIFF
--- a/.changeset/yellow-rocks-drum.md
+++ b/.changeset/yellow-rocks-drum.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+fix(LionInputStepper): prevent click on increase/decrease buttons when is readonly

--- a/docs/components/input-stepper/use-cases.md
+++ b/docs/components/input-stepper/use-cases.md
@@ -127,3 +127,29 @@ The value is always aligned with the defined step size when using the increase o
   value="55"
 ></lion-input-stepper>
 ```
+
+### Disabled
+
+`disabled` attribute will be delegated to the native `<input>` to make it disabled.
+
+This field **will not be included** in the parent fieldset or form's `serializedValue`.
+
+```html preview-story
+<lion-input-stepper name="year" disabled value="10">
+  <label slot="label">How old is the existence?</label>
+  <div slot="after" data-description>In Billion Years</div>
+</lion-input-stepper>
+```
+
+### ReadOnly
+
+`readonly` attribute will be delegated to the native `<input>` to make it read-only, and will prevent buttons to increase or decrease value.
+
+This field **will still be included** in the parent fieldset or form's `serializedValue`.
+
+```html preview-story
+<lion-input-stepper name="year" readonly value="10">
+  <label slot="label">How old is the existence?</label>
+  <div slot="after" data-description>In Billion Years</div>
+</lion-input-stepper>
+```

--- a/packages/ui/components/input-stepper/src/LionInputStepper.js
+++ b/packages/ui/components/input-stepper/src/LionInputStepper.js
@@ -1,7 +1,7 @@
-import { html, css, render, nothing } from 'lit';
-import { formatNumber, LocalizeMixin, parseNumber } from '@lion/ui/localize-no-side-effects.js';
+import { IsNumber, MaxNumber, MinNumber } from '@lion/ui/form-core.js';
 import { LionInput } from '@lion/ui/input.js';
-import { IsNumber, MinNumber, MaxNumber } from '@lion/ui/form-core.js';
+import { formatNumber, LocalizeMixin, parseNumber } from '@lion/ui/localize-no-side-effects.js';
+import { css, html, nothing, render } from 'lit';
 import { localizeNamespaceLoader } from './localizeNamespaceLoader.js';
 
 /**
@@ -280,9 +280,14 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
 
   /**
    * Increment the value based on given step or default step value is 1
+   * @param {Event} ev - Click event
    * @protected
    */
-  _increment() {
+  _increment(ev) {
+    if (this.disabled || this.readOnly) {
+      ev?.preventDefault();
+      return;
+    }
     const { step, min, max } = this.values;
     const stepMin = min !== Infinity ? min : 0;
     const epsilon = 1e-10; // Tolerance for floating-point comparison
@@ -309,9 +314,14 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
 
   /**
    * Decrement the value based on given step or default step value is 1
+   * @param {Event} ev - Click event
    * @protected
    */
-  _decrement() {
+  _decrement(ev) {
+    if (this.disabled || this.readOnly) {
+      ev?.preventDefault();
+      return;
+    }
     const { step, max, min } = this.values;
     const stepMin = min !== Infinity ? min : 0;
     const epsilon = 1e-10; // Tolerance for floating-point comparison
@@ -410,7 +420,6 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
   _decrementorTemplate() {
     return html`
       <button
-        ?disabled=${this.disabled || this.readOnly}
         @click=${this._decrement}
         type="button"
         aria-label="${this.msgLit('lion-input-stepper:decrease')} ${this.fieldName}"
@@ -428,7 +437,6 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
   _incrementorTemplate() {
     return html`
       <button
-        ?disabled=${this.disabled || this.readOnly}
         @click=${this._increment}
         type="button"
         aria-label="${this.msgLit('lion-input-stepper:increase')} ${this.fieldName}"

--- a/packages/ui/components/input-stepper/test-suites/lion-input-stepper.suite.js
+++ b/packages/ui/components/input-stepper/test-suites/lion-input-stepper.suite.js
@@ -1,14 +1,14 @@
+import { formatNumber } from '@lion/ui/localize-no-side-effects.js';
 import {
-  expect,
-  defineCE,
   fixture as _fixture,
+  defineCE,
+  expect,
+  html,
   nextFrame,
   unsafeStatic,
-  html,
 } from '@open-wc/testing';
 import { nothing } from 'lit';
 import sinon from 'sinon';
-import { formatNumber } from '@lion/ui/localize-no-side-effects.js';
 import { LionInputStepper } from '../src/LionInputStepper.js';
 
 /**
@@ -28,6 +28,14 @@ export function runInputStepperSuite(klass = LionInputStepper) {
     min="100"
     max="200"
     label="Label"
+  ></${tag}>`;
+  const inputStepperReadOnly = html`<${tag}
+    step="10"
+    min="100"
+    max="200"
+    label="Label"
+    value="1"
+    readonly
   ></${tag}>`;
 
   describe('InputStepper', async () => {
@@ -104,6 +112,22 @@ export function runInputStepperSuite(klass = LionInputStepper) {
     });
 
     describe('User interaction', () => {
+      it('should NOT increment the value to 1 on [ArrowUp] when is readonly', async () => {
+        const el = await fixture(inputStepperReadOnly);
+        expect(el.value).to.equal('1');
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp' }));
+        await el.updateComplete;
+        expect(el.value).to.equal('1');
+      });
+
+      it('should NOT decrement the value to -1 on [ArrowDown] when is readonly', async () => {
+        const el = await fixture(inputStepperReadOnly);
+        expect(el.value).to.equal('1');
+        el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+        await el.updateComplete;
+        expect(el.value).to.equal('1');
+      });
+
       it('should increment the value to 1 on [ArrowUp]', async () => {
         const el = await fixture(defaultInputStepper);
         expect(el.value).to.equal('');


### PR DESCRIPTION
## What I did

1. When LionInputStepper has readonly attribute is still possible to click on increase/decrease buttons at prefix/suffix slots, so you can change the input stepper value even if is a readonly field. This commit prevents click on this scenario.
