### PR TITLE
Add bottom sheet modifier fallbacks to dropDownConfig

### DIFF
--- a/.changeset/shaggy-brooms-tap.md
+++ b/.changeset/shaggy-brooms-tap.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Correctly position bottom sheet for small screens

--- a/packages/ui/components/overlays/src/configurations/withDropdownConfig.js
+++ b/packages/ui/components/overlays/src/configurations/withDropdownConfig.js
@@ -1,24 +1,4 @@
-import { withClickInteraction } from './visibility-trigger-partials/withClickInteraction.js';
-
-/**
- * @typedef {import('../../types/OverlayConfig.js').OverlayConfig} OverlayConfig
- */
+import { withPopoverConfig } from './withPopoverConfig.js';
 
 export const withDropdownConfig = () =>
-  /** @type {OverlayConfig} */ ({
-    placementMode: 'local',
-    inheritsReferenceWidth: 'min',
-    hidesOnOutsideClick: true,
-    hidesOnEsc: true,
-    popperConfig: {
-      placement: 'bottom-start',
-      modifiers: [
-        {
-          name: 'offset',
-          enabled: false,
-        },
-      ],
-    },
-    handlesAccessibility: true,
-    ...withClickInteraction(),
-  });
+  withPopoverConfig({ horizontalFallback: false, placement: 'bottom-start' });

--- a/packages/ui/components/overlays/src/configurations/withPopoverConfig.js
+++ b/packages/ui/components/overlays/src/configurations/withPopoverConfig.js
@@ -1,0 +1,32 @@
+import { withClickInteraction } from './visibility-trigger-partials/withClickInteraction.js';
+
+/**
+ * @typedef {import('../../types/OverlayConfig.js').OverlayConfig} OverlayConfig
+ */
+
+export const withPopoverConfig = ({ horizontalFallback = true, placement = 'auto' } = {}) =>
+  /** @type {OverlayConfig} */ ({
+    placementMode: 'local',
+    inheritsReferenceWidth: 'min',
+    hidesOnOutsideClick: true,
+    hidesOnEsc: true,
+    popperConfig: {
+      placement,
+      modifiers: [
+        {
+          name: 'offset',
+          enabled: false,
+        },
+        {
+          name: 'flip',
+          options: {
+            fallbackPlacements: horizontalFallback
+              ? ['bottom', 'top', 'right', 'left']
+              : ['bottom', 'top'],
+          },
+        },
+      ],
+    },
+    handlesAccessibility: true,
+    ...withClickInteraction(),
+  });

--- a/packages/ui/exports/overlays.js
+++ b/packages/ui/exports/overlays.js
@@ -8,6 +8,7 @@ export { withBottomSheetConfig } from '../components/overlays/src/configurations
 export { withModalDialogConfig } from '../components/overlays/src/configurations/withModalDialogConfig.js';
 export { withDropdownConfig } from '../components/overlays/src/configurations/withDropdownConfig.js';
 export { withTooltipConfig } from '../components/overlays/src/configurations/withTooltipConfig.js';
+export { withPopoverConfig } from '../components/overlays/src/configurations/withPopoverConfig.js';
 
 export { deepContains } from '../components/overlays/src/utils/deep-contains.js';
 // re-export via this entrypoint for backwards compatibility


### PR DESCRIPTION
## What I did

Add "top" (a flipped bottom) and "right" fallbacks to bottom sheet modifiers.
Handles bottom sheet placement on narrow width and height containers. 
