### PR TITLE
Implement readonly on LionSwitchButton

### DIFF
--- a/.changeset/wild-planes-matter.md
+++ b/.changeset/wild-planes-matter.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Add readonly property to LionSwitchButton

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -35,10 +35,10 @@ jobs:
       - uses: google/wireit@setup-github-actions-caching/v2
       - uses: actions/checkout@v4
 
-      - name: Setup Node 24.x
+      - name: Setup Node 22.x
         uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: 22.x
           cache: npm
 
       - name: Install Dependencies

--- a/packages/ui/components/switch/src/LionSwitchButton.js
+++ b/packages/ui/components/switch/src/LionSwitchButton.js
@@ -13,6 +13,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
         type: Boolean,
         reflect: true,
       },
+      readOnly: { type: Boolean, attribute: 'readonly', reflect: true },
     };
   }
 
@@ -76,7 +77,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
     super();
     // inputNode = this, which always requires a value prop
     this.value = '';
-
+    this.readOnly = false;
     this.checked = false;
     this.__initialized = false;
     /** @protected */
@@ -105,7 +106,7 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
 
   /** @protected */
   _toggleChecked() {
-    if (this.disabled) {
+    if (this.disabled || this.readOnly) {
       return;
     }
     // Force IE11 to focus the component.
@@ -151,6 +152,9 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
     if (changedProperties.has('disabled')) {
       this.setAttribute('aria-disabled', `${this.disabled}`); // create mixin if we need it in more places
     }
+    if (changedProperties.has('readOnly')) {
+      this.setAttribute('aria-readonly', `${this.readOnly}`);
+    }
   }
 
   /**
@@ -166,7 +170,8 @@ export class LionSwitchButton extends DisabledWithTabIndexMixin(LitElement) {
       this.isConnected &&
       name === 'checked' &&
       this.checked !== oldValue &&
-      !this.disabled
+      !this.disabled &&
+      !this.readOnly
     ) {
       this.__checkedStateChange();
     }

--- a/packages/ui/components/switch/test/lion-switch-button.test.js
+++ b/packages/ui/components/switch/test/lion-switch-button.test.js
@@ -78,6 +78,20 @@ describe('lion-switch-button', () => {
     expect(el.hasAttribute('checked')).to.be.true;
   });
 
+  it('can be readonly', async () => {
+    el.readOnly = true;
+    expect(el.checked).to.be.false;
+    el.click();
+    await el.updateComplete;
+    expect(el.checked).to.be.false;
+    expect(el.hasAttribute('checked')).to.be.false;
+    el.checked = true;
+    el.click();
+    await el.updateComplete;
+    expect(el.checked).to.be.true;
+    expect(el.hasAttribute('checked')).to.be.true;
+  });
+
   it('should dispatch "checked-changed" event when toggled', () => {
     const handlerSpy = sinon.spy();
     el.addEventListener('checked-changed', handlerSpy);
@@ -118,9 +132,25 @@ describe('lion-switch-button', () => {
     expect(handlerSpy.called).to.be.false;
   });
 
+  it('should not dispatch "checked-changed" event if readonly', () => {
+    const handlerSpy = sinon.spy();
+    el.readOnly = true;
+    el.addEventListener('checked-changed', handlerSpy);
+    el.click();
+    expect(handlerSpy.called).to.be.false;
+  });
+
   it('should not dispatch "checked-changed" event if disabled on update', () => {
     const handlerSpy = sinon.spy();
     el.disabled = true;
+    el.addEventListener('checked-changed', handlerSpy);
+    el.checked = !el.checked;
+    expect(handlerSpy.called).to.be.false;
+  });
+
+  it('should not dispatch "checked-changed" event if readonly on update', () => {
+    const handlerSpy = sinon.spy();
+    el.readOnly = true;
     el.addEventListener('checked-changed', handlerSpy);
     el.checked = !el.checked;
     expect(handlerSpy.called).to.be.false;
@@ -174,5 +204,13 @@ describe('lion-switch-button', () => {
     el.disabled = false;
     await el.updateComplete;
     expect(el.getAttribute('aria-disabled')).to.equal('false');
+  });
+  it('should manage "aria-readonly"', async () => {
+    el.readOnly = true;
+    await el.updateComplete;
+    expect(el.getAttribute('aria-readonly')).to.equal('true');
+    el.readOnly = false;
+    await el.updateComplete;
+    expect(el.getAttribute('aria-readonly')).to.equal('false');
   });
 });


### PR DESCRIPTION
## What I did

Implement readonly property on LionSwitchButton

## Why

Allows consumers to style "disabled" differently to "readonly".
"disabled" switches can appear greyed out while "readonly" switches can be normally styled but unusable