### PR TITLE
feat: implement interactive month and year navigation in LionCalendar with updated translation strings

### DIFF
--- a/.changeset/five-emus-visit.md
+++ b/.changeset/five-emus-visit.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Added interactive month and year navigation to LionCalendar. Users can now click the month or year heading to open a dedicated month/year grid selection view.

--- a/packages/ui/components/calendar/src/LionCalendar.js
+++ b/packages/ui/components/calendar/src/LionCalendar.js
@@ -34,6 +34,12 @@ function isDisabledDayButton(el) {
   return el.getAttribute('aria-disabled') === 'true';
 }
 
+/** Number of months in a year */
+const MONTHS_IN_YEAR = 12;
+
+/** Number of years displayed in the year selection grid */
+const YEAR_GRID_SIZE = 12;
+
 /**
  * @customElement lion-calendar
  */
@@ -166,6 +172,30 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
        * Data to render current month grid
        */
       __data: { attribute: false },
+
+      /**
+       * Current view mode: 'month' | 'month-selection' | 'year-selection'
+       * @private
+       */
+      __viewMode: { attribute: false },
+
+      /**
+       * First year in the current year selection grid
+       * @private
+       */
+      __yearRangeStart: { attribute: false },
+
+      /**
+       * Focused month index (0-11) in month selection view
+       * @private
+       */
+      __focusedMonthIndex: { attribute: false },
+
+      /**
+       * Focused year index (0-11) in year selection view
+       * @private
+       */
+      __focusedYearIndex: { attribute: false },
     };
   }
 
@@ -209,6 +239,25 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     this.__boundFocusDateDelegation = this.__focusDateDelegation.bind(this);
     /** @private */
     this.__boundBlurDateDelegation = this.__focusDateDelegation.bind(this);
+
+    // Month/Year selection state
+    /** @type {'month' | 'month-selection' | 'year-selection'} @private */
+    this.__viewMode = 'month';
+    /** @type {number} @private */
+    this.__yearRangeStart = new Date().getFullYear() - 4;
+    /** @type {number} @private */
+    this.__focusedMonthIndex = 0;
+    /** @type {number} @private */
+    this.__focusedYearIndex = 0;
+    /**
+     * Cache for month disabled state computation (disableDates)
+     * @type {Map<string, boolean> | null}
+     * @private
+     */
+    this.__monthDisabledCache = null;
+
+    /** @private */
+    this.__boundHandleClickOutside = this.__handleClickOutside.bind(this);
   }
 
   static get styles() {
@@ -216,9 +265,21 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
   }
 
   render() {
+    const isSelectionActive = this.__viewMode !== 'month';
     return html`
-      <div class="calendar" role="application">
+      <div
+        class="calendar${isSelectionActive ? ' calendar--selection-active' : ''}"
+        role="application"
+      >
         ${this.__renderNavigation()} ${this.__renderData()}
+        ${this.__viewMode === 'month-selection' ? this.__renderMonthSelectionView() : ''}
+        ${this.__viewMode === 'year-selection' ? this.__renderYearSelectionView() : ''}
+        <div
+          aria-live="polite"
+          aria-atomic="true"
+          class="u-sr-only"
+          id="calendar-live-region"
+        ></div>
       </div>
     `;
   }
@@ -256,9 +317,12 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     const datesTable = /** @type {HTMLElement} */ (
       this.shadowRoot?.querySelector('#js-content-wrapper')
     );
+    if (!datesTable) return;
     const button = /** @type {HTMLElement} */ (datesTable.querySelector('[tabindex="0"]'));
-    button.focus();
-    this.__focusedDate = this.centralDate;
+    if (button) {
+      button.focus();
+      this.__focusedDate = this.centralDate;
+    }
   }
 
   async focusSelectedDate() {
@@ -295,10 +359,15 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
       this.__contentWrapperElement = /** @type {HTMLButtonElement} */ (
         this.shadowRoot?.getElementById('js-content-wrapper')
       );
-      this.__contentWrapperElement.addEventListener('click', this.__boundClickDateDelegation);
-      this.__contentWrapperElement.addEventListener('focus', this.__boundFocusDateDelegation);
-      this.__contentWrapperElement.addEventListener('blur', this.__boundBlurDateDelegation);
-      this.__contentWrapperElement.addEventListener('keydown', this.__boundKeyboardNavigationEvent);
+      if (this.__contentWrapperElement) {
+        this.__contentWrapperElement.addEventListener('click', this.__boundClickDateDelegation);
+        this.__contentWrapperElement.addEventListener('focus', this.__boundFocusDateDelegation);
+        this.__contentWrapperElement.addEventListener('blur', this.__boundBlurDateDelegation);
+        this.__contentWrapperElement.addEventListener(
+          'keydown',
+          this.__boundKeyboardNavigationEvent,
+        );
+      }
       this.__eventsAdded = true;
     }
   }
@@ -325,6 +394,8 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
 
       this.__eventsAdded = false;
     }
+    // Clean up click outside listener if active
+    this.__removeClickOutsideListener();
   }
 
   /** @param {import('lit').PropertyValues } changedProperties */
@@ -332,6 +403,14 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     super.updated(changedProperties);
     if (changedProperties.has('__focusedDate') && this.__focusedDate) {
       this.focusCentralDate();
+    }
+    // Manage click-outside listener based on view mode
+    if (changedProperties.has('__viewMode')) {
+      if (this.__viewMode !== 'month') {
+        this.__setupClickOutsideListener();
+      } else {
+        this.__removeClickOutsideListener();
+      }
     }
   }
 
@@ -355,6 +434,10 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     const updateDataOn = ['centralDate', 'minDate', 'maxDate', 'selectedDate', 'disableDates'];
 
     if (updateDataOn.includes(name) && this.__connectedCallbackDone) {
+      // Invalidate month disabled cache when constraints change
+      if (['minDate', 'maxDate', 'disableDates'].includes(name)) {
+        this.__monthDisabledCache = null;
+      }
       this.__data = this.__createData();
     }
   }
