### PR TITLE
Add MaxFileCount validator to LionInputFile

### DIFF
--- a/.changeset/spotty-ducks-cover.md
+++ b/.changeset/spotty-ducks-cover.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+Added MaxFileCount validator to LionInputFile

--- a/docs/components/input-file/use-cases.md
+++ b/docs/components/input-file/use-cases.md
@@ -173,6 +173,24 @@ export const sizeValidator = () => {
 };
 ```
 
+### Maximum File Count
+
+```js preview-story
+export const fileCountValidator = () => {
+  return html`
+    <lion-input-file
+      label="Passport"
+      max-file-size="1024000"
+      accept=".jpg,.svg,.xml,image/svg+xml"
+      .validators=${[
+        new MaxFileCount(2, { getMessage: () => 'You must not select more than 2 files' }),
+      ]}
+    >
+    </lion-input-file>
+  `;
+};
+```
+
 ### Multiple file upload
 
 When file has to be uploaded as soon as it is selected by the user. Use `file-list-changed` event to get the newly added files, upload it to your server and set the response back to component via `uploadResponse` property for each file.

--- a/packages/ui/components/input-file/src/validators.js
+++ b/packages/ui/components/input-file/src/validators.js
@@ -2,13 +2,14 @@ import { Validator } from '@lion/ui/form-core.js';
 import { getLocalizeManager } from '@lion/ui/localize-no-side-effects.js';
 
 /**
+ * @typedef {import('../../form-core/types/validate/index.js').FeedbackMessageData} FeedbackMessageData
  * @typedef {import('../../form-core/types/validate/validate.js').ValidatorConfig} ValidatorConfig
  * @typedef {import('../../form-core/types/validate/validate.js').ValidatorParam} ValidatorParam
  * @typedef {import('../../form-core/types/validate/validate.js').ValidatorOutcome} ValidatorOutcome
  * @typedef {import('../types/input-file.js').InputFile} InputFile
  */
 
-/* eslint max-classes-per-file: ["error", 2] */
+/* eslint max-classes-per-file: ["error", 3] */
 export class IsAcceptedFile extends Validator {
   static validatorName = 'IsAcceptedFile';
 
@@ -110,5 +111,34 @@ export class DuplicateFileNames extends Validator {
     // TODO: we need to make sure namespace is loaded
     // TODO: keep Validators localize system agnostic
     return localizeManager.msg('lion-input-file:uploadTextDuplicateFileName');
+  }
+}
+
+export class MaxFileCount extends Validator {
+  static get validatorName() {
+    return 'MaxFileCount';
+  }
+
+  /**
+   * @param {Partial<FeedbackMessageData>} [data]
+   * @returns {Promise<string|Element>}
+   */
+  static async getMessage(data) {
+    const localizeManager = getLocalizeManager();
+    if (!data?.params || typeof data.params !== 'number' || data.params <= 0) {
+      return 'Invalid MaxFileCount parameter. Please provide a valid number greater than 0.';
+    }
+    return localizeManager.msg('lion-input-file:maxFileCountExceeded', {
+      maxFileCount: data.params,
+    });
+  }
+
+  /**
+   * @param {File[]} value
+   * @param {number} maxFiles
+   * @returns {boolean}
+   */
+  execute(value, maxFiles = this.param || 0) {
+    return maxFiles > 0 && value.length > maxFiles;
   }
 }

--- a/packages/ui/components/input-file/test/FileValidators.test.js
+++ b/packages/ui/components/input-file/test/FileValidators.test.js
@@ -1,4 +1,5 @@
 import { expect } from '@open-wc/testing';
+import { MaxFileCount } from '@lion/ui/input-file.js';
 import { IsAcceptedFile } from '../src/validators.js';
 
 describe('lion-input-file: IsAcceptedFile', () => {
@@ -165,6 +166,36 @@ describe('lion-input-file: IsAcceptedFile', () => {
       });
 
       expect(returnVal).to.be.true;
+    });
+  });
+
+  describe('Max File Count', () => {
+    /**
+     *
+     * @param {string} filename
+     * @returns {File}
+     */
+    const newFile = filename => new File([], filename);
+
+    it('Allow up to 2 files', () => {
+      const validator = new MaxFileCount(2);
+      expect(MaxFileCount.validatorName).to.equal('MaxFileCount');
+
+      let isEnabled = validator.execute([newFile('file1.txt'), newFile('file2.txt')]);
+      expect(isEnabled).to.be.false;
+
+      isEnabled = validator.execute([
+        newFile('file1.txt'),
+        newFile('file2.txt'),
+        newFile('file3.txt'),
+      ]);
+      expect(isEnabled).to.be.true;
+    });
+
+    it('Allow any number of files with empty param', () => {
+      const validator = new MaxFileCount();
+      const isEnabled = validator.execute([newFile('file1.txt'), newFile('file2.txt')]);
+      expect(isEnabled).to.be.false;
     });
   });
 });

--- a/packages/ui/components/input-file/translations/bg.js
+++ b/packages/ui/components/input-file/translations/bg.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Файл със същото име на файл вече е налице.',
   selectTextMultipleFile: 'Избор на файлове',
   selectTextSingleFile: 'Избор на файл',
+  maxFileCountExceeded: 'Броят на качените файлове не може да надвишава {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/cs.js
+++ b/packages/ui/components/input-file/translations/cs.js
@@ -18,4 +18,5 @@ export default {
   selectTextDuplicateFileName: 'Soubor se stejným názvem byl již přítomen.',
   selectTextMultipleFile: 'Vybrat soubory',
   selectTextSingleFile: 'Vybrat soubor',
+  maxFileCountExceeded: 'Počet nahraných souborů nesmí překročit {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/de.js
+++ b/packages/ui/components/input-file/translations/de.js
@@ -17,4 +17,6 @@ export default {
   selectTextDuplicateFileName: 'Eine Datei mit demselben Dateinamen war bereits vorhanden.',
   selectTextMultipleFile: 'Dateien auswählen',
   selectTextSingleFile: 'Datei auswählen',
+  maxFileCountExceeded:
+    'Die Anzahl der hochgeladenen Dateien darf {maxFileCount} nicht überschreiten.',
 };

--- a/packages/ui/components/input-file/translations/en.js
+++ b/packages/ui/components/input-file/translations/en.js
@@ -16,4 +16,5 @@ export default {
   selectTextDuplicateFileName: 'A file with same filename was already present.',
   selectTextMultipleFile: 'Select files',
   selectTextSingleFile: 'Select file',
+  maxFileCountExceeded: 'You can upload up to {maxFileCount} files.',
 };

--- a/packages/ui/components/input-file/translations/en.js
+++ b/packages/ui/components/input-file/translations/en.js
@@ -16,5 +16,5 @@ export default {
   selectTextDuplicateFileName: 'A file with same filename was already present.',
   selectTextMultipleFile: 'Select files',
   selectTextSingleFile: 'Select file',
-  maxFileCountExceeded: 'You can upload up to {maxFileCount} files.',
+  maxFileCountExceeded: 'The number of uploaded files must not exceed {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/es.js
+++ b/packages/ui/components/input-file/translations/es.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Ya había un archivo con el mismo nombre de archivo.',
   selectTextMultipleFile: 'Seleccionar archivos',
   selectTextSingleFile: 'Seleccionar archivo',
+  maxFileCountExceeded: 'El número de archivos cargados no puede superar {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/fr.js
+++ b/packages/ui/components/input-file/translations/fr.js
@@ -18,4 +18,5 @@ export default {
   selectTextDuplicateFileName: 'Un fichier portant le même nom de fichier était déjà présent.',
   selectTextMultipleFile: 'Sélectionnez des fichiers',
   selectTextSingleFile: 'Sélectionnez un fichier',
+  maxFileCountExceeded: 'Le nombre de fichiers téléchargés ne peut pas dépasser {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/hu.js
+++ b/packages/ui/components/input-file/translations/hu.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Már volt ilyen nevű fájl.',
   selectTextMultipleFile: 'Fájl(ok) kiválasztása',
   selectTextSingleFile: 'Fájl kiválasztása',
+  maxFileCountExceeded: 'A feltöltött fájlok száma nem haladhatja meg a {maxFileCount}-ot.',
 };

--- a/packages/ui/components/input-file/translations/id.js
+++ b/packages/ui/components/input-file/translations/id.js
@@ -16,4 +16,5 @@ export default {
   selectTextDuplicateFileName: 'File dengan nama file yang sama sudah ada.',
   selectTextMultipleFile: 'Pilih beberapa file',
   selectTextSingleFile: 'Pilih berkas',
+  maxFileCountExceeded: 'Jumlah file yang diunggah tidak boleh melebihi {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/it.js
+++ b/packages/ui/components/input-file/translations/it.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Un file con lo stesso nome file era già presente.',
   selectTextMultipleFile: 'Seleziona file',
   selectTextSingleFile: 'Seleziona file',
+  maxFileCountExceeded: 'Il numero di file caricati non può superare {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/nl.js
+++ b/packages/ui/components/input-file/translations/nl.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Er bestaat al een bestand met dezelfde bestandsnaam.',
   selectTextMultipleFile: 'Selecteer bestanden',
   selectTextSingleFile: 'Selecteer bestand',
+  maxFileCountExceeded: 'Het aantal geüploade bestanden mag niet meer dan {maxFileCount} zijn.',
 };

--- a/packages/ui/components/input-file/translations/pl.js
+++ b/packages/ui/components/input-file/translations/pl.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Plik o tej samej nazwie już istnieje.',
   selectTextMultipleFile: 'Wybierz pliki',
   selectTextSingleFile: 'Wybierz plik',
+  maxFileCountExceeded: 'Liczba przesłanych plików nie może przekraczać {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/ro.js
+++ b/packages/ui/components/input-file/translations/ro.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Există deja un fişier cu acelaşi nume de fişier.',
   selectTextMultipleFile: 'Selectare fișiere',
   selectTextSingleFile: 'Selectare fișier',
+  maxFileCountExceeded: 'Numărul de fișiere încărcate nu poate depăși {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/ru.js
+++ b/packages/ui/components/input-file/translations/ru.js
@@ -16,4 +16,5 @@ export default {
   selectTextDuplicateFileName: 'Файл с таким названием уже существует.',
   selectTextMultipleFile: 'Выберите файлы',
   selectTextSingleFile: 'Выберите файл',
+  maxFileCountExceeded: 'Количество загруженных файлов не может превышать {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/sk.js
+++ b/packages/ui/components/input-file/translations/sk.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Súbor s rovnakým názvom súboru už existoval.',
   selectTextMultipleFile: 'Vybrať súbory',
   selectTextSingleFile: 'Vybrať súbor',
+  maxFileCountExceeded: 'Počet nahratých súborov nesmie prekročiť {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/uk.js
+++ b/packages/ui/components/input-file/translations/uk.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: 'Файл із такою назвою вже існував.',
   selectTextMultipleFile: 'Виберіть файли',
   selectTextSingleFile: 'Виберіть файл',
+  maxFileCountExceeded: 'Кількість завантажених файлів не може перевищувати {maxFileCount}.',
 };

--- a/packages/ui/components/input-file/translations/zh.js
+++ b/packages/ui/components/input-file/translations/zh.js
@@ -17,4 +17,5 @@ export default {
   selectTextDuplicateFileName: '已存在具有相同文件名的文件。',
   selectTextMultipleFile: '选择多个文件',
   selectTextSingleFile: '选择文件',
+  maxFileCountExceeded: '上传的文件数量不能超过 {maxFileCount} 个。',
 };

--- a/packages/ui/exports/input-file.js
+++ b/packages/ui/exports/input-file.js
@@ -1,3 +1,7 @@
 export { LionInputFile } from '../components/input-file/src/LionInputFile.js';
 export { LionSelectedFileList } from '../components/input-file/src/LionSelectedFileList.js';
-export { IsAcceptedFile, DuplicateFileNames } from '../components/input-file/src/validators.js';
+export {
+  IsAcceptedFile,
+  DuplicateFileNames,
+  MaxFileCount,
+} from '../components/input-file/src/validators.js';


### PR DESCRIPTION
## What I did

Added a MaxFileCount validator to the LionInputFile component

This allows a cap on the uploadable files through specifying the validator:

```
<lion-input-file
      label="Passport"
      max-file-size="1024000"
      accept=".jpg,.svg,.xml,image/svg+xml"
      .validators=${[
        new MaxFileCount(2, { getMessage: () => 'You must not select more than 2 files' }),
      ]}
    ></lion-input-file>
```

