### PR TITLE
Fix/run types on verify-pr pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:markdownlint": "git ls-files '*.md' | xargs markdownlint --ignore '{.github/**/*.md,.changeset/*.md,**/CHANGELOG.md,packages/ui/_legacy-changelogs/*.md}'",
     "lint:phone-number-up-to-date": "node ./scripts/lint-phone-number-lib.js",
     "lint:prettier": "prettier \"**/*.js\" --list-different || (echo '↑↑ these files are not prettier formatted ↑↑' && exit 1)",
+    "lint:types": "npm run types",
     "lint:versions": "node ./scripts/lint-versions.js",
     "prepare": "husky install",
     "preview": "npx serve _site",

--- a/packages/ui/components/overlays/test/withHoverInteraction.test.js
+++ b/packages/ui/components/overlays/test/withHoverInteraction.test.js
@@ -6,8 +6,8 @@ import { withHoverInteraction } from '../src/configurations/visibility-trigger-p
 function makeCtrl(opts = {}) {
   return new OverlayController({
     placementMode: 'local',
-    contentNode: fixtureSync(html`<div>content</div>`),
-    invokerNode: fixtureSync(html`<button>invoker</button>`),
+    contentNode: /** @type {HTMLElement} */ (fixtureSync(html`<div>content</div>`)),
+    invokerNode: /** @type {HTMLElement} */ (fixtureSync(html`<button>invoker</button>`)),
     ...withHoverInteraction(opts),
   });
 }


### PR DESCRIPTION
## What I did

1. fixed 2 failing lint issues
2. enabled `npm run types` to run on "lint" task of verify-pr pipeline (so it catches any issues before releasing)