@@ -364,8 +447,19 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
    * reinitialize when calendar is opened
    */
   initCentralDate() {
+    // Reset view mode when calendar is re-opened (e.g. from datepicker overlay)
+    this.__viewMode = 'month';
     if (this.selectedDate) {
-      this.focusSelectedDate();
+      if (this.__isEnabledDate(this.selectedDate)) {
+        // Selected date is valid and within range — navigate to it
+        this.focusSelectedDate();
+      } else {
+        // Selected date exists but is outside min/max range (e.g. user typed an out-of-range
+        // date in the input). Navigate to the nearest selectable date instead so the user can
+        // pick from a valid range.
+        this.centralDate = this.findNearestEnabledDate(this.selectedDate);
+        this.focusCentralDate();
+      }
     } else {
       if (!this.__isEnabledDate(/** @type {Date} */ (this.__initialCentralDate))) {
         this.centralDate = this.findNearestEnabledDate(this.__initialCentralDate);
@@ -412,10 +506,21 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
         : getMonthNames({ locale: this.__getLocale() })[this.centralDate.getMonth() - 1];
     const nextYear = this.centralDate.getMonth() === 11 ? year + 1 : year;
     const previousYear = this.centralDate.getMonth() === 0 ? year - 1 : year;
+
     return html`
       <div class="calendar__navigation__month">
         ${this.__renderPreviousButton('Month', previousMonth, previousYear)}
-        <h2 class="calendar__navigation-heading" id="month" aria-atomic="true">${month}</h2>
+        <button
+          id="month-heading"
+          class="calendar__navigation-heading calendar__navigation-heading--interactive"
+          aria-label="${month}, ${this.msgLit('lion-calendar:selectMonth')}"
+          aria-atomic="true"
+          @click=${this.__toggleMonthSelection}
+          @keydown=${this.__monthHeadingKeydown}
+        >
+          ${month}
+          <span class="calendar__heading-indicator" aria-hidden="true">▾</span>
+        </button>
         ${this.__renderNextButton('Month', nextMonth, nextYear)}
       </div>
     `;
@@ -433,7 +538,16 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     return html`
       <div class="calendar__navigation__year">
         ${this.__renderPreviousButton('FullYear', month, previousYear)}
-        <h2 class="calendar__navigation-heading" id="year" aria-atomic="true">${year}</h2>
+        <button
+          id="year-heading"
+          class="calendar__navigation-heading calendar__navigation-heading--interactive"
+          aria-label="${year}, ${this.msgLit('lion-calendar:selectYear')}"
+          @click=${this.__toggleYearSelection}
+          @keydown=${this.__yearHeadingKeydown}
+        >
+          ${year}
+          <span class="calendar__heading-indicator" aria-hidden="true">▾</span>
+        </button>
         ${this.__renderNextButton('FullYear', month, nextYear)}
       </div>
     `;
@@ -448,6 +562,106 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
     return html`
       <div class="calendar__navigation">
         ${this.__renderYearNavigation(month, year)} ${this.__renderMonthNavigation(month, year)}
+      </div>
+    `;
+  }
+
+  /**
+   * Renders the month selection grid (3x4, 12 months)
+   * @private
+   */
+  __renderMonthSelectionView() {
+    const months = getMonthNames({ locale: this.__getLocale() });
+    const currentMonth = this.centralDate.getMonth();
+
+    return html`
+      <div
+        id="month-selection-grid"
+        class="calendar__month-selection"
+        role="grid"
+        aria-label="${this.msgLit('lion-calendar:selectMonth')}"
+        @keydown=${this.__monthSelectionKeydownHandler}
+      >
+        ${months.map((monthName, index) => {
+          const isDisabled = this.__isMonthDisabled(index);
+          const isCurrent = index === currentMonth;
+          const isFocused = index === this.__focusedMonthIndex;
+          return html`
+            <button
+              class="calendar__month-button${isCurrent ? ' calendar__month-button--current' : ''}"
+              role="gridcell"
+              aria-disabled="${isDisabled}"
+              aria-selected="${isCurrent}"
+              tabindex="${isFocused ? '0' : '-1'}"
+              data-month-index="${index}"
+              @click=${() => this.__selectMonth(index)}
+            >
+              ${monthName}
+            </button>
+          `;
+        })}
+      </div>
+    `;
+  }
+
+  /**
+   * Renders the year selection grid (4x3, 12 years) with range navigation
+   * @private
+   */
+  __renderYearSelectionView() {
+    const years = this.__getYearsForCurrentRange();
+    const currentYear = this.centralDate.getFullYear();
+    const rangeEnd = this.__yearRangeStart + YEAR_GRID_SIZE - 1;
+
+    return html`
+      <div class="calendar__year-selection">
+        <div class="calendar__year-selection-header">
+          <button
+            class="calendar__year-range-prev"
+            @click=${this.__previousYearRange}
+            ?disabled=${this.__isPreviousRangeDisabled()}
+            aria-label="${this.msgLit('lion-calendar:previousYearRange')}"
+          >
+            ${this._previousIconTemplate()}
+          </button>
+          <span class="calendar__year-range-label">
+            ${this.__yearRangeStart}&nbsp;–&nbsp;${rangeEnd}
+          </span>
+          <button
+            class="calendar__year-range-next"
+            @click=${this.__nextYearRange}
+            ?disabled=${this.__isNextRangeDisabled()}
+            aria-label="${this.msgLit('lion-calendar:nextYearRange')}"
+          >
+            ${this._nextIconTemplate()}
+          </button>
+        </div>
+        <div
+          id="year-selection-grid"
+          class="calendar__year-grid"
+          role="grid"
+          aria-label="${this.msgLit('lion-calendar:selectYear')}"
+          @keydown=${this.__yearSelectionKeydownHandler}
+        >
+          ${years.map((year, index) => {
+            const isDisabled = this.__isYearDisabled(year);
+            const isCurrent = year === currentYear;
+            const isFocused = index === this.__focusedYearIndex;
+            return html`
+              <button
+                class="calendar__year-button${isCurrent ? ' calendar__year-button--current' : ''}"
+                role="gridcell"
+                aria-disabled="${isDisabled}"
+                aria-selected="${isCurrent}"
+                tabindex="${isFocused ? '0' : '-1'}"
+                data-year="${year}"
+                @click=${() => this.__selectYear(year)}
+              >
+                ${year}
+              </button>
+            `;
+          })}
+        </div>
       </div>
     `;
   }
@@ -604,6 +818,630 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
    */
   __getNavigationLabel(mode, type, month, year) {
     return `${this.msgLit(`lion-calendar:${mode}${type}`)}, ${month} ${year}`;
+  }
+
+  /**
+   * Toggle the month selection view
+   * @private
+   */
+  __toggleMonthSelection() {
+    if (this.__viewMode === 'month-selection') {
+      this.__closeSelectionView('month-heading');
+    } else {
+      this.__openMonthSelection();
+    }
+  }
+
+  /**
+   * Toggle the year selection view
+   * @private
+   */
+  __toggleYearSelection() {
+    if (this.__viewMode === 'year-selection') {
+      this.__closeSelectionView('year-heading');
+    } else {
+      this.__openYearSelection();
+    }
+  }
+
+  /**
+   * Open month selection view and set initial focus
+   * @private
+   */
+  async __openMonthSelection() {
+    this.__focusedMonthIndex = this.centralDate.getMonth();
+    this.__viewMode = 'month-selection';
+    await this.updateComplete;
+    this.__announceToScreenReader(this.msgLit('lion-calendar:monthSelectionOpened'));
+    this.__focusMonthInSelection(this.__focusedMonthIndex);
+  }
+
+  /**
+   * Open year selection view and set initial focus
+   * @private
+   */
+  async __openYearSelection() {
+    const currentYear = this.centralDate.getFullYear();
+    this.__initializeYearRange(currentYear);
+    // Set focused index to the current year position in range
+    this.__focusedYearIndex = currentYear - this.__yearRangeStart;
+    if (this.__focusedYearIndex < 0 || this.__focusedYearIndex >= YEAR_GRID_SIZE) {
+      this.__focusedYearIndex = 0;
+    }
+    this.__viewMode = 'year-selection';
+    await this.updateComplete;
+    const rangeEnd = this.__yearRangeStart + YEAR_GRID_SIZE - 1;
+    this.__announceToScreenReader(
+      this.msgLit('lion-calendar:yearSelectionOpened', {
+        startYear: this.__yearRangeStart,
+        endYear: rangeEnd,
+      }),
+    );
+    this.__focusYearInSelection(this.__focusedYearIndex);
+  }
+
+  /**
+   * Close the current selection view and return focus to heading
+   * @param {string} headingId
+   * @private
+   */
+  __closeSelectionView(headingId) {
+    this.__viewMode = 'month';
+    // Return focus to heading after DOM update
+    requestAnimationFrame(() => {
+      const heading = /** @type {HTMLElement | null} */ (
+        this.shadowRoot?.getElementById(headingId)
+      );
+      heading?.focus();
+    });
+  }
+
+  /**
+   * Select a month from the month selection view
+   * @param {number} monthIndex - 0-11
+   * @private
+   */
+  async __selectMonth(monthIndex) {
+    if (this.__isMonthDisabled(monthIndex)) {
+      return;
+    }
+    const newDate = new Date(this.centralDate);
+    newDate.setMonth(monthIndex);
+    // Clamp day to valid range for the new month
+    const maxDays = new Date(newDate.getFullYear(), monthIndex + 1, 0).getDate();
+    newDate.setDate(Math.min(this.centralDate.getDate(), maxDays));
+    // Clamp to minDate/maxDate
+    this.centralDate = this.__clampDateToRange(newDate);
+    this.__viewMode = 'month';
+    await this.updateComplete;
+    this.__announceToScreenReader(
+      `${getMonthNames({ locale: this.__getLocale() })[this.centralDate.getMonth()]} ${this.centralDate.getFullYear()}`,
+    );
+    this.__focusFirstEnabledDay();
+  }
+
+  /**
+   * Keyboard handler for month heading button
+   * @param {KeyboardEvent} ev
+   * @private
+   */
+  __monthHeadingKeydown(ev) {
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      ev.preventDefault();
+      this.__toggleMonthSelection();
+    }
+  }
+
+  /**
+   * Keyboard handler inside month selection grid
+   * @param {KeyboardEvent} ev
+   * @private
+   */
+  __monthSelectionKeydownHandler(ev) {
+    const preventedKeys = [
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'Enter',
+      ' ',
+      'Escape',
+      'Tab',
+    ];
+    if (preventedKeys.includes(ev.key)) {
+      ev.preventDefault();
+    }
+
+    const COLS = 3;
+    let newIndex = this.__focusedMonthIndex;
+
+    switch (ev.key) {
+      case 'ArrowRight':
+        newIndex = this.__findNextEnabledMonthFrom(this.__focusedMonthIndex, 1);
+        break;
+      case 'ArrowLeft':
+        newIndex = this.__findNextEnabledMonthFrom(this.__focusedMonthIndex, -1);
+        break;
+      case 'ArrowDown':
+        newIndex = this.__findNextEnabledMonthFrom(this.__focusedMonthIndex, COLS);
+        break;
+      case 'ArrowUp':
+        newIndex = this.__findNextEnabledMonthFrom(this.__focusedMonthIndex, -COLS);
+        break;
+      case 'Enter':
+      case ' ':
+        this.__selectMonth(this.__focusedMonthIndex);
+        return;
+      case 'Escape':
+        this.__closeSelectionView('month-heading');
+        return;
+      case 'Tab':
+        // Allow tab to exit the grid naturally
+        this.__viewMode = 'month';
+        return;
+      // no default
+    }
+
+    if (newIndex !== -1 && newIndex !== this.__focusedMonthIndex) {
+      this.__focusedMonthIndex = newIndex;
+      this.__focusMonthInSelection(newIndex);
+    }
+  }
+
+  /**
+   * Find the next enabled month from a given index, moving by `step`
+   * Wraps within 0-11 range
+   * @param {number} currentIndex
+   * @param {number} step
+   * @returns {number} next enabled month index, or currentIndex if none
+   * @private
+   */
+  __findNextEnabledMonthFrom(currentIndex, step) {
+    const wrapMonth = n => ((n % MONTHS_IN_YEAR) + MONTHS_IN_YEAR) % MONTHS_IN_YEAR;
+    const direction = step > 0 ? 1 : -1;
+    const startIndex = wrapMonth(currentIndex + step);
+    const candidate = Array.from({ length: MONTHS_IN_YEAR }, (_, i) =>
+      wrapMonth(startIndex + direction * i),
+    ).find(idx => !this.__isMonthDisabled(idx));
+    return candidate ?? currentIndex;
+  }
+
+  /**
+   * Focus a month button in the selection view
+   * @param {number} monthIndex
+   * @private
+   */
+  async __focusMonthInSelection(monthIndex) {
+    await this.updateComplete;
+    const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+      this.shadowRoot?.querySelectorAll('.calendar__month-button')
+    );
+    if (buttons && buttons[monthIndex] && !this.__isMonthDisabled(monthIndex)) {
+      buttons[monthIndex].focus();
+    } else if (buttons) {
+      // Find first enabled month
+      const enabledIndex = Array.from({ length: MONTHS_IN_YEAR }, (_, i) => i).find(
+        i => !this.__isMonthDisabled(i),
+      );
+      if (enabledIndex !== undefined) {
+        this.__focusedMonthIndex = enabledIndex;
+        buttons[enabledIndex]?.focus();
+      }
+    }
+  }
+
+  /**
+   * Select a year from the year selection view
+   * @param {number} year
+   * @private
+   */
+  async __selectYear(year) {
+    if (this.__isYearDisabled(year)) {
+      return;
+    }
+    const newDate = new Date(this.centralDate);
+    newDate.setFullYear(year);
+    // Adjust month if the new year causes out-of-range
+    this.centralDate = this.__clampDateToRange(newDate);
+    this.__viewMode = 'month';
+    await this.updateComplete;
+    this.__announceToScreenReader(
+      `${getMonthNames({ locale: this.__getLocale() })[this.centralDate.getMonth()]} ${this.centralDate.getFullYear()}`,
+    );
+    this.__focusFirstEnabledDay();
+  }
+
+  /**
+   * Keyboard handler for year heading button
+   * @param {KeyboardEvent} ev
+   * @private
+   */
+  __yearHeadingKeydown(ev) {
+    if (ev.key === 'Enter' || ev.key === ' ') {
+      ev.preventDefault();
+      this.__toggleYearSelection();
+    }
+  }
+
+  /**
+   * Keyboard handler inside year selection grid
+   * @param {KeyboardEvent} ev
+   * @private
+   */
+  __yearSelectionKeydownHandler(ev) {
+    const preventedKeys = [
+      'ArrowLeft',
+      'ArrowRight',
+      'ArrowUp',
+      'ArrowDown',
+      'Enter',
+      ' ',
+      'Escape',
+      'PageUp',
+      'PageDown',
+      'Tab',
+    ];
+    if (preventedKeys.includes(ev.key)) {
+      ev.preventDefault();
+    }
+
+    const COLS = 4;
+    let newIndex = this.__focusedYearIndex;
+
+    switch (ev.key) {
+      case 'ArrowRight':
+        newIndex = this.__findNextEnabledYearFrom(this.__focusedYearIndex, 1);
+        break;
+      case 'ArrowLeft':
+        newIndex = this.__findNextEnabledYearFrom(this.__focusedYearIndex, -1);
+        break;
+      case 'ArrowDown':
+        newIndex = this.__findNextEnabledYearFrom(this.__focusedYearIndex, COLS);
+        break;
+      case 'ArrowUp':
+        newIndex = this.__findNextEnabledYearFrom(this.__focusedYearIndex, -COLS);
+        break;
+      case 'Enter':
+      case ' ': {
+        const years = this.__getYearsForCurrentRange();
+        this.__selectYear(years[this.__focusedYearIndex]);
+        return;
+      }
+      case 'Escape':
+        this.__closeSelectionView('year-heading');
+        return;
+      case 'PageDown':
+        this.__nextYearRange();
+        return;
+      case 'PageUp':
+        this.__previousYearRange();
+        return;
+      case 'Tab':
+        this.__viewMode = 'month';
+        return;
+      // no default
+    }
+
+    if (newIndex !== this.__focusedYearIndex) {
+      this.__focusedYearIndex = newIndex;
+      this.__focusYearInSelection(newIndex);
+    }
+  }
+
+  /**
+   * Find next enabled year index from current index, moving by `step`
+   * Stays within the 0-(YEAR_GRID_SIZE-1) range
+   * @param {number} currentIndex
+   * @param {number} step
+   * @returns {number}
+   * @private
+   */
+  __findNextEnabledYearFrom(currentIndex, step) {
+    const years = this.__getYearsForCurrentRange();
+    const total = years.length;
+    const startIndex = Math.max(0, Math.min(total - 1, currentIndex + step));
+    const direction = step > 0 ? 1 : -1;
+    const candidate = Array.from({ length: total }, (_, i) => startIndex + direction * i).find(
+      idx => idx >= 0 && idx < total && !this.__isYearDisabled(years[idx]),
+    );
+    return candidate ?? currentIndex;
+  }
+
+  /**
+   * Focus a year button in the year selection grid
+   * @param {number} yearIndex
+   * @private
+   */
+  async __focusYearInSelection(yearIndex) {
+    await this.updateComplete;
+    const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+      this.shadowRoot?.querySelectorAll('.calendar__year-button')
+    );
+    const years = this.__getYearsForCurrentRange();
+    if (buttons && buttons[yearIndex] && !this.__isYearDisabled(years[yearIndex])) {
+      buttons[yearIndex].focus();
+    } else if (buttons) {
+      // Find first enabled year
+      const enabledIndex = years.findIndex(year => !this.__isYearDisabled(year));
+      if (enabledIndex !== -1) {
+        this.__focusedYearIndex = enabledIndex;
+        buttons[enabledIndex]?.focus();
+      }
+    }
+  }
+
+  /**
+   * Returns array of years for the current range
+   * @returns {number[]}
+   * @private
+   */
+  __getYearsForCurrentRange() {
+    return Array.from({ length: YEAR_GRID_SIZE }, (_, i) => this.__yearRangeStart + i);
+  }
+
+  /**
+   * Initialize year range centered on targetYear
+   * @param {number} targetYear
+   * @private
+   */
+  __initializeYearRange(targetYear) {
+    // Center the range: show 4 years before, 7 after (0-indexed)
+    const clampedYear = Math.max(5, Math.min(9988, targetYear));
+    this.__yearRangeStart = clampedYear - 4;
+  }
+
+  /**
+   * Navigate to the previous year range
+   * @private
+   */
+  async __previousYearRange() {
+    if (this.__isPreviousRangeDisabled()) return;
+    this.__yearRangeStart -= YEAR_GRID_SIZE;
+    // Focus first enabled year in new range
+    this.__focusedYearIndex = 0;
+    await this.updateComplete;
+    const rangeEnd = this.__yearRangeStart + YEAR_GRID_SIZE - 1;
+    this.__announceYearRange(this.__yearRangeStart, rangeEnd);
+    this.__focusYearInSelection(0);
+  }
+
+  /**
+   * Navigate to the next year range
+   * @private
+   */
+  async __nextYearRange() {
+    if (this.__isNextRangeDisabled()) return;
+    this.__yearRangeStart += YEAR_GRID_SIZE;
+    this.__focusedYearIndex = 0;
+    await this.updateComplete;
+    const rangeEnd = this.__yearRangeStart + YEAR_GRID_SIZE - 1;
+    this.__announceYearRange(this.__yearRangeStart, rangeEnd);
+    this.__focusYearInSelection(0);
+  }
+
+  /**
+   * Checks if the previous year range button should be disabled
+   * @returns {boolean}
+   * @private
+   */
+  __isPreviousRangeDisabled() {
+    if (!this.__hasMinDateConstraint()) return false;
+    // Disabled when the last year in the previous range would still be before minDate
+    return this.__yearRangeStart - 1 < this.minDate.getFullYear();
+  }
+
+  /**
+   * Checks if the next year range button should be disabled
+   * @returns {boolean}
+   * @private
+   */
+  __isNextRangeDisabled() {
+    if (!this.__hasMaxDateConstraint()) return false;
+    // Disabled when the first year in the next range would be after maxDate
+    return this.__yearRangeStart + YEAR_GRID_SIZE > this.maxDate.getFullYear();
+  }
+
+  /**
+   * Returns true when minDate is set to something other than the epoch default.
+   * @returns {boolean}
+   * @private
+   */
+  __hasMinDateConstraint() {
+    return this.minDate != null && this.minDate.getTime() !== new Date(0).getTime();
+  }
+
+  /**
+   * Returns true when maxDate is set to something other than the max-date-value default.
+   * @returns {boolean}
+   * @private
+   */
+  __hasMaxDateConstraint() {
+    return this.maxDate != null && this.maxDate.getTime() !== new Date(8640000000000000).getTime();
+  }
+
+  /**
+   * Determines if a month is entirely disabled based on constraints.
+   * A month is disabled if it's before minDate month (in minDate year) or
+   * after maxDate month (in maxDate year), or all its days are disabled.
+   * @param {number} monthIndex - 0-11
+   * @returns {boolean}
+   * @private
+   */
+  __isMonthDisabled(monthIndex) {
+    const year = this.centralDate.getFullYear();
+
+    if (this.__hasMinDateConstraint()) {
+      const minYear = this.minDate.getFullYear();
+      const minMonth = this.minDate.getMonth();
+      if (year < minYear || (year === minYear && monthIndex < minMonth)) {
+        return true;
+      }
+    }
+
+    if (this.__hasMaxDateConstraint()) {
+      const maxYear = this.maxDate.getFullYear();
+      const maxMonth = this.maxDate.getMonth();
+      if (year > maxYear || (year === maxYear && monthIndex > maxMonth)) {
+        return true;
+      }
+    }
+
+    // Check if all days in month are disabled by disableDates
+    return this.__isMonthFullyDisabledByDisableDates(year, monthIndex);
+  }
+
+  /**
+   * Checks if the disableDates function disables all days in a month.
+   * Results are cached per year/month combination.
+   * @param {number} year
+   * @param {number} monthIndex
+   * @returns {boolean}
+   * @private
+   */
+  __isMonthFullyDisabledByDisableDates(year, monthIndex) {
+    // Skip if disableDates is the default no-op function
+    if (this.disableDates === /** @type {any} */ (LionCalendar.prototype.disableDates)) {
+      return false;
+    }
+
+    const cacheKey = `${year}-${monthIndex}`;
+    if (this.__monthDisabledCache?.has(cacheKey)) {
+      return /** @type {boolean} */ (this.__monthDisabledCache.get(cacheKey));
+    }
+
+    const daysInMonth = new Date(year, monthIndex + 1, 0).getDate();
+    const isFullyDisabled = Array.from(
+      { length: daysInMonth },
+      (_, i) => new Date(year, monthIndex, i + 1),
+    ).every(date => this.disableDates(date));
+
+    if (!this.__monthDisabledCache) {
+      this.__monthDisabledCache = new Map();
+    }
+    this.__monthDisabledCache.set(cacheKey, isFullyDisabled);
+
+    return isFullyDisabled;
+  }
+
+  /**
+   * Determines if a year is disabled based on minDate/maxDate constraints
+   * @param {number} year
+   * @returns {boolean}
+   * @private
+   */
+  __isYearDisabled(year) {
+    if (this.__hasMinDateConstraint() && year < this.minDate.getFullYear()) return true;
+    if (this.__hasMaxDateConstraint() && year > this.maxDate.getFullYear()) return true;
+    return false;
+  }
+
+  /**
+   * Clamp a date to the minDate/maxDate range
+   * @param {Date} date
+   * @returns {Date}
+   * @private
+   */
+  __clampDateToRange(date) {
+    let result = new Date(date);
+    if (this.__hasMinDateConstraint() && result < this.minDate) {
+      result = new Date(this.minDate);
+    }
+    if (this.__hasMaxDateConstraint() && result > this.maxDate) {
+      result = new Date(this.maxDate);
+    }
+    return result;
+  }
+
+  /**
+   * Focus the first enabled day in the current month
+   * @private
+   */
+  async __focusFirstEnabledDay() {
+    await this.updateComplete;
+    const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+      this.shadowRoot?.querySelectorAll('.calendar__day-button:not([aria-disabled="true"])')
+    );
+    if (buttons && buttons.length > 0) {
+      /** @type {HTMLElement} */ (buttons[0]).focus();
+    } else {
+      // Fallback to central date
+      this.focusCentralDate();
+    }
+  }
+
+  // ==========================================
+  // PRIVATE: Screen Reader Announcements
+  // ==========================================
+
+  /**
+   * Announce a message via the ARIA live region
+   * @param {string} message
+   * @private
+   */
+  __announceToScreenReader(message) {
+    const liveRegion = /** @type {HTMLElement | null} */ (
+      this.shadowRoot?.getElementById('calendar-live-region')
+    );
+    if (liveRegion) {
+      // Clear then set to ensure announcement fires even for identical messages
+      liveRegion.textContent = '';
+      requestAnimationFrame(() => {
+        liveRegion.textContent = message;
+      });
+    }
+  }
+
+  /**
+   * Announce a year range change to screen readers
+   * @param {number} startYear
+   * @param {number} endYear
+   * @private
+   */
+  __announceYearRange(startYear, endYear) {
+    this.__announceToScreenReader(
+      this.msgLit('lion-calendar:yearsRange', {
+        startYear,
+        endYear,
+      }),
+    );
+  }
+
+  /**
+   * Set up document-level click listener to close selection views
+   * @private
+   */
+  __setupClickOutsideListener() {
+    // Use setTimeout to avoid immediately closing on the click that opened the view
+    this.__clickOutsideTimeoutId = setTimeout(() => {
+      document.addEventListener('click', this.__boundHandleClickOutside, { capture: true });
+      this.__clickOutsideTimeoutId = null;
+    }, 0);
+  }
+
+  /**
+   * Remove the document-level click listener
+   * @private
+   */
+  __removeClickOutsideListener() {
+    if (this.__clickOutsideTimeoutId) {
+      clearTimeout(this.__clickOutsideTimeoutId);
+      this.__clickOutsideTimeoutId = null;
+    }
+    document.removeEventListener('click', this.__boundHandleClickOutside, { capture: true });
+  }
+
+  /**
+   * Handle clicks outside the calendar to close selection views
+   * @param {MouseEvent} ev
+   * @private
+   */
+  __handleClickOutside(ev) {
+    const path = ev.composedPath();
+    const isInsideCalendar = path.some(el => el === this);
+    if (!isInsideCalendar && this.__viewMode !== 'month') {
+      const headingId = this.__viewMode === 'month-selection' ? 'month-heading' : 'year-heading';
+      this.__closeSelectionView(headingId);
+    }
   }
 
   /**
@@ -803,6 +1641,10 @@ export class LionCalendar extends LocalizeMixin(LitElement) {
       `Could not find a selectable date within +/- 750 day for ${year}/${month}/${day}`,
     );
   }
+
+  // ==========================================
+  // PRIVATE: Event Delegation (Day Grid)
+  // ==========================================
 
   /**
    * @param {Event} ev

--- a/packages/ui/components/calendar/src/calendarStyle.js
+++ b/packages/ui/components/calendar/src/calendarStyle.js
@@ -13,6 +13,11 @@ export const calendarStyle = css`
     display: block;
   }
 
+  /* Hide day grid when month/year selection view is active */
+  .calendar--selection-active #js-content-wrapper {
+    display: none;
+  }
+
   .calendar__navigation {
     padding: 0 8px;
   }
