### PR TITLE
feat(tooltip): support longpress on mobile

### DIFF
--- a/.changeset/real-stars-fix.md
+++ b/.changeset/real-stars-fix.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[tooltip]: support longpress on mobile

--- a/docs/components/tooltip/use-cases.md
+++ b/docs/components/tooltip/use-cases.md
@@ -147,6 +147,28 @@ Modifier explanations:
 - flip: enables flipping behavior on the primary axis (e.g. if top placement, flipping to bottom if there is not enough space on the top). The padding property defines the margin with the boundariesElement, which is usually the viewport.
 - offset: enables an offset between the content node and the invoker node. First argument is horizontal margin, second argument is vertical margin.
 
+## Mobile: longpress
+
+On desktop the tooltip is triggered by hover and focus, as usual. On touch devices where hover is unavailable, the same tooltip instead responds to a long-press on the invoker (default 500ms). No extra configuration is needed. The tooltip auto-detects which interaction model to use via the `(hover: hover)` CSS media query.
+
+> To test the touch path on desktop: enable Chrome DevTools device emulation, pick a phone preset, **reload the page**, then press-and-hold the invoker for 500ms. Tap or hover will no longer trigger it.
+
+```js preview-story
+export const longpress = () => html`
+  <style>
+    .demo-tooltip-invoker {
+      margin: 50px;
+    }
+  </style>
+  <lion-tooltip has-arrow>
+    <button slot="invoker" class="demo-tooltip-invoker">
+      Hover (desktop) / long-press 500ms (touch)
+    </button>
+    <div slot="content">Tooltip content</div>
+  </lion-tooltip>
+`;
+```
+
 ## Arrow
 
 By default, the arrow is disabled for our tooltip. Via the `has-arrow` property it can be enabled.

--- a/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
+++ b/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
@@ -5,68 +5,122 @@
 
 // N.B. Below logic is tested in LionTooltip
 
+// TODO: this is copied from menu system. Move them to common ancestor entrypoint (maybe a core entrypoint for all interactive controls)
+/**
+ * @param {HTMLElement|undefined} item
+ */
+export function isDisabled(item) {
+  return item && (item.hasAttribute('disabled') || item.getAttribute('aria-disabled') === 'true');
+}
+
 /**
  * Use for tooltips and [flyout menus](https://www.w3.org/WAI/tutorials/menus/flyout/).
  * Note that it handles both mouse hover and focus interaction.
  * Provide delayIn and delayOut when the content needs a small delay before being showed
- * @param {{ delayIn?: number, delayOut?: number  }} options
+ * @param {{ isHoverSupported?: boolean, longpressDuration?: number, delayIn?: number, delayOut?: number  }} options
  * @returns {Partial<OverlayConfig>}
  */
