### PR TITLE
Feat/tooltip longpress on mobile

### DIFF
--- a/.changeset/funky-rings-drop.md
+++ b/.changeset/funky-rings-drop.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+add longpress tooltip on touch devices and suppress tap-focus and post-longpress click collisions

--- a/docs/components/tooltip/use-cases.md
+++ b/docs/components/tooltip/use-cases.md
@@ -169,6 +169,39 @@ export const longpress = () => html`
 `;
 ```
 
+## Mobile: tooltip on an invoker that also opens an overlay
+
+When an invoker opens an overlay on tap, the two interactions do not collide:
+
+- **Tap**: dialog opens, tooltip does not show.
+- **Long-press 500ms**: tooltip shows, click is suppressed so the dialog does not open.
+
+> To test on desktop: enable Chrome DevTools device emulation, pick a phone preset, **reload the page**, then tap or long-press the button.
+
+```js preview-story
+export const overlayAndLongpress = () => html`
+  <style>
+    .demo-tooltip-invoker {
+      margin: 50px;
+    }
+  </style>
+  <lion-tooltip has-arrow>
+    <button
+      slot="invoker"
+      class="demo-tooltip-invoker"
+      @click="${e => e.target.closest('lion-tooltip').nextElementSibling.showModal()}"
+    >
+      Tap opens dialog /</br> Long-press shows tooltip
+    </button>
+    <div slot="content">Tooltip content</div>
+  </lion-tooltip>
+  <dialog>
+    <p>Dialog opened by tap</p>
+    <button @click="${e => e.target.closest('dialog').close()}">Close</button>
+  </dialog>
+`;
+```
+
 ## Arrow
 
 By default, the arrow is disabled for our tooltip. Via the `has-arrow` property it can be enabled.

--- a/docs/components/tooltip/use-cases.md
+++ b/docs/components/tooltip/use-cases.md
@@ -151,7 +151,7 @@ Modifier explanations:
 
 On desktop the tooltip is triggered by hover and focus, as usual. On touch devices where hover is unavailable, the same tooltip instead responds to a long-press on the invoker (default 500ms). No extra configuration is needed. The tooltip auto-detects which interaction model to use via the `(hover: hover)` CSS media query.
 
-> To test the touch path on desktop: enable Chrome DevTools device emulation, pick a phone preset, **reload the page**, then press-and-hold the invoker for 500ms. Tap or hover will no longer trigger it.
+> To test the touch path on desktop: enable Chrome DevTools device emulation, **reload the page**, then press-and-hold the invoker for 500ms. Tap or hover will no longer trigger it.
 
 ```js preview-story
 export const longpress = () => html`
@@ -169,14 +169,14 @@ export const longpress = () => html`
 `;
 ```
 
-## Mobile: tooltip on an invoker that also opens an overlay
+### Mobile: tooltip on an invoker that also opens an overlay
 
 When an invoker opens an overlay on tap, the two interactions do not collide:
 
 - **Tap**: dialog opens, tooltip does not show.
 - **Long-press 500ms**: tooltip shows, click is suppressed so the dialog does not open.
 
-> To test on desktop: enable Chrome DevTools device emulation, pick a phone preset, **reload the page**, then tap or long-press the button.
+> To test on desktop: enable Chrome DevTools device emulation, **reload the page**, then tap or long-press the button.
 
 ```js preview-story
 export const overlayAndLongpress = () => html`