@@ -105,5 +110,266 @@ export const calendarStyle = css`
     border: 0;
     margin: 0;
     padding: 0;
+  }
+
+  .calendar__navigation-heading--interactive {
+    cursor: pointer;
+    background: none;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    padding: 0.25em 0.5em;
+    font-size: inherit;
+    font-weight: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: background-color 0.15s ease;
+  }
+
+  .calendar__navigation-heading--interactive:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+    border-color: rgba(0, 0, 0, 0.1);
+  }
+
+  /* WCAG 1.4.11: focus ring min 3:1 contrast ratio, min 2px width */
+  .calendar__navigation-heading--interactive:focus {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+  }
+
+  /* Hide default focus outline for mouse users (keep for keyboard) */
+  .calendar__navigation-heading--interactive:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  .calendar__navigation-heading--interactive:focus-visible {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+  }
+
+  .calendar__heading-indicator {
+    font-size: 0.75em;
+    display: inline-block;
+    transition: transform 0.2s ease;
+    pointer-events: none;
+  }
+
+  .calendar__navigation-heading--interactive[aria-expanded='true'] .calendar__heading-indicator {
+    transform: rotate(180deg);
+  }
+
+  /* =============================================
+   * Month Selection View — 3×4 Grid
+   * WCAG 2.5.5: min 44×44px touch targets
+   * ============================================= */
+
+  .calendar__month-selection {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    padding: 16px 8px;
+    animation: calendarFadeIn 0.15s ease;
+  }
+
+  /* =============================================
+   * Year Selection View
+   * ============================================= */
+
+  .calendar__year-selection {
+    padding: 8px;
+    animation: calendarFadeIn 0.15s ease;
+  }
+
+  .calendar__year-selection-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 0 12px;
+  }
+
+  .calendar__year-range-label {
+    font-weight: 500;
+    font-size: 0.95em;
+  }
+
+  /* Year Grid — 4×3 */
+  .calendar__year-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 8px;
+  }
+
+  /* Year range navigation buttons */
+  .calendar__year-range-prev,
+  .calendar__year-range-next {
+    min-width: 44px;
+    min-height: 44px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .calendar__year-range-prev:hover:not(:disabled),
+  .calendar__year-range-next:hover:not(:disabled) {
+    background-color: #f0f0f0;
+    border-color: #bbb;
+  }
+
+  .calendar__year-range-prev:focus,
+  .calendar__year-range-next:focus {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+  }
+
+  .calendar__year-range-prev:focus:not(:focus-visible),
+  .calendar__year-range-next:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  .calendar__year-range-prev:focus-visible,
+  .calendar__year-range-next:focus-visible {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+  }
+
+  .calendar__year-range-prev:disabled,
+  .calendar__year-range-next:disabled {
+    color: #aaa;
+    cursor: not-allowed;
+    background-color: #f9f9f9;
+  }
+
+  /* =============================================
+   * Month and Year Selection Buttons
+   * WCAG 2.5.5: min 44×44px touch targets
+   * WCAG 1.4.11: focus ring 3:1 contrast
+   * ============================================= */
+
+  .calendar__month-button,
+  .calendar__year-button {
+    min-width: 44px;
+    min-height: 44px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    transition:
+      background-color 0.15s ease,
+      border-color 0.15s ease;
+  }
+
+  .calendar__month-button:hover:not([aria-disabled='true']),
+  .calendar__year-button:hover:not([aria-disabled='true']) {
+    background-color: #f0f0f0;
+    border-color: #bbb;
+  }
+
+  /* WCAG 1.4.11: focus ring min 3:1 contrast, 2px width */
+  .calendar__month-button:focus,
+  .calendar__year-button:focus {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+  }
+
+  .calendar__month-button:focus:not(:focus-visible),
+  .calendar__year-button:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  .calendar__month-button:focus-visible,
+  .calendar__year-button:focus-visible {
+    outline: 2px solid #005fcc;
+    outline-offset: 2px;
+  }
+
+  /* Highlight current month/year */
+  .calendar__month-button--current,
+  .calendar__year-button--current {
+    background-color: #e3f2fd;
+    border-color: #005fcc;
+    font-weight: bold;
+  }
+
+  /* Disabled state — WCAG 1.4.3: sufficient contrast with background */
+  .calendar__month-button[aria-disabled='true'],
+  .calendar__year-button[aria-disabled='true'] {
+    color: #767676;
+    background-color: #f5f5f5;
+    border-color: #ddd;
+    cursor: not-allowed;
+  }
+
+  /* =============================================
+   * Fade-in animation
+   * ============================================= */
+
+  @keyframes calendarFadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(-8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* =============================================
+   * Reduced Motion — WCAG 2.3.3 (AAA) / EAA
+   * Disable or minimize all animations/transitions
+   * ============================================= */
+
+  @media (prefers-reduced-motion: reduce) {
+    .calendar__month-selection,
+    .calendar__year-selection {
+      animation: none;
+    }
+
+    .calendar__navigation-heading--interactive,
+    .calendar__month-button,
+    .calendar__year-button,
+    .calendar__year-range-prev,
+    .calendar__year-range-next {
+      transition: none;
+    }
+
+    .calendar__heading-indicator {
+      transition: none;
+    }
+  }
+
+  /* =============================================
+   * Responsive — small viewports
+   * WCAG 2.5.5: maintain 44×44px on small screens
+   * ============================================= */
+
+  @media (max-width: 320px) {
+    .calendar__month-selection {
+      gap: 4px;
+      padding: 8px 4px;
+    }
+
+    .calendar__year-grid {
+      gap: 4px;
+    }
+
+    .calendar__month-button,
+    .calendar__year-button {
+      font-size: 12px;
+      min-width: 44px;
+      min-height: 44px;
+    }
   }
 `;