-export function withHoverInteraction({ delayIn = 0, delayOut = 300 }) {
+export function withHoverInteraction({
+  isHoverSupported = window.matchMedia('(hover: hover)').matches,
+  longpressDuration = 500,
+  delayOut = 300,
+  delayIn = 0,
+} = {}) {
   return {
     visibilityTriggerFunction: (
       /** @type {{ controller: OverlayController }} */ { controller },
     ) => {
       let isFocused = false;
       let isHovered = false;
+      let isTapping = false;
       /** @type {NodeJS.Timeout} */
-      let delayTimeout;
+      let pendingDelayTimeout;
+      /** @type {NodeJS.Timeout} */
+      let pendingLongpressTimeout;
 
       function resetActive() {
         isFocused = false;
         isHovered = false;
+        isTapping = false;
       }
 
       /**
-       * @param {Event} event
+       * @param {{ shouldOpen: boolean, openTimeout?: number, closeTimeout?: number }} cfg
        */
-      function handleOpenClosed(event) {
+      function openClose({ shouldOpen, openTimeout = 0, closeTimeout = 0 }) {
+        clearTimeout(pendingDelayTimeout);
+        if (shouldOpen && !isDisabled(controller.invokerNode)) {
+          pendingDelayTimeout = setTimeout(() => controller.show(), openTimeout);
+        } else {
+          pendingDelayTimeout = setTimeout(() => controller.hide(), closeTimeout);
+        }
+      }
+
+      /**
+       * @param {Event|PointerEvent} event
+       */
+      async function handleHoverAndFocus(event) {
+        const { type } = event;
+        isFocused = type === 'focusout' ? false : isFocused || type === 'focusin';
+        if (isHoverSupported) {
+          isHovered = type === 'mouseleave' ? false : isHovered || type === 'mouseenter';
+        }
+        const shouldOpen = isFocused || isHovered;
+        openClose({ shouldOpen, openTimeout: delayIn, closeTimeout: delayOut });
+      }
+
+      /**
+       * @param {PointerEvent} event
+       */
+      async function handleLongpress(event) {
+        clearTimeout(pendingLongpressTimeout);
+        if (event.pointerType !== 'touch') return;
         const { type } = event;
 
-        clearTimeout(delayTimeout);
-        isFocused = type === 'focusout' ? false : isFocused || type === 'focusin';
-        isHovered = type === 'mouseleave' ? false : isHovered || type === 'mouseenter';
-        const shouldOpen = isFocused || isHovered;
-
-        if (shouldOpen && !controller._hasDisabledInvoker()) {
-          delayTimeout = setTimeout(() => {
-            controller.show();
-          }, delayIn);
-        } else {
-          delayTimeout = setTimeout(() => {
-            controller.hide();
-          }, delayOut);
+        isTapping =
+          type === 'pointerup' || type === 'pointerleave' ? false : type === 'pointerdown';
+        if (isTapping) {
+          pendingLongpressTimeout = setTimeout(() => {
+            openClose({ shouldOpen: true });
+          }, longpressDuration);
         }
+        openClose({ shouldOpen: isTapping || isHovered });
       }
 
       return {
         init: () => {
           controller.addEventListener('hide', resetActive);
-          controller.contentNode?.addEventListener('mouseenter', handleOpenClosed);
-          controller.contentNode?.addEventListener('mouseleave', handleOpenClosed);
-          controller.invokerNode?.addEventListener('mouseenter', handleOpenClosed);
-          controller.invokerNode?.addEventListener('mouseleave', handleOpenClosed);
-          controller.invokerNode?.addEventListener('focusin', handleOpenClosed);
-          controller.invokerNode?.addEventListener('focusout', handleOpenClosed);
+
+          controller.invokerNode?.addEventListener('focusin', handleHoverAndFocus);
+          controller.invokerNode?.addEventListener('focusout', handleHoverAndFocus);
+
+          if (isHoverSupported) {
+            controller.contentNode?.addEventListener('mouseenter', handleHoverAndFocus);
+            controller.contentNode?.addEventListener('mouseleave', handleHoverAndFocus);
+            controller.invokerNode?.addEventListener('mouseenter', handleHoverAndFocus);
+            controller.invokerNode?.addEventListener('mouseleave', handleHoverAndFocus);
+          } else {
+            controller.invokerNode?.addEventListener('pointerdown', handleLongpress);
+            controller.invokerNode?.addEventListener('pointerup', handleLongpress);
+            controller.invokerNode?.addEventListener('pointerleave', handleLongpress);
+          }
         },
         teardown: () => {
           controller.removeEventListener('hide', resetActive);
-          controller.contentNode?.removeEventListener('mouseenter', handleOpenClosed);
-          controller.contentNode?.removeEventListener('mouseleave', handleOpenClosed);
-          controller.invokerNode?.removeEventListener('mouseenter', handleOpenClosed);
-          controller.invokerNode?.removeEventListener('mouseleave', handleOpenClosed);
-          controller.invokerNode?.removeEventListener('focusin', handleOpenClosed);
-          controller.invokerNode?.removeEventListener('focusout', handleOpenClosed);
+
+          controller.invokerNode?.removeEventListener('focusin', handleHoverAndFocus);
+          controller.invokerNode?.removeEventListener('focusout', handleHoverAndFocus);
+
+          if (isHoverSupported) {
+            controller.contentNode?.removeEventListener('mouseenter', handleHoverAndFocus);
+            controller.contentNode?.removeEventListener('mouseleave', handleHoverAndFocus);
+            controller.invokerNode?.removeEventListener('mouseenter', handleHoverAndFocus);
+            controller.invokerNode?.removeEventListener('mouseleave', handleHoverAndFocus);
+          } else {
+            controller.invokerNode?.removeEventListener('pointerdown', handleLongpress);
+            controller.invokerNode?.removeEventListener('pointerup', handleLongpress);
+            controller.invokerNode?.removeEventListener('pointerleave', handleLongpress);
+          }
         },
       };
     },

--- a/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
+++ b/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
@@ -36,10 +36,12 @@ export function withHoverInteraction({
       let pendingDelayTimeout;
       /** @type {NodeJS.Timeout} */
       let pendingLongpressTimeout;
+      let longpressCompleted = false;
 
       function resetActive() {
         isFocused = false;
         isHovered = false;
+        longpressCompleted = false;
       }
 
       /**
@@ -72,20 +74,28 @@ export function withHoverInteraction({
         openClose({ shouldOpen, openTimeout: delayIn, closeTimeout: delayOut });
       }
 
-      /**
-       * @param {PointerEvent} event
-       */
+      /** @param {Event} e */
+      function preventContextMenu(e) {
+        e.preventDefault();
+      }
+
+      /** @param {PointerEvent} event */
       async function handleLongpress(event) {
         clearTimeout(pendingLongpressTimeout);
         if (event.pointerType !== 'touch') return;
         const { type } = event;
 
         if (type === 'pointerdown') {
+          longpressCompleted = false;
           pendingLongpressTimeout = setTimeout(() => {
+            longpressCompleted = true;
             openClose({ shouldOpen: true });
           }, longpressDuration);
         } else {
-          openClose({ shouldOpen: false });
+          openClose({
+            shouldOpen: false,
+            closeTimeout: longpressCompleted ? longpressDuration : 0,
+          });
         }
       }
 
@@ -102,6 +112,7 @@ export function withHoverInteraction({
             controller.invokerNode?.addEventListener('mouseenter', handleHoverAndFocus);
             controller.invokerNode?.addEventListener('mouseleave', handleHoverAndFocus);
           } else {
+            controller.invokerNode?.addEventListener('contextmenu', preventContextMenu);
             controller.invokerNode?.addEventListener('pointerdown', handleLongpress);
             controller.invokerNode?.addEventListener('pointerup', handleLongpress);
             controller.invokerNode?.addEventListener('pointerleave', handleLongpress);
@@ -119,6 +130,7 @@ export function withHoverInteraction({
             controller.invokerNode?.removeEventListener('mouseenter', handleHoverAndFocus);
             controller.invokerNode?.removeEventListener('mouseleave', handleHoverAndFocus);
           } else {
+            controller.invokerNode?.removeEventListener('contextmenu', preventContextMenu);
             controller.invokerNode?.removeEventListener('pointerdown', handleLongpress);
             controller.invokerNode?.removeEventListener('pointerup', handleLongpress);
             controller.invokerNode?.removeEventListener('pointerleave', handleLongpress);

--- a/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
+++ b/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
@@ -112,6 +112,9 @@ export function withHoverInteraction({
             controller.invokerNode?.addEventListener('mouseenter', handleHoverAndFocus);
             controller.invokerNode?.addEventListener('mouseleave', handleHoverAndFocus);
           } else {
+            controller.invokerNode?.style.setProperty('-webkit-touch-callout', 'none');
+            controller.invokerNode?.style.setProperty('user-select', 'none');
+            controller.invokerNode?.style.setProperty('-webkit-user-select', 'none');
             controller.invokerNode?.addEventListener('contextmenu', preventContextMenu);
             controller.invokerNode?.addEventListener('pointerdown', handleLongpress);
             controller.invokerNode?.addEventListener('pointerup', handleLongpress);
@@ -130,6 +133,9 @@ export function withHoverInteraction({
             controller.invokerNode?.removeEventListener('mouseenter', handleHoverAndFocus);
             controller.invokerNode?.removeEventListener('mouseleave', handleHoverAndFocus);
           } else {
+            controller.invokerNode?.style.removeProperty('-webkit-touch-callout');
+            controller.invokerNode?.style.removeProperty('user-select');
+            controller.invokerNode?.style.removeProperty('-webkit-user-select');
             controller.invokerNode?.removeEventListener('contextmenu', preventContextMenu);
             controller.invokerNode?.removeEventListener('pointerdown', handleLongpress);
             controller.invokerNode?.removeEventListener('pointerup', handleLongpress);

--- a/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
+++ b/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
@@ -32,7 +32,6 @@ export function withHoverInteraction({
     ) => {
       let isFocused = false;
       let isHovered = false;
-      let isTapping = false;
       /** @type {NodeJS.Timeout} */
       let pendingDelayTimeout;
       /** @type {NodeJS.Timeout} */
@@ -41,7 +40,6 @@ export function withHoverInteraction({
       function resetActive() {
         isFocused = false;
         isHovered = false;
-        isTapping = false;
       }
 
       /**
@@ -62,9 +60,14 @@ export function withHoverInteraction({
       async function handleHoverAndFocus(event) {
         const { type } = event;
         isFocused = type === 'focusout' ? false : isFocused || type === 'focusin';
-        if (isHoverSupported) {
-          isHovered = type === 'mouseleave' ? false : isHovered || type === 'mouseenter';
-        }
+        isHovered = type === 'mouseleave' ? false : isHovered || type === 'mouseenter';
+        // On touch devices, only open on keyboard-triggered focus, not tap-triggered focus
+        if (
+          !isHoverSupported &&
+          type === 'focusin' &&
+          !controller.invokerNode?.matches(':focus-visible')
+        )
+          return;
         const shouldOpen = isFocused || isHovered;
         openClose({ shouldOpen, openTimeout: delayIn, closeTimeout: delayOut });
       }
@@ -77,14 +80,13 @@ export function withHoverInteraction({
         if (event.pointerType !== 'touch') return;
         const { type } = event;
 
-        isTapping =
-          type === 'pointerup' || type === 'pointerleave' ? false : type === 'pointerdown';
-        if (isTapping) {
+        if (type === 'pointerdown') {
           pendingLongpressTimeout = setTimeout(() => {
             openClose({ shouldOpen: true });
           }, longpressDuration);
+        } else {
+          openClose({ shouldOpen: false });
         }
-        openClose({ shouldOpen: isTapping || isHovered });
       }
 
       return {

--- a/packages/ui/components/overlays/test/withHoverInteraction.test.js
+++ b/packages/ui/components/overlays/test/withHoverInteraction.test.js
@@ -71,6 +71,17 @@ describe('withHoverInteraction (isHoverSupported: false)', () => {
     expect(ctrl.isShown).to.equal(false);
   });
 
+  it('disables text selection on the invoker on init and restores it on teardown', () => {
+    const { invokerNode } = ctrl;
+    const getUserSelect = () =>
+      invokerNode?.style.getPropertyValue('user-select') ||
+      invokerNode?.style.getPropertyValue('-webkit-user-select');
+    expect(getUserSelect()).to.equal('none');
+
+    ctrl.teardown();
+    expect(getUserSelect()).to.equal('');
+  });
+
   it('does not open on tap-triggered focusin', () => {
     ctrl.invokerNode?.dispatchEvent(new Event('focusin', { bubbles: true }));
     clock.tick(300);

--- a/packages/ui/components/overlays/test/withHoverInteraction.test.js
+++ b/packages/ui/components/overlays/test/withHoverInteraction.test.js
@@ -37,7 +37,7 @@ describe('withHoverInteraction (isHoverSupported: false)', () => {
     expect(ctrl.isShown).to.equal(true);
   });
 
-  it('stays hidden on brief touch — pointerup cancels the timer', () => {
+  it('stays hidden on brief touch: pointerup cancels the timer', () => {
     ctrl.invokerNode?.dispatchEvent(
       new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
     );
@@ -56,7 +56,22 @@ describe('withHoverInteraction (isHoverSupported: false)', () => {
     expect(ctrl.isShown).to.equal(false);
   });
 
-  it('does not open on tap-triggered focusin (synthetic focusin is not :focus-visible)', () => {
+  it('auto-closes after longpressDuration once press ends', async () => {
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+    );
+    clock.runAll();
+    await Promise.resolve();
+    expect(ctrl.isShown).to.equal(true);
+
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true }),
+    );
+    await clock.tickAsync(501);
+    expect(ctrl.isShown).to.equal(false);
+  });
+
+  it('does not open on tap-triggered focusin', () => {
     ctrl.invokerNode?.dispatchEvent(new Event('focusin', { bubbles: true }));
     clock.tick(300);
     expect(ctrl.isShown).to.equal(false);

--- a/packages/ui/components/overlays/test/withHoverInteraction.test.js
+++ b/packages/ui/components/overlays/test/withHoverInteraction.test.js
@@ -1,0 +1,64 @@
+import { OverlayController } from '@lion/ui/overlays.js';
+import { expect, fixtureSync, html } from '@open-wc/testing';
+import sinon from 'sinon';
+import { withHoverInteraction } from '../src/configurations/visibility-trigger-partials/withHoverInteraction.js';
+
+function makeCtrl(opts = {}) {
+  return new OverlayController({
+    placementMode: 'local',
+    contentNode: fixtureSync(html`<div>content</div>`),
+    invokerNode: fixtureSync(html`<button>invoker</button>`),
+    ...withHoverInteraction(opts),
+  });
+}
+
+describe('withHoverInteraction (isHoverSupported: false)', () => {
+  /** @type {sinon.SinonFakeTimers} */
+  let clock;
+  /** @type {OverlayController} */
+  let ctrl;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    ctrl = makeCtrl({ isHoverSupported: false });
+  });
+
+  afterEach(() => {
+    ctrl.teardown();
+    clock.restore();
+  });
+
+  it('opens after holding for longpressDuration (500ms)', async () => {
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+    );
+    clock.runAll();
+    await Promise.resolve();
+    expect(ctrl.isShown).to.equal(true);
+  });
+
+  it('stays hidden on brief touch — pointerup cancels the timer', () => {
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+    );
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true }),
+    );
+    clock.tick(500);
+    expect(ctrl.isShown).to.equal(false);
+  });
+
+  it('ignores non-touch pointer events (mouse)', () => {
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerType: 'mouse', bubbles: true }),
+    );
+    clock.tick(500);
+    expect(ctrl.isShown).to.equal(false);
+  });
+
+  it('does not open on tap-triggered focusin (synthetic focusin is not :focus-visible)', () => {
+    ctrl.invokerNode?.dispatchEvent(new Event('focusin', { bubbles: true }));
+    clock.tick(300);
+    expect(ctrl.isShown).to.equal(false);
+  });
+});


### PR DESCRIPTION
Makes sure that mobile devices (not meant for hover behavior) implement longpress behavior (like on Android).

TODO:

- write unit tests 
- test on real mobile devices (iOS (16) and Android)
- test on Talkback / VoiceOver / NVDA in both old and new (longpress) situation, with aria-label and aria-description

More info:
https://mayank.co/blog/tooltips-on-touchscreens/ 