### PR TITLE
feat: Add custom min/max labels to input range

### DIFF
--- a/.changeset/whole-planes-slide.md
+++ b/.changeset/whole-planes-slide.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Added custom min max labels to input range

--- a/docs/components/input-range/use-cases.md
+++ b/docs/components/input-range/use-cases.md
@@ -60,6 +60,20 @@ import '@lion/ui/define/lion-input-range.js';
 ></lion-input-range>
 ```
 
+## Custom Min Max Labels
+
+```html preview-story
+<lion-input-range
+  min="0"
+  max="11"
+  min-label="less than 1 item"
+  max-label="more than 10 items"
+  .modelValue="${4}"
+  unit="Items"
+  label="Items"
+></lion-input-range>
+```
+
 ## Disabled
 
 ```html preview-story

--- a/packages/ui/components/input-range/src/LionInputRange.js
+++ b/packages/ui/components/input-range/src/LionInputRange.js
@@ -38,6 +38,14 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
         type: Boolean,
         attribute: 'no-min-max-labels',
       },
+      minLabel: {
+        type: String,
+        attribute: 'min-label',
+      },
+      maxLabel: {
+        type: String,
+        attribute: 'max-label',
+      },
     };
   }
 
@@ -84,6 +92,25 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
     return /** @type {HTMLInputElement} */ (super._inputNode);
   }
 
+  /**
+   * Get the display info for the current value
+   * @protected
+   * @returns {{ text: string, showUnit: boolean }}
+   */
+  get _valueDisplay() {
+    const currentValue = parseFloat(/** @type {string} */ (this.formattedValue));
+
+    if (this.minLabel && currentValue === this.min) {
+      return { text: this.minLabel, showUnit: false };
+    }
+
+    if (this.maxLabel && currentValue === this.max) {
+      return { text: this.maxLabel, showUnit: false };
+    }
+
+    return { text: formatNumber(currentValue), showUnit: true };
+  }
+
   constructor() {
     super();
     /** @type {ScopedStylesController} */
@@ -94,6 +121,8 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
     this.unit = '';
     this.type = 'range';
     this.noMinMaxLabels = false;
+    this.minLabel = '';
+    this.maxLabel = '';
     /**
      * @param {string} modelValue
      */
@@ -130,12 +159,12 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
 
   /** @protected */
   _inputGroupTemplate() {
+    const display = this._valueDisplay;
+
     return html`
       <div>
-        <span class="input-range__value"
-          >${formatNumber(parseFloat(/** @type {string} */ (this.formattedValue)))}</span
-        >
-        <span class="input-range__unit">${this.unit}</span>
+        <span class="input-range__value">${display.text}</span>
+        ${display.showUnit ? html`<span class="input-range__unit">${this.unit}</span>` : ''}
       </div>
       <div class="input-group">
         ${this._inputGroupBeforeTemplate()}
@@ -157,12 +186,12 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
           ? html`
               <div class="input-range__limits">
                 <div>
-                  <span class="sr-only">${this.msgLit('lion-input-range:minimum')} </span
-                  >${formatNumber(this.min)}
+                  <span class="sr-only">${this.msgLit('lion-input-range:minimum')} </span>
+                  ${this.minLabel ? this.minLabel : formatNumber(this.min)}
                 </div>
                 <div>
-                  <span class="sr-only">${this.msgLit('lion-input-range:maximum')} </span
-                  >${formatNumber(this.max)}
+                  <span class="sr-only">${this.msgLit('lion-input-range:maximum')} </span>
+                  ${this.maxLabel ? this.maxLabel : formatNumber(this.max)}
                 </div>
               </div>
             `

--- a/packages/ui/components/input-range/src/LionInputRange.js
+++ b/packages/ui/components/input-range/src/LionInputRange.js
@@ -144,6 +144,16 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
     if (changedProperties.has('step')) {
       this._inputNode.step = `${this.step}`;
     }
+
+    if (changedProperties.has('modelValue')) {
+      if (this.minLabel && this.modelValue === this.min) {
+        this._inputNode.setAttribute('aria-valuetext', `${this.minLabel}`);
+      } else if (this.maxLabel && this.modelValue === this.max) {
+        this._inputNode.setAttribute('aria-valuetext', `${this.maxLabel}`);
+      } else {
+        this._inputNode.removeAttribute('aria-valuetext');
+      }
+    }
   }
 
   /** @param {import('lit').PropertyValues } changedProperties */

--- a/packages/ui/components/input-range/src/LionInputRange.js
+++ b/packages/ui/components/input-range/src/LionInputRange.js
@@ -186,12 +186,16 @@ export class LionInputRange extends LocalizeMixin(LionInput) {
           ? html`
               <div class="input-range__limits">
                 <div>
-                  <span class="sr-only">${this.msgLit('lion-input-range:minimum')} </span>
-                  ${this.minLabel ? this.minLabel : formatNumber(this.min)}
+                  <span class="sr-only">${this.msgLit('lion-input-range:minimum')} </span>${this
+                    .minLabel
+                    ? this.minLabel
+                    : formatNumber(this.min)}
                 </div>
                 <div>
-                  <span class="sr-only">${this.msgLit('lion-input-range:maximum')} </span>
-                  ${this.maxLabel ? this.maxLabel : formatNumber(this.max)}
+                  <span class="sr-only">${this.msgLit('lion-input-range:maximum')} </span>${this
+                    .maxLabel
+                    ? this.maxLabel
+                    : formatNumber(this.max)}
                 </div>
               </div>
             `

--- a/packages/ui/components/input-range/test/lion-input-range.test.js
+++ b/packages/ui/components/input-range/test/lion-input-range.test.js
@@ -84,4 +84,76 @@ describe('<lion-input-range>', () => {
     const el = await fixture(`<lion-input-range label="range" disabled></lion-input-range>`);
     await expect(el).to.be.accessible();
   });
+
+  describe('Custom min/max labels', () => {
+    it('displays custom minLabel in the limits when provided', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" min-label="Low" .modelValue=${50}></lion-input-range>
+      `);
+      const minDiv = /** @type {HTMLElement} */ (
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelectorAll('.input-range__limits > div')[0]
+      );
+      expect(minDiv.textContent?.trim()).to.equal('Minimum Low');
+    });
+
+    it('displays custom maxLabel in the limits when provided', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" max-label="High" .modelValue=${50}></lion-input-range>
+      `);
+      const maxDiv = /** @type {HTMLElement} */ (
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelectorAll('.input-range__limits > div')[1]
+      );
+      expect(maxDiv.textContent?.trim()).to.equal('Maximum High');
+    });
+
+    it('displays custom minLabel as value display when value equals min', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" min-label="Low" .modelValue=${0}></lion-input-range>
+      `);
+      const valueSpan = /** @type {HTMLElement} */ (
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelector('.input-range__value')
+      );
+      expect(valueSpan.innerText).to.equal('Low');
+    });
+
+    it('displays custom maxLabel as value display when value equals max', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" max-label="High" .modelValue=${100}></lion-input-range>
+      `);
+      const valueSpan = /** @type {HTMLElement} */ (
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelector('.input-range__value')
+      );
+      expect(valueSpan.innerText).to.equal('High');
+    });
+
+    it('displays formatted number when value is between min and max', async () => {
+      const el = await fixture(html`
+        <lion-input-range
+          min="0"
+          max="100"
+          min-label="Low"
+          max-label="High"
+          .modelValue=${50}
+        ></lion-input-range>
+      `);
+      const valueSpan = /** @type {HTMLElement} */ (
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelector('.input-range__value')
+      );
+      expect(valueSpan.innerText).to.equal('50');
+    });
+
+    it('maintains numeric modelValue even when displaying custom label', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" min-label="Low" .modelValue=${0}></lion-input-range>
+      `);
+      const valueSpan = /** @type {HTMLElement} */ (
+        /** @type {ShadowRoot} */ (el.shadowRoot).querySelector('.input-range__value')
+      );
+      // Display shows custom label
+      expect(valueSpan.innerText).to.equal('Low');
+      // But modelValue is still the number
+      expect(el.modelValue).to.equal(0);
+      expect(typeof el.modelValue).to.equal('number');
+    });
+  });
 });

