### PR TITLE
Add readonly to switch button

### DIFF
--- a/.changeset/shaggy-brooms-tap.md
+++ b/.changeset/shaggy-brooms-tap.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Correctly position bottom sheet for small screens

--- a/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
+++ b/packages/ui/components/input-datepicker/src/LionInputDatepicker.js
@@ -320,6 +320,15 @@ export class LionInputDatepicker extends ScopedElementsMixin(
         popperConfig: {
           ...super._defineOverlayConfig().popperConfig,
           placement: 'bottom',
+          modifiers: [
+            ...(super._defineOverlayConfig().popperConfig?.modifiers || []),
+            {
+              name: 'flip',
+              options: {
+                fallbackPlacements: ['top', 'right'],
+              },
+            },
+          ],
         },
       };
     }

--- a/packages/ui/components/switch/src/LionSwitchButton.js
+++ b/packages/ui/components/switch/src/LionSwitchButton.js
@@ -13,6 +13,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
         type: Boolean,
         reflect: true,
       },
+      readOnly: { type: Boolean, attribute: 'readonly', reflect: true },
     };
   }
 
@@ -76,7 +77,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
     super();
     // inputNode = this, which always requires a value prop
     this.value = '';
-
+    this.readOnly = false;
     this.checked = false;
     this.__initialized = false;
     /** @protected */
@@ -105,7 +106,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
 
   /** @protected */
   _toggleChecked() {
-    if (this.disabled) {
+    if (this.disabled || this.readOnly) {
       return;
     }
     // Force IE11 to focus the component.
@@ -151,6 +152,9 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
     if (changedProperties.has('disabled')) {
       this.setAttribute('aria-disabled', `${this.disabled}`); // create mixin if we need it in more places
     }
+    if (changedProperties.has('readOnly')) {
+      this.setAttribute('aria-readonly', `${this.readOnly}`);
+    }
   }
 
   /**
@@ -166,7 +170,8 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
       this.isConnected &&
       name === 'checked' &&
       this.checked !== oldValue &&
-      !this.disabled
+      !this.disabled &&
+      !this.readOnly
     ) {
       this.__checkedStateChange();
     }


### PR DESCRIPTION
## What I did

Implement readonly in  LionSwitchButton

This allows for different styling between "disabled" and "readonly".

"disabled" is normally "greyed out" and "readonly" should resemble an active control that is not modifiable (i.e. styling stays the same).