--- a/packages/ui/components/calendar/src/utils/dataTemplate.js
+++ b/packages/ui/components/calendar/src/utils/dataTemplate.js
@@ -18,7 +18,7 @@ export function dataTemplate(
             data-wrap-cols
             aria-readonly="true"
             class="calendar__grid"
-            aria-labelledby="month year"
+            aria-labelledby="month-heading year-heading"
           >
             <thead>
               <tr role="row">

--- a/packages/ui/components/calendar/test-helpers/CalendarObject.js
+++ b/packages/ui/components/calendar/test-helpers/CalendarObject.js
@@ -25,11 +25,11 @@ export class CalendarObject {
   }
 
   get yearHeadingEl() {
-    return this.el.shadowRoot?.querySelector('#year');
+    return this.el.shadowRoot?.querySelector('#year-heading');
   }
 
   get monthHeadingEl() {
-    return this.el.shadowRoot?.querySelector('#month');
+    return this.el.shadowRoot?.querySelector('#month-heading');
   }
 
   get nextYearButtonEl() {
@@ -165,10 +165,12 @@ export class CalendarObject {
    * States
    */
   get activeMonth() {
-    return this.monthHeadingEl?.textContent?.trim();
+    const text = this.monthHeadingEl?.textContent || '';
+    return text.replace('▾', '').trim();
   }
 
   get activeYear() {
-    return this.yearHeadingEl?.textContent?.trim();
+    const text = this.yearHeadingEl?.textContent || '';
+    return text.replace('▾', '').trim();
   }
 }

--- a/packages/ui/components/calendar/test/lion-calendar-month-year-navigation.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar-month-year-navigation.test.js
@@ -1,0 +1,991 @@
+import { html } from 'lit';
+import { localizeTearDown } from '@lion/ui/localize-test-helpers.js';
+import { expect, fixture as _fixture } from '@open-wc/testing';
+import '@lion/ui/define/lion-calendar.js';
+
+/**
+ * @typedef {import('../src/LionCalendar.js').LionCalendar} LionCalendar
+ * @typedef {import('lit').TemplateResult} TemplateResult
+ */
+
+const fixture = /** @type {(arg: TemplateResult) => Promise<LionCalendar>} */ (_fixture);
+/** Waits for the current macrotask queue to flush (e.g. to let setTimeout(0) callbacks run). */
+const nextMacrotask = () =>
+  new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
+
+describe('LionCalendar - Month and Year Navigation', () => {
+  beforeEach(() => {
+    localizeTearDown();
+  });
+
+  describe('Heading Element Interaction States', () => {
+    it('renders month heading as an interactive button with cursor pointer affordance', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = el.shadowRoot?.querySelector('#month-heading');
+      expect(monthBtn).to.exist;
+      expect(monthBtn?.tagName.toLowerCase()).to.equal('button');
+      expect(monthBtn?.classList.contains('calendar__navigation-heading--interactive')).to.be.true;
+    });
+
+    it('renders year heading as an interactive button with cursor pointer affordance', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = el.shadowRoot?.querySelector('#year-heading');
+      expect(yearBtn).to.exist;
+      expect(yearBtn?.tagName.toLowerCase()).to.equal('button');
+      expect(yearBtn?.classList.contains('calendar__navigation-heading--interactive')).to.be.true;
+    });
+
+    it('displays a visual chevron indicator on the month heading', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const indicator = el.shadowRoot?.querySelector('#month-heading .calendar__heading-indicator');
+      expect(indicator).to.exist;
+      expect(indicator?.getAttribute('aria-hidden')).to.equal('true');
+    });
+
+    it('displays a visual chevron indicator on the year heading', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const indicator = el.shadowRoot?.querySelector('#year-heading .calendar__heading-indicator');
+      expect(indicator).to.exist;
+      expect(indicator?.getAttribute('aria-hidden')).to.equal('true');
+    });
+  });
+
+  describe('Month Selection View Trigger', () => {
+    it('opens month selection view when month heading is clicked', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.not.exist;
+
+      monthBtn.click();
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+    });
+
+    it('shows all 12 months in the month selection view', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const monthButtons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      expect(monthButtons?.length).to.equal(12);
+    });
+
+    it('month selection view has role="grid" and correct aria-label', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__month-selection');
+      expect(grid?.getAttribute('role')).to.equal('grid');
+      expect(grid?.getAttribute('aria-label')).to.be.a('string').and.not.empty;
+    });
+
+    it('month buttons have role="gridcell"', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      buttons?.forEach(btn => {
+        expect(btn.getAttribute('role')).to.equal('gridcell');
+      });
+    });
+
+    it('hides the day grid when month selection view is open', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const calendarRoot = el.shadowRoot?.querySelector('.calendar');
+      expect(calendarRoot?.classList.contains('calendar--selection-active')).to.be.true;
+    });
+
+    it('highlights the currently selected month', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      // June is index 5 (0-based)
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      expect(buttons?.[5].classList.contains('calendar__month-button--current')).to.be.true;
+      expect(buttons?.[5].getAttribute('aria-selected')).to.equal('true');
+    });
+
+    it('closes month selection view when month heading is clicked again (toggle)', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+
+      // Open
+      monthBtn.click();
+      await el.updateComplete;
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+
+      // Close
+      monthBtn.click();
+      await el.updateComplete;
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.not.exist;
+    });
+  });
+
+  describe('Year Selection View Trigger', () => {
+    it('opens year selection view when year heading is clicked', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.not.exist;
+      yearBtn.click();
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.exist;
+    });
+
+    it('shows 12 years in the year selection grid', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const yearButtons = el.shadowRoot?.querySelectorAll('.calendar__year-button');
+      expect(yearButtons?.length).to.equal(12);
+    });
+
+    it('year selection grid has role="grid" and correct aria-label', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__year-grid');
+      expect(grid?.getAttribute('role')).to.equal('grid');
+      expect(grid?.getAttribute('aria-label')).to.be.a('string').and.not.empty;
+    });
+
+    it('year buttons have role="gridcell"', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__year-button');
+      buttons?.forEach(btn => {
+        expect(btn.getAttribute('role')).to.equal('gridcell');
+      });
+    });
+
+    it('hides day grid when year selection view is open', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const calendarRoot = el.shadowRoot?.querySelector('.calendar');
+      expect(calendarRoot?.classList.contains('calendar--selection-active')).to.be.true;
+    });
+
+    it('highlights the currently selected year in the year selection grid', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const currentYearBtn = el.shadowRoot?.querySelector('.calendar__year-button--current');
+      expect(currentYearBtn).to.exist;
+      expect(currentYearBtn?.textContent?.trim()).to.equal('2024');
+      expect(currentYearBtn?.getAttribute('aria-selected')).to.equal('true');
+    });
+  });
+
+  describe('Month Selection Navigation', () => {
+    it('selecting an enabled month updates centralDate and returns to month view', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const monthHeadingBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('#month-heading')
+      );
+      monthHeadingBtn.click();
+      await el.updateComplete;
+
+      // Click January (index 0)
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__month-button')
+      );
+      buttons[0].click();
+      await el.updateComplete;
+
+      expect(el.centralDate.getMonth()).to.equal(0); // January
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.not.exist;
+      const calendarRoot = el.shadowRoot?.querySelector('.calendar');
+      expect(calendarRoot?.classList.contains('calendar--selection-active')).to.be.false;
+    });
+
+    it('clicking a disabled month does not change centralDate', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .minDate=${new Date('2024/04/01')}
+        ></lion-calendar>`,
+      );
+      const monthHeadingBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('#month-heading')
+      );
+      monthHeadingBtn.click();
+      await el.updateComplete;
+
+      const originalMonth = el.centralDate.getMonth();
+
+      // Click January (index 0) - disabled because minDate is April 2024
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__month-button')
+      );
+      buttons[0].click();
+      await el.updateComplete;
+
+      expect(el.centralDate.getMonth()).to.equal(originalMonth);
+      // View should remain open
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+    });
+  });
+
+  describe('Year Selection Navigation', () => {
+    it('selecting an enabled year updates centralDate and returns to month view', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearHeadingBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('#year-heading')
+      );
+      yearHeadingBtn.click();
+      await el.updateComplete;
+
+      // Find and click year 2020
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      const targetBtn = Array.from(buttons).find(b => b.textContent?.trim() === '2020');
+      targetBtn?.click();
+      await el.updateComplete;
+
+      expect(el.centralDate.getFullYear()).to.equal(2020);
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.not.exist;
+    });
+
+    it('selecting a year preserves the current month', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearHeadingBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('#year-heading')
+      );
+      yearHeadingBtn.click();
+      await el.updateComplete;
+
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      const targetBtn = Array.from(buttons).find(b => b.textContent?.trim() === '2022');
+      targetBtn?.click();
+      await el.updateComplete;
+
+      // Month should still be June (5)
+      expect(el.centralDate.getMonth()).to.equal(5);
+      expect(el.centralDate.getFullYear()).to.equal(2022);
+    });
+
+    it('clicking a disabled year does not change centralDate', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .minDate=${new Date('2023/01/01')}
+        ></lion-calendar>`,
+      );
+      const yearHeadingBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('#year-heading')
+      );
+      yearHeadingBtn.click();
+      await el.updateComplete;
+
+      const originalYear = el.centralDate.getFullYear();
+
+      // Find a year before minDate (e.g., 2020)
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      const disabledBtn = Array.from(buttons).find(b => b.getAttribute('aria-disabled') === 'true');
+      if (disabledBtn) {
+        disabledBtn.click();
+        await el.updateComplete;
+        expect(el.centralDate.getFullYear()).to.equal(originalYear);
+        // View should remain open
+        expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.exist;
+      }
+    });
+  });
+
+  describe('Year Range Pagination', () => {
+    it('shows previous and next range navigation buttons', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const prevBtn = el.shadowRoot?.querySelector('.calendar__year-range-prev');
+      const nextBtn = el.shadowRoot?.querySelector('.calendar__year-range-next');
+      expect(prevBtn).to.exist;
+      expect(nextBtn).to.exist;
+    });
+
+    it('shows 12 new years after clicking next range button', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const initialFirstYear = el.shadowRoot
+        ?.querySelector('.calendar__year-button')
+        ?.textContent?.trim();
+
+      const nextRangeBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('.calendar__year-range-next')
+      );
+      nextRangeBtn.click();
+      await el.updateComplete;
+
+      const newFirstYear = el.shadowRoot
+        ?.querySelector('.calendar__year-button')
+        ?.textContent?.trim();
+
+      expect(Number(newFirstYear)).to.equal(Number(initialFirstYear) + 12);
+    });
+
+    it('shows 12 earlier years after clicking previous range button', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const initialFirstYear = el.shadowRoot
+        ?.querySelector('.calendar__year-button')
+        ?.textContent?.trim();
+
+      const prevRangeBtn = /** @type {HTMLElement} */ (
+        el.shadowRoot?.querySelector('.calendar__year-range-prev')
+      );
+      prevRangeBtn.click();
+      await el.updateComplete;
+
+      const newFirstYear = el.shadowRoot
+        ?.querySelector('.calendar__year-button')
+        ?.textContent?.trim();
+
+      expect(Number(newFirstYear)).to.equal(Number(initialFirstYear) - 12);
+    });
+  });
+
+  describe('Keyboard Navigation in Month Selection View', () => {
+    it('opens month selection view on Enter keypress on month heading', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = el.shadowRoot?.querySelector('#month-heading');
+
+      monthBtn?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+    });
+
+    it('opens month selection view on Space keypress on month heading', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = el.shadowRoot?.querySelector('#month-heading');
+
+      monthBtn?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+    });
+
+    it('selects focused month on Enter keypress', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      // Navigate to January (index 0) - set focusedMonthIndex directly
+      el.__focusedMonthIndex = 0;
+      await el.updateComplete;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__month-selection');
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.centralDate.getMonth()).to.equal(0); // January
+    });
+
+    it('does not change centralDate when Escape is pressed', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const originalMonth = el.centralDate.getMonth();
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__month-selection');
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.centralDate.getMonth()).to.equal(originalMonth);
+    });
+
+    it('navigates grid with Arrow keys', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      // June is index 5
+      el.__focusedMonthIndex = 5;
+      await el.updateComplete;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__month-selection');
+
+      // ArrowRight -> July (6)
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedMonthIndex).to.equal(6);
+
+      // ArrowLeft -> June (5)
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedMonthIndex).to.equal(5);
+
+      // ArrowDown -> September (8) (3 columns -> +3)
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedMonthIndex).to.equal(8);
+
+      // ArrowUp -> June (5)
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedMonthIndex).to.equal(5);
+    });
+  });
+
+  describe('Keyboard Navigation in Year Selection View', () => {
+    it('opens year selection view on Enter keypress on year heading', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = el.shadowRoot?.querySelector('#year-heading');
+
+      yearBtn?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.exist;
+    });
+
+    it('opens year selection view on Space keypress on year heading', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = el.shadowRoot?.querySelector('#year-heading');
+
+      yearBtn?.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.exist;
+    });
+
+    it('closes year selection view on Escape', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+
+      yearBtn.click();
+      await el.updateComplete;
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.exist;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__year-grid');
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.not.exist;
+    });
+
+    it('navigates to next year range on PageDown', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const initialFirstYear = Number(
+        el.shadowRoot?.querySelector('.calendar__year-button')?.textContent?.trim(),
+      );
+
+      const grid = el.shadowRoot?.querySelector('.calendar__year-grid');
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true }));
+      await el.updateComplete;
+
+      const newFirstYear = Number(
+        el.shadowRoot?.querySelector('.calendar__year-button')?.textContent?.trim(),
+      );
+      expect(newFirstYear).to.equal(initialFirstYear + 12);
+    });
+
+    it('navigates to previous year range on PageUp', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const initialFirstYear = Number(
+        el.shadowRoot?.querySelector('.calendar__year-button')?.textContent?.trim(),
+      );
+
+      const grid = el.shadowRoot?.querySelector('.calendar__year-grid');
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true }));
+      await el.updateComplete;
+
+      const newFirstYear = Number(
+        el.shadowRoot?.querySelector('.calendar__year-button')?.textContent?.trim(),
+      );
+      expect(newFirstYear).to.equal(initialFirstYear - 12);
+    });
+
+    it('navigates grid with Arrow keys', async () => {
+      const el = await fixture(
+        html`<lion-calendar .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      // Set focus to the 5th year in the grid (index 4)
+      el.__focusedYearIndex = 4;
+      await el.updateComplete;
+
+      const grid = el.shadowRoot?.querySelector('.calendar__year-grid');
+
+      // ArrowRight -> index 5
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedYearIndex).to.equal(5);
+
+      // ArrowLeft -> index 4
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedYearIndex).to.equal(4);
+
+      // ArrowDown -> index 8 (4 columns -> +4)
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedYearIndex).to.equal(8);
+
+      // ArrowUp -> index 4
+      grid?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      await el.updateComplete;
+      expect(el.__focusedYearIndex).to.equal(4);
+    });
+  });
+
+  describe('MinDate and MaxDate Constraints', () => {
+    it('disables months before minDate month in the minDate year', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .minDate=${new Date('2024/04/01')}
+        ></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      // January (0), February (1), March (2) should be disabled
+      expect(buttons?.[0].getAttribute('aria-disabled')).to.equal('true'); // Jan
+      expect(buttons?.[1].getAttribute('aria-disabled')).to.equal('true'); // Feb
+      expect(buttons?.[2].getAttribute('aria-disabled')).to.equal('true'); // Mar
+      // April should be enabled
+      expect(buttons?.[3].getAttribute('aria-disabled')).to.equal('false'); // Apr
+    });
+
+    it('disables months after maxDate month in the maxDate year', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .maxDate=${new Date('2024/09/30')}
+        ></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      // October (9), November (10), December (11) should be disabled
+      expect(buttons?.[9].getAttribute('aria-disabled')).to.equal('true'); // Oct
+      expect(buttons?.[10].getAttribute('aria-disabled')).to.equal('true'); // Nov
+      expect(buttons?.[11].getAttribute('aria-disabled')).to.equal('true'); // Dec
+      // September should be enabled
+      expect(buttons?.[8].getAttribute('aria-disabled')).to.equal('false'); // Sep
+    });
+
+    it('disables years before minDate year in year selection', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .minDate=${new Date('2022/01/01')}
+        ></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      buttons.forEach(btn => {
+        const year = Number(btn.textContent?.trim());
+        if (year < 2022) {
+          expect(btn.getAttribute('aria-disabled')).to.equal('true');
+        } else {
+          expect(btn.getAttribute('aria-disabled')).to.equal('false');
+        }
+      });
+    });
+
+    it('disables years after maxDate year in year selection', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .maxDate=${new Date('2025/12/31')}
+        ></lion-calendar>`,
+      );
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      buttons.forEach(btn => {
+        const year = Number(btn.textContent?.trim());
+        if (year > 2025) {
+          expect(btn.getAttribute('aria-disabled')).to.equal('true');
+        } else {
+          expect(btn.getAttribute('aria-disabled')).to.equal('false');
+        }
+      });
+    });
+  });
+
+  describe('Integration with LionInputDatepicker', () => {
+    it('resets view to month view when initCentralDate is called', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+
+      // Open month selection
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+
+      // Call initCentralDate (simulates datepicker overlay reopening)
+      el.initCentralDate();
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.not.exist;
+      const calendarRoot = el.shadowRoot?.querySelector('.calendar');
+      expect(calendarRoot?.classList.contains('calendar--selection-active')).to.be.false;
+    });
+  });
+
+  describe('Localization Support', () => {
+    it('displays month names in the correct locale', async () => {
+      const el = await fixture(
+        html`<lion-calendar locale="de-DE" .centralDate=${new Date('2024/06/15')}></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      // In German, January is "Januar"
+      const firstMonthBtn = el.shadowRoot?.querySelector('.calendar__month-button');
+      // German months: Januar, Februar, März...
+      expect(firstMonthBtn?.textContent?.trim()).to.be.a('string').and.not.empty;
+    });
+  });
+
+  describe('Requirement 18: DisableDates Constraint Integration', () => {
+    it('disables month when all its days are disabled by disableDates', async () => {
+      const el = await fixture(
+        html`<lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .disableDates=${(/** @type {Date} */ date) =>
+            date.getFullYear() === 2024 && date.getMonth() === 1}
+        ></lion-calendar>`,
+      );
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      // February is index 1
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      expect(buttons?.[1].getAttribute('aria-disabled')).to.equal('true'); // Feb disabled
+      // Other months enabled (e.g., March)
+      expect(buttons?.[2].getAttribute('aria-disabled')).to.equal('false'); // Mar enabled
+    });
+  });
+
+  describe('Screen Reader Live Region', () => {
+    it('has an aria-live region for announcements', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const liveRegion = el.shadowRoot?.querySelector('[aria-live="polite"]');
+      expect(liveRegion).to.exist;
+      expect(liveRegion?.getAttribute('aria-atomic')).to.equal('true');
+    });
+  });
+
+  describe('Click Outside Behavior', () => {
+    it('closes month selection view when clicking outside', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+
+      monthBtn.click();
+      await el.updateComplete;
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.exist;
+
+      // Wait for the next macrotask so the Click Outside listener is attached
+      await nextMacrotask();
+
+      // Click outside
+      document.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__month-selection')).to.not.exist;
+    });
+
+    it('closes year selection view when clicking outside', async () => {
+      const el = await fixture(html`<lion-calendar></lion-calendar>`);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+
+      yearBtn.click();
+      await el.updateComplete;
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.exist;
+
+      // Wait for the next macrotask so the Click Outside listener is attached
+      await nextMacrotask();
+
+      // Click outside
+      document.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+      await el.updateComplete;
+
+      expect(el.shadowRoot?.querySelector('.calendar__year-selection')).to.not.exist;
+    });
+  });
+
+  describe('minDate / maxDate constraints in month and year selection', () => {
+    it('disables months before minDate month when viewing minDate year', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .minDate=${new Date('2024/06/01')}
+        ></lion-calendar>
+      `);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      for (let i = 0; i < 5; i += 1) {
+        expect(
+          buttons?.[i].getAttribute('aria-disabled'),
+          `month ${i} should be disabled`,
+        ).to.equal('true');
+      }
+      for (let i = 5; i < 12; i += 1) {
+        expect(buttons?.[i].getAttribute('aria-disabled'), `month ${i} should be enabled`).to.equal(
+          'false',
+        );
+      }
+    });
+
+    it('enables all months when viewing a year after minDate year', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .centralDate=${new Date('2024/03/01')}
+          .minDate=${new Date('2023/06/01')}
+        ></lion-calendar>
+      `);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      for (let i = 0; i < 12; i += 1) {
+        expect(buttons?.[i].getAttribute('aria-disabled'), `month ${i} should be enabled`).to.equal(
+          'false',
+        );
+      }
+    });
+
+    it('disables all months when viewing a year before minDate year', async () => {
+      const el = await fixture(html`
+        <lion-calendar .minDate=${new Date('2024/03/01')}></lion-calendar>
+      `);
+      el.centralDate = new Date('2022/06/15');
+      await el.updateComplete;
+
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      for (let i = 0; i < 12; i += 1) {
+        expect(
+          buttons?.[i].getAttribute('aria-disabled'),
+          `month ${i} should be disabled`,
+        ).to.equal('true');
+      }
+    });
+
+    // ------------------------------------------
+    // Month grid — maxDate
+    // ------------------------------------------
+
+    it('disables months after maxDate month when viewing maxDate year', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .maxDate=${new Date('2024/09/30')}
+        ></lion-calendar>
+      `);
+      const monthBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#month-heading'));
+      monthBtn.click();
+      await el.updateComplete;
+
+      const buttons = el.shadowRoot?.querySelectorAll('.calendar__month-button');
+      for (let i = 0; i <= 8; i += 1) {
+        expect(buttons?.[i].getAttribute('aria-disabled'), `month ${i} should be enabled`).to.equal(
+          'false',
+        );
+      }
+      for (let i = 9; i < 12; i += 1) {
+        expect(
+          buttons?.[i].getAttribute('aria-disabled'),
+          `month ${i} should be disabled`,
+        ).to.equal('true');
+      }
+    });
+
+    it('disables years before minDate year in the year selection grid', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .minDate=${new Date('2024/01/01')}
+        ></lion-calendar>
+      `);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      buttons.forEach(btn => {
+        const year = Number(btn.dataset.year);
+        const expected = year < 2024 ? 'true' : 'false';
+        expect(btn.getAttribute('aria-disabled'), `year ${year} aria-disabled`).to.equal(expected);
+      });
+    });
+
+    it('disables years after maxDate year in the year selection grid', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .centralDate=${new Date('2024/06/15')}
+          .maxDate=${new Date('2025/12/31')}
+        ></lion-calendar>
+      `);
+      const yearBtn = /** @type {HTMLElement} */ (el.shadowRoot?.querySelector('#year-heading'));
+      yearBtn.click();
+      await el.updateComplete;
+
+      const buttons = /** @type {NodeListOf<HTMLElement>} */ (
+        el.shadowRoot?.querySelectorAll('.calendar__year-button')
+      );
+      buttons.forEach(btn => {
+        const year = Number(btn.dataset.year);
+        const expected = year > 2025 ? 'true' : 'false';
+        expect(btn.getAttribute('aria-disabled'), `year ${year} aria-disabled`).to.equal(expected);
+      });
+    });
+
+    // ------------------------------------------
+    // initCentralDate — selectedDate outside range
+    // ------------------------------------------
+
+    it('navigates to nearest enabled date when selectedDate is before minDate', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .selectedDate=${new Date('2020/01/01')}
+          .minDate=${new Date('2024/06/01')}
+        ></lion-calendar>
+      `);
+      el.initCentralDate();
+      await el.updateComplete;
+
+      expect(el.centralDate.getFullYear()).to.equal(2024);
+      expect(el.centralDate.getMonth()).to.be.at.least(5);
+    });
+
+    it('navigates to nearest enabled date when selectedDate is after maxDate', async () => {
+      const el = await fixture(html`
+        <lion-calendar
+          .selectedDate=${new Date('2030/12/01')}
+          .maxDate=${new Date('2024/09/30')}
+        ></lion-calendar>
+      `);
+      el.initCentralDate();
+      await el.updateComplete;
+
+      expect(el.centralDate.getFullYear()).to.equal(2024);
+      expect(el.centralDate.getMonth()).to.be.at.most(8);
+    });
+
+    it('does NOT move centralDate when selectedDate is within range', async () => {
+      const selected = new Date('2024/07/10');
+      const el = await fixture(html`
+        <lion-calendar
+          .selectedDate=${selected}
+          .minDate=${new Date('2024/01/01')}
+          .maxDate=${new Date('2024/12/31')}
+        ></lion-calendar>
+      `);
+      el.initCentralDate();
+      await el.updateComplete;
+
+      expect(el.centralDate.getFullYear()).to.equal(2024);
+      expect(el.centralDate.getMonth()).to.equal(6);
+      expect(el.centralDate.getDate()).to.equal(10);
+    });
+  });
+});

--- a/packages/ui/components/calendar/test/lion-calendar.test.js
+++ b/packages/ui/components/calendar/test/lion-calendar.test.js
@@ -38,24 +38,17 @@ describe('<lion-calendar>', () => {
 
       const el = await fixture(html`<lion-calendar></lion-calendar>`);
 
-      expect(el.shadowRoot?.querySelector('#year')).dom.to.equal(`
-        <h2
-          id="year"
-          class="calendar__navigation-heading"
-          aria-atomic="true"
-        >
-          2000
-        </h2>
-      `);
-      expect(el.shadowRoot?.querySelector('#month')).dom.to.equal(`
-      <h2
-        id="month"
-        class="calendar__navigation-heading"
-        aria-atomic="true"
-      >
-        December
-      </h2>
-    `);
+      // Year heading is now an interactive button (WCAG: role=button)
+      const yearHeading = el.shadowRoot?.querySelector('#year-heading');
+      expect(yearHeading).to.exist;
+      expect(yearHeading?.tagName.toLowerCase()).to.equal('button');
+      expect(yearHeading?.textContent?.trim()).to.include('2000');
+
+      // Month heading is now an interactive button (WCAG: role=button)
+      const monthHeading = el.shadowRoot?.querySelector('#month-heading');
+      expect(monthHeading).to.exist;
+      expect(monthHeading?.tagName.toLowerCase()).to.equal('button');
+      expect(monthHeading?.textContent?.trim()).to.include('December');
 
       clock.restore();
     });

--- a/packages/ui/components/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
+++ b/packages/ui/components/calendar/test/utils/snapshots/monthTemplate_en-GB_Sunday_2018-12.js
@@ -3,7 +3,7 @@ const html = /** @param {TemplateStringsArray} strings */ strings => strings[0];
 export default html`
   <div id="js-content-wrapper">
     <table
-      aria-labelledby="month year"
+      aria-labelledby="month-heading year-heading"
       aria-readonly="true"
       class="calendar__grid"
       data-wrap-cols=""

--- a/packages/ui/components/calendar/translations/bg.js
+++ b/packages/ui/components/calendar/translations/bg.js
@@ -8,4 +8,11 @@ export default {
     'Тази дата не е налична. Най-ранната налична да е {params}. Моля, изберете друга дата.',
   afterDisabledDate:
     'Тази дата не е налична. Най-късната налична дата е {params}. Моля, изберете друга дата.',
+  selectMonth: 'Изберете месец',
+  selectYear: 'Изберете година',
+  monthSelectionOpened: 'Избор на месец, налични 12 месеца',
+  yearSelectionOpened: 'Избор на година, години {startYear} до {endYear} налични',
+  previousYearRange: 'Предходен диапазон от години',
+  nextYearRange: 'Следващ диапазон от години',
+  yearsRange: 'Години {startYear} до {endYear}',
 };

--- a/packages/ui/components/calendar/translations/cs.js
+++ b/packages/ui/components/calendar/translations/cs.js
@@ -8,4 +8,11 @@ export default {
     'Toto datum není k dispozici. Nejbližší dostupné datum je {params}. Vyberte jiné datum.',
   afterDisabledDate:
     'Toto datum není k dispozici. Poslední dostupné datum je {params}. Vyberte jiné datum.',
+  selectMonth: 'Vyberte měsíc',
+  selectYear: 'Vyberte rok',
+  monthSelectionOpened: 'Výběr měsíce, k dispozici 12 měsíců',
+  yearSelectionOpened: 'Výběr roku, dostupné roky {startYear} až {endYear}',
+  previousYearRange: 'Předchozí rozsah let',
+  nextYearRange: 'Další rozsah let',
+  yearsRange: 'Roky {startYear} až {endYear}',
 };

--- a/packages/ui/components/calendar/translations/de.js
+++ b/packages/ui/components/calendar/translations/de.js
@@ -8,4 +8,11 @@ export default {
     'Dieses Datum ist nicht verfügbar. Das früheste verfügbare Datum ist {params}. Bitte wählen Sie ein anderes Datum aus.',
   afterDisabledDate:
     'Dieses Datum ist nicht verfügbar. Das späteste verfügbare Datum ist {params}. Bitte wählen Sie ein anderes Datum aus.',
+  selectMonth: 'Monat auswählen',
+  selectYear: 'Jahr auswählen',
+  monthSelectionOpened: 'Monatsauswahl, 12 Monate verfügbar',
+  yearSelectionOpened: 'Jahresauswahl, Jahre {startYear} bis {endYear} verfügbar',
+  previousYearRange: 'Vorheriger Jahresbereich',
+  nextYearRange: 'Nächster Jahresbereich',
+  yearsRange: 'Jahre {startYear} bis {endYear}',
 };

--- a/packages/ui/components/calendar/translations/en.js
+++ b/packages/ui/components/calendar/translations/en.js
@@ -8,4 +8,11 @@ export default {
     'This date is unavailable. Earliest available date is {params}. Please choose another date.',
   afterDisabledDate:
     'This date is unavailable. Latest available date is {params}. Please choose another date.',
+  selectMonth: 'Select month',
+  selectYear: 'Select year',
+  monthSelectionOpened: 'Month selection, 12 months available',
+  yearSelectionOpened: 'Year selection, years {startYear} through {endYear} available',
+  previousYearRange: 'Previous year range',
+  nextYearRange: 'Next year range',
+  yearsRange: 'Years {startYear} through {endYear}',
 };

--- a/packages/ui/components/calendar/translations/es.js
+++ b/packages/ui/components/calendar/translations/es.js
@@ -8,4 +8,11 @@ export default {
     'Esta fecha no está disponible. La fecha más próxima disponible es {params}. Elija otra.',
   afterDisabledDate:
     'Esta fecha no está disponible. La fecha más lejana disponible es {params}. Elija otra.',
+  selectMonth: 'Seleccionar mes',
+  selectYear: 'Seleccionar año',
+  monthSelectionOpened: 'Selección de mes, 12 meses disponibles',
+  yearSelectionOpened: 'Selección de año, años {startYear} a {endYear} disponibles',
+  previousYearRange: 'Rango de años anterior',
+  nextYearRange: 'Siguiente rango de años',
+  yearsRange: 'Años {startYear} a {endYear}',
 };

--- a/packages/ui/components/calendar/translations/fr.js
+++ b/packages/ui/components/calendar/translations/fr.js
@@ -8,4 +8,11 @@ export default {
     "Cette date n'est pas disponible. La prochaine date disponible est la suivante : {params}. Veuillez choisir une autre date.",
   afterDisabledDate:
     "Cette date n'est pas disponible. La dernière date disponible est la suivante : {params}. Veuillez choisir une autre date.",
+  selectMonth: 'Sélectionner le mois',
+  selectYear: "Sélectionner l'année",
+  monthSelectionOpened: 'Sélection du mois, 12 mois disponibles',
+  yearSelectionOpened: "Sélection de l'année, années {startYear} à {endYear} disponibles",
+  previousYearRange: "Plage d'années précédente",
+  nextYearRange: "Plage d'années suivante",
+  yearsRange: 'Années {startYear} à {endYear}',
 };

--- a/packages/ui/components/calendar/translations/hu.js
+++ b/packages/ui/components/calendar/translations/hu.js
@@ -8,4 +8,11 @@ export default {
     'Ez a dátum nem választható. A legkorábbi elérhető dátum {params}. Válasszon másik dátumot.',
   afterDisabledDate:
     'Ez a dátum nem választható. A legkésőbbi elérhető dátum {params}. Válasszon másik dátumot.',
+  selectMonth: 'Hónap kiválasztása',
+  selectYear: 'Év kiválasztása',
+  monthSelectionOpened: 'Hónap kiválasztása, 12 hónap elérhető',
+  yearSelectionOpened: 'Év kiválasztása, {startYear}–{endYear} évek elérhetők',
+  previousYearRange: 'Előző évtartomány',
+  nextYearRange: 'Következő évtartomány',
+  yearsRange: '{startYear}–{endYear} évek',
 };

--- a/packages/ui/components/calendar/translations/it.js
+++ b/packages/ui/components/calendar/translations/it.js
@@ -8,4 +8,11 @@ export default {
     "Questa data non è disponibile. La prima data disponibile è {params}. Scegline un'altra.",
   afterDisabledDate:
     "Questa data non è disponibile. L'ultima data disponibile è {params}. Scegline un'altra.",
+  selectMonth: 'Seleziona mese',
+  selectYear: 'Seleziona anno',
+  monthSelectionOpened: 'Selezione mese, 12 mesi disponibili',
+  yearSelectionOpened: 'Selezione anno, anni {startYear} a {endYear} disponibili',
+  previousYearRange: 'Intervallo anni precedente',
+  nextYearRange: 'Intervallo anni successivo',
+  yearsRange: 'Anni {startYear} a {endYear}',
 };

--- a/packages/ui/components/calendar/translations/nl.js
+++ b/packages/ui/components/calendar/translations/nl.js
@@ -8,4 +8,11 @@ export default {
     'Deze datum is niet beschikbaar. Vroegste beschikbare datum is {params}. Kies een andere datum.',
   afterDisabledDate:
     'Deze datum is niet beschikbaar. Laatste beschikbare datum is {params}. Kies een andere datum.',
+  selectMonth: 'Selecteer maand',
+  selectYear: 'Selecteer jaar',
+  monthSelectionOpened: 'Maandselectie, 12 maanden beschikbaar',
+  yearSelectionOpened: 'Jaarselectie, jaren {startYear} tot {endYear} beschikbaar',
+  previousYearRange: 'Vorig jaarbereik',
+  nextYearRange: 'Volgend jaarbereik',
+  yearsRange: 'Jaren {startYear} tot {endYear}',
 };

--- a/packages/ui/components/calendar/translations/pl.js
+++ b/packages/ui/components/calendar/translations/pl.js
@@ -8,4 +8,11 @@ export default {
     'Ta data jest niedostępna. Najwcześniejsza dostępna data to {params}. Wybierz inną datę.',
   afterDisabledDate:
     'Ta data jest niedostępna. Najpóźniejsza dostępna data to {params}. Wybierz inną datę.',
+  selectMonth: 'Wybierz miesiąc',
+  selectYear: 'Wybierz rok',
+  monthSelectionOpened: 'Wybór miesiąca, dostępnych 12 miesięcy',
+  yearSelectionOpened: 'Wybór roku, dostępne lata {startYear} do {endYear}',
+  previousYearRange: 'Poprzedni zakres lat',
+  nextYearRange: 'Następny zakres lat',
+  yearsRange: 'Lata {startYear} do {endYear}',
 };

--- a/packages/ui/components/calendar/translations/ro.js
+++ b/packages/ui/components/calendar/translations/ro.js
@@ -8,4 +8,11 @@ export default {
     'Această dată nu este disponibilă. Cea mai apropiată dată disponibilă este {params}. Vă rugăm să alegeți altă dată.',
   afterDisabledDate:
     'Această dată nu este disponibilă. Ultima dată disponibilă este {params}. Vă rugăm să alegeți altă dată.',
+  selectMonth: 'Selectați luna',
+  selectYear: 'Selectați anul',
+  monthSelectionOpened: 'Selecție lună, 12 luni disponibile',
+  yearSelectionOpened: 'Selecție an, ani {startYear} până la {endYear} disponibili',
+  previousYearRange: 'Intervalul de ani anterior',
+  nextYearRange: 'Următorul interval de ani',
+  yearsRange: 'Ani {startYear} până la {endYear}',
 };

--- a/packages/ui/components/calendar/translations/ru.js
+++ b/packages/ui/components/calendar/translations/ru.js
@@ -8,4 +8,11 @@ export default {
     'Эта дата недоступна. Самая ранняя доступная дата — {params}. Выберите другую дату.',
   afterDisabledDate:
     'Эта дата недоступна. Самая поздняя доступная дата — {params}. Выберите другую дату.',
+  selectMonth: 'Выберите месяц',
+  selectYear: 'Выберите год',
+  monthSelectionOpened: 'Выбор месяца, доступно 12 месяцев',
+  yearSelectionOpened: 'Выбор года, доступны годы с {startYear} по {endYear}',
+  previousYearRange: 'Предыдущий диапазон лет',
+  nextYearRange: 'Следующий диапазон лет',
+  yearsRange: 'Годы с {startYear} по {endYear}',
 };

--- a/packages/ui/components/calendar/translations/sk.js
+++ b/packages/ui/components/calendar/translations/sk.js
@@ -8,4 +8,11 @@ export default {
     'Tento dátum nie je k dispozícii. Najbližší možný dátum je {params}. Vyberte iný dátum.',
   afterDisabledDate:
     'Tento dátum nie je k dispozícii. Posledný možný dátum je {params}. Vyberte iný dátum.',
+  selectMonth: 'Vyberte mesiac',
+  selectYear: 'Vyberte rok',
+  monthSelectionOpened: 'Výber mesiaca, k dispozícii 12 mesiacov',
+  yearSelectionOpened: 'Výber roku, dostupné roky {startYear} až {endYear}',
+  previousYearRange: 'Predchádzajúci rozsah rokov',
+  nextYearRange: 'Nasledujúci rozsah rokov',
+  yearsRange: 'Roky {startYear} až {endYear}',
 };

--- a/packages/ui/components/calendar/translations/tr.js
+++ b/packages/ui/components/calendar/translations/tr.js
@@ -8,4 +8,11 @@ export default {
     'Bu tarih kullanılamaz. En erken kullanılabilir tarih: {params}. Lütfen başka bir tarih seçin.',
   afterDisabledDate:
     'Bu tarih kullanılamaz. En geç kullanılabilir tarih: {params}. Lütfen başka bir tarih seçin.',
+  selectMonth: 'Ay seçin',
+  selectYear: 'Yıl seçin',
+  monthSelectionOpened: 'Ay seçimi, 12 ay mevcut',
+  yearSelectionOpened: 'Yıl seçimi, {startYear} ile {endYear} yılları mevcut',
+  previousYearRange: 'Önceki yıl aralığı',
+  nextYearRange: 'Sonraki yıl aralığı',
+  yearsRange: '{startYear} ile {endYear} yılları',
 };

--- a/packages/ui/components/calendar/translations/uk.js
+++ b/packages/ui/components/calendar/translations/uk.js
@@ -6,4 +6,11 @@ export default {
   defaultDisabledDate: 'Ця дата недоступна. Виберіть іншу дату.',
   beforeDisabledDate: 'Ця дата недоступна. Найближча доступна дата {params}. Виберіть іншу дату.',
   afterDisabledDate: 'Ця дата недоступна. Остання доступна дата {params}. Виберіть іншу дату.',
+  selectMonth: 'Виберіть місяць',
+  selectYear: 'Виберіть рік',
+  monthSelectionOpened: 'Вибір місяця, доступно 12 місяців',
+  yearSelectionOpened: 'Вибір року, доступні роки з {startYear} по {endYear}',
+  previousYearRange: 'Попередній діапазон років',
+  nextYearRange: 'Наступний діапазон років',
+  yearsRange: 'Роки з {startYear} по {endYear}',
 };

--- a/packages/ui/components/calendar/translations/zh.js
+++ b/packages/ui/components/calendar/translations/zh.js
@@ -6,4 +6,11 @@ export default {
   defaultDisabledDate: '此日期不可选。请选择另一个日期。',
   beforeDisabledDate: '此日期不可选。最早可选日期为 {params}。请选择另一个日期。',
   afterDisabledDate: '此日期不可选。最晚可选日期为 {params}。请选择另一个日期。',
+  selectMonth: '选择月份',
+  selectYear: '选择年份',
+  monthSelectionOpened: '选择月份，共12个月可选',
+  yearSelectionOpened: '选择年份，{startYear}年至{endYear}年可选',
+  previousYearRange: '上一年份范围',
+  nextYearRange: '下一年份范围',
+  yearsRange: '{startYear}年至{endYear}年',
 };

--- a/packages/ui/components/overlays/test/OverlayController.test.js
+++ b/packages/ui/components/overlays/test/OverlayController.test.js
@@ -393,7 +393,7 @@ describe('OverlayController', () => {
             // The total dom structure created...
             expect(el).shadowDom.to.equal(
               `
-              <dialog data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
+              <dialog closedby="none" data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
                 <div data-id="content-wrapper">
                   <slot name="content">
                   </slot>
@@ -423,7 +423,7 @@ describe('OverlayController', () => {
             // The total dom structure created...
             expect(el).lightDom.to.equal(
               `
-              <dialog data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
+              <dialog closedby="none" data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
                 <div data-id="content-wrapper">
                   <div id="content">non projected</div>
                 </div>
@@ -467,7 +467,7 @@ describe('OverlayController', () => {
             // The total dom structure created...
             expect(el).shadowDom.to.equal(
               `
-              <dialog data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
+              <dialog closedby="none" data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
                 <div data-id="content-wrapper">
                   <slot name="content"></slot>
                 </div>
@@ -513,7 +513,7 @@ describe('OverlayController', () => {
             // The total dom structure created...
             expect(el).shadowDom.to.equal(
               `
-              <dialog data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
+              <dialog closedby="none" data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
                 <div data-id="content-wrapper">
                   <div id="arrow"></div>
                   <slot name="content"></slot>
@@ -582,7 +582,7 @@ describe('OverlayController', () => {
         // The total dom structure created...
         expect(el).shadowDom.to.equal(
           `
-          <dialog data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
+          <dialog closedby="none" data-overlay-outer-wrapper="" open="" role="none" style="${wrappingDialogNodeStyle}">
             <div class="overlays__backdrop"></div>
             <div data-id="content-wrapper">
               <slot name="content">


### PR DESCRIPTION
## What I did

Implemented the Interactive Month and Year Navigation for `LionCalendar`. 
**Key features & fixes:**
- **Month and Year Selection Views:** Users can now click the month or year headers to open a dedicated 12-month or year-range grid view.
- **`minDate` & `maxDate` Constraints ** Disables selection for out-of-bounds months and years within the new navigation grids. 
- **Smart Date Initialization (`initCentralDate`):** Added a robust fallback mechanism that auto-corrects the `centralDate` to the nearest available enabled date if the provided `selectedDate` falls completely outside the active limits (e.g. pre-`minDate` or post-`maxDate`).
- **Refactoring & Code Quality:** Extracted date sentinel check logic (`new Date(0)` and `8640000000000000`) into dedicated private helpers (`__hasMinDateConstraint` and `__hasMaxDateConstraint`). Replaced legacy `for`-loops with cleaner `Array.from` and `findIndex` patterns.
- **Accessibility (WCAG 2.1 AA):** Added proper ARIA live region support, keyboard traversal (Arrow keys, Esc to cancel, PageUp/PageDown for year pagination), and logical focus management when transitioning between selection views.
- **Tests Coverage:** Handled edge cases regarding date grid pagination, click-outside behaviors, and completely verified all month/year limit validations. Fixed all test execution async flakiness with a local `nextMacrotask` helper.