--- a/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
+++ b/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
@@ -37,11 +37,20 @@ export function withHoverInteraction({
       /** @type {NodeJS.Timeout} */
       let pendingLongpressTimeout;
       let longpressCompleted = false;
+      let lastPointerWasTouch = false;
+      /** @type {((e: Event) => void) | null} */
+      let pendingClickSuppressor = null;
 
       function resetActive() {
         isFocused = false;
         isHovered = false;
         longpressCompleted = false;
+        if (pendingClickSuppressor) {
+          controller.invokerNode?.removeEventListener('click', pendingClickSuppressor, {
+            capture: true,
+          });
+          pendingClickSuppressor = null;
+        }
       }
 
       /**
@@ -63,13 +72,16 @@ export function withHoverInteraction({
         const { type } = event;
         isFocused = type === 'focusout' ? false : isFocused || type === 'focusin';
         isHovered = type === 'mouseleave' ? false : isHovered || type === 'mouseenter';
-        // On touch devices, only open on keyboard-triggered focus, not tap-triggered focus
-        if (
-          !isHoverSupported &&
-          type === 'focusin' &&
-          !controller.invokerNode?.matches(':focus-visible')
-        )
-          return;
+        // On touch devices, only open on keyboard-triggered focus, not tap-triggered focus.
+        // :focus-visible alone is unreliable — some browsers apply it on tap too — so we
+        // also track whether a touch pointerdown just preceded this focusin.
+        if (!isHoverSupported && type === 'focusin') {
+          if (lastPointerWasTouch) {
+            lastPointerWasTouch = false;
+            return;
+          }
+          if (!controller.invokerNode?.matches(':focus-visible')) return;
+        }
         const shouldOpen = isFocused || isHovered;
         openClose({ shouldOpen, openTimeout: delayIn, closeTimeout: delayOut });
       }
@@ -87,8 +99,14 @@ export function withHoverInteraction({
 
         if (type === 'pointerdown') {
           longpressCompleted = false;
+          lastPointerWasTouch = true;
           pendingLongpressTimeout = setTimeout(() => {
             longpressCompleted = true;
+            pendingClickSuppressor = e => e.stopImmediatePropagation();
+            controller.invokerNode?.addEventListener('click', pendingClickSuppressor, {
+              once: true,
+              capture: true,
+            });
             openClose({ shouldOpen: true });
           }, longpressDuration);
         } else {
@@ -140,6 +158,12 @@ export function withHoverInteraction({
             controller.invokerNode?.removeEventListener('pointerdown', handleLongpress);
             controller.invokerNode?.removeEventListener('pointerup', handleLongpress);
             controller.invokerNode?.removeEventListener('pointerleave', handleLongpress);
+            if (pendingClickSuppressor) {
+              controller.invokerNode?.removeEventListener('click', pendingClickSuppressor, {
+                capture: true,
+              });
+              pendingClickSuppressor = null;
+            }
           }
         },
       };

--- a/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
+++ b/packages/ui/components/overlays/src/configurations/visibility-trigger-partials/withHoverInteraction.js
@@ -37,7 +37,16 @@ export function withHoverInteraction({
       /** @type {NodeJS.Timeout} */
       let pendingLongpressTimeout;
       let longpressCompleted = false;
-      let lastPointerWasTouch = false;
+      // A tap fires pointerdown → pointerup → focusin because the browser moves keyboard focus to
+      // the tapped element. We only want focusin to open the tooltip when triggered by keyboard (Tab),
+      // not by tap. isLastPointerTouch marks that the preceding pointer event was a touch so the
+      // focusin handler can skip it.
+      let isLastPointerTouch = false;
+      // A tap fires the full mouse compatibility sequence: pointerdown → pointerup → mousedown → mouseup → click.
+      // Browsers generate these compatibility events automatically so touch works with mouse-only code.
+      // After a longpress the same click fires, which would trigger any click handler on the invoker
+      // e.g. opening a dialog alongside the tooltip. We register a capture-phase listener at longpress
+      // completion to intercept it, as capture runs before bubble so we stop it regardless of registration order.
       /** @type {((e: Event) => void) | null} */
       let pendingClickSuppressor = null;
 
@@ -68,16 +77,13 @@ export function withHoverInteraction({
       /**
        * @param {Event|PointerEvent} event
        */
-      async function handleHoverAndFocus(event) {
+      function handleHoverAndFocus(event) {
         const { type } = event;
         isFocused = type === 'focusout' ? false : isFocused || type === 'focusin';
         isHovered = type === 'mouseleave' ? false : isHovered || type === 'mouseenter';
-        // On touch devices, only open on keyboard-triggered focus, not tap-triggered focus.
-        // :focus-visible alone is unreliable — some browsers apply it on tap too — so we
-        // also track whether a touch pointerdown just preceded this focusin.
         if (!isHoverSupported && type === 'focusin') {
-          if (lastPointerWasTouch) {
-            lastPointerWasTouch = false;
+          if (isLastPointerTouch) {
+            isLastPointerTouch = false;
             return;
           }
           if (!controller.invokerNode?.matches(':focus-visible')) return;
@@ -92,19 +98,21 @@ export function withHoverInteraction({
       }
 
       /** @param {PointerEvent} event */
-      async function handleLongpress(event) {
+      function handleLongpress(event) {
         clearTimeout(pendingLongpressTimeout);
         if (event.pointerType !== 'touch') return;
         const { type } = event;
 
         if (type === 'pointerdown') {
           longpressCompleted = false;
-          lastPointerWasTouch = true;
+          isLastPointerTouch = true;
           pendingLongpressTimeout = setTimeout(() => {
             longpressCompleted = true;
+            // Intercept the compatibility click the browser generates at the end of the touch sequence.
+            // Capture phase ensures we run before any bubble-phase handler (e.g. a dialog opener).
             pendingClickSuppressor = e => e.stopImmediatePropagation();
             controller.invokerNode?.addEventListener('click', pendingClickSuppressor, {
-              once: true,
+              once: true, // auto-removes after first click
               capture: true,
             });
             openClose({ shouldOpen: true });

--- a/packages/ui/components/overlays/test/withHoverInteraction.test.js
+++ b/packages/ui/components/overlays/test/withHoverInteraction.test.js
@@ -87,4 +87,32 @@ describe('withHoverInteraction (isHoverSupported: false)', () => {
     clock.tick(300);
     expect(ctrl.isShown).to.equal(false);
   });
+
+  it('suppresses focusin that immediately follows a touch pointerdown', () => {
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+    );
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerup', { pointerType: 'touch', bubbles: true }),
+    );
+    ctrl.invokerNode?.dispatchEvent(new Event('focusin', { bubbles: true }));
+    clock.tick(1); // fires any 0ms open timer if focusin was not suppressed
+    expect(ctrl.isShown).to.equal(false);
+  });
+
+  it('suppresses the click event that fires after a completed longpress', async () => {
+    ctrl.invokerNode?.dispatchEvent(
+      new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+    );
+    clock.runAll();
+    await Promise.resolve();
+    expect(ctrl.isShown).to.equal(true);
+
+    let clickFired = false;
+    ctrl.invokerNode?.addEventListener('click', () => {
+      clickFired = true;
+    });
+    ctrl.invokerNode?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(clickFired).to.equal(false);
+  });
 });


### PR DESCRIPTION
## What I did

1. Suppressed `focusin` triggered by a tap:`lastPointerWasTouch` flag used instead of `:focus-visible` alone, which some browsers apply on tap too.
2. Suppressed the `click` event that fires after a completed longpress, so an invoker that also opens an overlay on tap does not trigger both interactions at once.
3. Added unit tests for both fixes and a matching use-case demo in the docs.



https://github.com/user-attachments/assets/d00cd68c-406a-40d7-a6a8-a12dfa9e181c

