### PR TITLE
Add numeric input preprocessor to LionInputStepper

### DIFF
--- a/packages/ui/components/input-stepper/src/LionInputStepper.js
+++ b/packages/ui/components/input-stepper/src/LionInputStepper.js
@@ -96,6 +96,54 @@ export class LionInputStepper extends LocalizeMixin(LionInput) {
 
     this._increment = this._increment.bind(this);
     this._decrement = this._decrement.bind(this);
+    this.preprocessor = LionInputStepper.numericPreprocessor;
+  }
+
+  /**
+   * Static preprocessor that only allows numeric and decimal characters.
+   * Allows digits (0-9), decimal separators (. and ,), and minus sign (-) at the start.
+   * Supports both ASCII hyphen-minus (-) and Unicode minus sign (−).
+   *
+   * Usage: Set `this.preprocessor = LionInputStepper.numericPreprocessor` in your subclass
+   * or instance to enable numeric-only input filtering.
+   *
+   * @param {string} viewValue
+   * @returns {string|undefined}
+   */
+  static numericPreprocessor(viewValue) {
+    if (typeof viewValue !== 'string') {
+      return viewValue;
+    }
+    // Allow digits, decimal separators (. and ,), and minus signs
+    // Unicode minus sign (U+2212) is used by formatNumber for negative numbers
+    const UNICODE_MINUS = '\u2212'; // −
+    const ASCII_MINUS = '-';
+
+    let result = '';
+    let hasDecimalSeparator = false;
+    let hasMinusSign = false;
+
+    for (let i = 0; i < viewValue.length; i += 1) {
+      const char = viewValue[i];
+
+      // Allow minus sign only at the start (both ASCII and Unicode minus)
+      if ((char === ASCII_MINUS || char === UNICODE_MINUS) && i === 0 && !hasMinusSign) {
+        result += char;
+        hasMinusSign = true;
+      }
+      // Allow digits
+      else if (char >= '0' && char <= '9') {
+        result += char;
+      }
+      // Allow only one decimal separator (. or ,)
+      else if ((char === '.' || char === ',') && !hasDecimalSeparator) {
+        result += char;
+        hasDecimalSeparator = true;
+      }
+    }
+
+    // Return undefined if no change to avoid unnecessary updates
+    return result === viewValue ? undefined : result;
   }
 
   connectedCallback() {

--- a/packages/ui/components/input-stepper/test-suites/lion-input-stepper.integration.suite.js
+++ b/packages/ui/components/input-stepper/test-suites/lion-input-stepper.integration.suite.js
@@ -6,7 +6,17 @@ import {
 import { LionInputStepper } from '../src/LionInputStepper.js';
 
 export const runInputStepperIntegrationSuite = (klass = LionInputStepper) => {
-  const tagString = defineCE(class extends klass {});
+  // Create a subclass that disables the numeric preprocessor for integration tests
+  // since the FormatMixin suite uses non-numeric string values like 'test', 'foo', etc.
+  const tagString = defineCE(
+    class extends klass {
+      constructor() {
+        super();
+        // Disable the numeric preprocessor for generic integration tests
+        this.preprocessor = () => undefined;
+      }
+    },
+  );
   runInteractionStateMixinSuite({
     tagString,
     allowedModelValueTypes: [Number],

--- a/packages/ui/components/input-stepper/test-suites/lion-input-stepper.suite.js
+++ b/packages/ui/components/input-stepper/test-suites/lion-input-stepper.suite.js
@@ -9,6 +9,7 @@ import {
 import { nothing } from 'lit';
 import sinon from 'sinon';
 import { formatNumber } from '@lion/ui/localize-no-side-effects.js';
+import { mimicUserInput } from '@lion/ui/form-core-test-helpers.js';
 import { LionInputStepper } from '../src/LionInputStepper.js';
 
 /**
@@ -85,7 +86,7 @@ export function runInputStepperSuite(klass = LionInputStepper) {
           html`<${tag}
             .formatOptions="${{ locale: 'nl-NL', decimalSeparator: '.' }}"
             .modelValue="${12.34}"
-            
+
           ></${tag}>`,
         );
         expect(el.formattedValue).to.equal('12.34');
@@ -96,10 +97,90 @@ export function runInputStepperSuite(klass = LionInputStepper) {
           html`<${tag}
             .formatOptions="${{ locale: 'nl-NL', groupSeparator: ',', decimalSeparator: '.' }}"
             .modelValue="${1234.56}"
-            
+
           ></${tag}>`,
         );
         expect(el.formattedValue).to.equal('1,234.56');
+      });
+    });
+
+    describe('Preprocessor', () => {
+      it('allows numeric digits', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12345');
+        expect(el.value).to.equal('12345');
+      });
+
+      it('filters out alphabetic characters', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12abc34');
+        expect(el.value).to.equal('1234');
+      });
+
+      it('filters out special characters except decimal separators and minus', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12@#$%34');
+        expect(el.value).to.equal('1234');
+      });
+
+      it('allows decimal separator (dot)', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12.34');
+        expect(el.value).to.equal('12.34');
+      });
+
+      it('allows decimal separator (comma)', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12,34');
+        expect(el.value).to.equal('12,34');
+      });
+
+      it('allows only one decimal separator', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12.34.56');
+        expect(el.value).to.equal('12.3456');
+      });
+
+      it('allows only one decimal separator (mixed)', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12.34,56');
+        expect(el.value).to.equal('12.3456');
+      });
+
+      it('allows minus sign at the start', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '-123');
+        expect(el.value).to.equal('-123');
+      });
+
+      it('filters out minus sign in the middle', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '12-34');
+        expect(el.value).to.equal('1234');
+      });
+
+      it('allows only one minus sign at the start', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '--123');
+        expect(el.value).to.equal('-123');
+      });
+
+      it('filters out all invalid characters in a complex input', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '-12abc.34def,56!@#');
+        expect(el.value).to.equal('-12.3456');
+      });
+
+      it('returns empty string when input contains only invalid characters', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, 'abcdef!@#');
+        expect(el.value).to.equal('');
+      });
+
+      it('allows negative decimal numbers', async () => {
+        const el = await fixture(defaultInputStepper);
+        mimicUserInput(el, '-12.34');
+        expect(el.value).to.equal('-12.34');
       });
     });
 
@@ -162,7 +243,7 @@ export function runInputStepperSuite(klass = LionInputStepper) {
               counter += 1;
             }}"
           >
-            
+
           ></${tag}>
         `);
         const incrementButton = el.querySelector('[slot=suffix]');
@@ -180,7 +261,7 @@ export function runInputStepperSuite(klass = LionInputStepper) {
               counter += 1;
             }}"
           >
-            
+
           ></${tag}>
         `);
         const decrementButton = el.querySelector('[slot=prefix]');


### PR DESCRIPTION
- Filters input to allow only digits, decimal separators, and minus sign

## What I did

Added a preprocessor to input stepper that only allows valid numeric input:
- A minus character (ASCII and Unicode so it matches with the integration tests from the parser
- A number for interger part
- A Comma or Dot
- A number for Decimal part

Tests are updated included and I had to deactivate the preprocessor, as FormatMixin tries to enter non-numeric data, and I didn't want to change those at first and I'm not sure how would you prefer to handle these. Let me know and I will fix.