### PR TITLE
Fix/revert overlay mananager

### DIFF
--- a/.changeset/many-waves-change.md
+++ b/.changeset/many-waves-change.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[overlays] bring some previously removed functions to OverlayManager

--- a/packages/ui/components/overlays/src/OverlaysManager.js
+++ b/packages/ui/components/overlays/src/OverlaysManager.js
@@ -86,6 +86,20 @@ export class OverlaysManager {
   }
 
   /**
+   * Bring removed earlier functions back to mitigate the errors like
+   * `disableTrapsKeyboardFocusForAll is not a function` in some older bundled versions of lion.
+   */
+
+  // eslint-disable-next-line class-methods-use-this
+  disableTrapsKeyboardFocusForAll() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  informTrapsKeyboardFocusGotEnabled() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  informTrapsKeyboardFocusGotDisabled() {}
+
+  /**
    * Registers an overlay controller.
    * @param {OverlayController} ctrlToAdd controller of the newly added overlay
    * @returns {OverlayController} same controller after adding to the manager


### PR DESCRIPTION
Some old bundled versions of Lion keeps calling the removed functions. We bring those back but only on the naming level. No actual code is added for those functions