--- a/packages/ui/components/input-range/test/lion-input-range.test.js
+++ b/packages/ui/components/input-range/test/lion-input-range.test.js
@@ -155,5 +155,47 @@ describe('<lion-input-range>', () => {
       expect(el.modelValue).to.equal(0);
       expect(typeof el.modelValue).to.equal('number');
     });
+
+    it('sets aria-valuetext to minLabel when modelValue equals min', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" min-label="Low" .modelValue=${50}></lion-input-range>
+      `);
+
+      el.modelValue = 0;
+      await nextFrame();
+
+      expect(el._inputNode.getAttribute('aria-valuetext')).to.equal('Low');
+    });
+
+    it('sets aria-valuetext to maxLabel when modelValue equals max', async () => {
+      const el = await fixture(html`
+        <lion-input-range min="0" max="100" max-label="High" .modelValue=${50}></lion-input-range>
+      `);
+
+      el.modelValue = 100;
+      await nextFrame();
+
+      expect(el._inputNode.getAttribute('aria-valuetext')).to.equal('High');
+    });
+
+    it('removes aria-valuetext when modelValue is between min and max', async () => {
+      const el = await fixture(html`
+        <lion-input-range
+          min="0"
+          max="100"
+          min-label="Low"
+          max-label="High"
+          .modelValue=${0}
+        ></lion-input-range>
+      `);
+
+      await nextFrame();
+      expect(el._inputNode.getAttribute('aria-valuetext')).to.equal('Low');
+
+      el.modelValue = 50;
+      await nextFrame();
+
+      expect(el._inputNode.hasAttribute('aria-valuetext')).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
## What I did

1. Added option for input-range to have custom min-max labels. 

<img width="1479" height="676" alt="image" src="https://github.com/user-attachments/assets/0d3a09fe-e459-4e80-8894-adf93c5774f9" />
<img width="1481" height="672" alt="image" src="https://github.com/user-attachments/assets/11111355-8e5c-4b12-aade-fa781f75ad3b" />
<img width="1484" height="671" alt="image" src="https://github.com/user-attachments/assets/62de6f6c-ad73-4686-b401-d073851cd41f" />

