### PR TITLE
fix: mutating adopted stylesheets breaks in older browsers

### DIFF
--- a/.changeset/itchy-games-clap.md
+++ b/.changeset/itchy-games-clap.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+avoid mutating adopted stylesheets for older browsers that don't support mutation

--- a/packages/ui/components/overlays/src/utils/adopt-styles.js
+++ b/packages/ui/components/overlays/src/utils/adopt-styles.js
@@ -126,7 +126,9 @@ export function adoptStyle(renderRoot, style, { teardown = false } = {}) {
     // eslint-disable-next-line no-param-reassign
     renderRoot.adoptedStyleSheets = [...renderRoot.adoptedStyleSheets, sheet];
   } else if (renderRoot.adoptedStyleSheets.includes(sheet)) {
-    renderRoot.adoptedStyleSheets.splice(renderRoot.adoptedStyleSheets.indexOf(sheet), 1);
+    // @ts-ignore
+    // eslint-disable-next-line no-param-reassign
+    renderRoot.adoptedStyleSheets = renderRoot.adoptedStyleSheets.filter(s => s !== sheet);
   }
 }
 


### PR DESCRIPTION
Adopted stylesheets are not mutable in older browsers. Reference [MDN Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets#browser_compatibility).

Closes [2785](https://github.com/ing-bank/lion/issues/2785)