### PR TITLE
Sync value upwards

### DIFF
--- a/.changeset/easy-boxes-ask.md
+++ b/.changeset/easy-boxes-ask.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': minor
+---
+
+Fix InputAmountDropdown currency reset when amount input field is cleared

--- a/packages/ui/components/form-core/test-suites/FormatMixin.suite.js
+++ b/packages/ui/components/form-core/test-suites/FormatMixin.suite.js
@@ -44,6 +44,8 @@ class FormatClass extends FormatMixin(LitElement) {
  * @property {(el: FormatClass) => any} [getExpectedInitialModelValue] - Optional. Expected initial modelValue state when element is created without a value. If not provided, defaults will be generated based on modelValueType.
  * @property {(el: FormatClass) => any} [getExpectedInitialFormattedValue] - Optional. Expected initial formattedValue state when element is created without a value. If not provided, defaults will be generated based on modelValueType.
  * @property {(el: FormatClass) => any} [getExpectedInitialSerializedValue] - Optional. Expected initial serializedValue state when element is created without a value. If not provided, defaults will be generated based on modelValueType.
+ * @property {(el: FormatClass) => any} [getExpectedModelValueForEmptyInputNode] - Optional. Expected modelValue after user clears the input node value. Defaults to empty string.
+ * @property {(value: string, opts?: any) => any} [parser] - Optional. Parser override used by tests. When provided, it is applied before connectedCallback so fallback init sync uses it.
  * @property {number} [valueChangeCounterOffset] - Optional. Offset for model-value-changed event counter. Use 0 for most types, 1 for Date types where parseDate() creates new objects. If not provided, defaults will be generated based on modelValueType.
  */
 
@@ -180,6 +182,10 @@ export function runFormatMixinSuite(customConfig) {
   const getExpectedInitialSerializedValue =
     cfg.getExpectedInitialSerializedValue ||
     createDefaultGetExpectedInitialSerializedValue(cfg.modelValueType);
+  const getExpectedModelValueForEmptyInputNode =
+    cfg.getExpectedModelValueForEmptyInputNode || (() => '');
+  const defaultParser = (/** @type {string} */ value) => value.replace('foo: ', '');
+  const parser = cfg.parser || defaultParser;
   const valueChangeCounterOffset =
     cfg.valueChangeCounterOffset !== undefined
       ? cfg.valueChangeCounterOffset
@@ -226,6 +232,13 @@ export function runFormatMixinSuite(customConfig) {
   }
 
   /**
+   * @param {FormatClass} el
+   */
+  function generateExpectedModelValueForEmptyInputNode(el) {
+    return getExpectedModelValueForEmptyInputNode(el);
+  }
+
+  /**
    * @param {any} actual
    * @param {any} expected
    * @param {string} message
@@ -253,7 +266,7 @@ export function runFormatMixinSuite(customConfig) {
       fooFormat = await fixture(html`
         <${tag}
           .formatter="${/** @param {string} value */ value => `foo: ${value}`}"
-          .parser="${/** @param {string} value */ value => value.replace('foo: ', '')}"
+          .parser="${parser}"
           .serializer="${/** @param {string} value */ value => `[foo] ${value}`}"
           .deserializer="${/** @param {string} value */ value => value.replace('[foo] ', '')}"
         >
@@ -368,7 +381,7 @@ export function runFormatMixinSuite(customConfig) {
           <${tag}
             value="string"
             .formatter=${/** @param {string} value */ value => `foo: ${value}`}
-            .parser=${/** @param {string} value */ value => value.replace('foo: ', '')}
+            .parser=${parser}
             .serializer=${/** @param {string} value */ value => `[foo] ${value}`}
             .deserializer=${/** @param {string} value */ value => value.replace('[foo] ', '')}
           >
@@ -378,12 +391,14 @@ export function runFormatMixinSuite(customConfig) {
         );
         // Now check if the format/parse/serialize loop has been triggered
         await formatElem.updateComplete;
-        expect(formatElem.formattedValue).to.equal('foo: string');
+        const expectedFormattedValue = `foo: ${formatElem.modelValue}`;
+        const expectedSerializedValue = `[foo] ${formatElem.modelValue}`;
 
-        expect(formatElem._inputNode.value).to.equal('foo: string');
+        expect(formatElem.formattedValue).to.equal(expectedFormattedValue);
 
-        expect(formatElem.serializedValue).to.equal('[foo] string');
-        expect(formatElem.modelValue).to.equal('string');
+        expect(formatElem._inputNode.value).to.equal(expectedFormattedValue);
+
+        expect(formatElem.serializedValue).to.equal(expectedSerializedValue);
       });
 
       describe('Unparseable values', () => {
@@ -445,9 +460,11 @@ export function runFormatMixinSuite(customConfig) {
           );
           // This could happen when the user erases the input value
           mimicUserInput(el, '');
-          // For backwards compatibility, we keep the modelValue an empty string here.
-          // Undefined would be more appropriate 'conceptually', however
-          expect(el.modelValue).to.equal('');
+          expectValue(
+            el.modelValue,
+            generateExpectedModelValueForEmptyInputNode(el),
+            'modelValue after clearing input node value',
+          );
         });
       });
     });
@@ -794,13 +811,13 @@ export function runFormatMixinSuite(customConfig) {
         `)
           );
 
-          expect(parserSpy.callCount).to.equal(1);
+          const initialParserCallCount = parserSpy.callCount;
           // This could happen for instance in a reset
           el.modelValue = undefined;
-          expect(parserSpy.callCount).to.equal(1);
+          expect(parserSpy.callCount).to.equal(initialParserCallCount);
           // This could happen when the user erases the input value
           mimicUserInput(el, '');
-          expect(parserSpy.callCount).to.equal(1);
+          expect(parserSpy.callCount).to.equal(initialParserCallCount);
         });
       });
 
@@ -824,12 +841,12 @@ export function runFormatMixinSuite(customConfig) {
 
           const { _inputNode } = getFormControlMembers(el);
 
-          expect(preprocessorSpy.callCount).to.equal(1);
+          const initialPreprocessorCallCount = preprocessorSpy.callCount;
 
           const parserSpy = sinon.spy(el, 'parser');
           mimicUserInput(el, toBeCorrectedVal);
 
-          expect(preprocessorSpy.callCount).to.equal(2);
+          expect(preprocessorSpy.callCount).to.equal(initialPreprocessorCallCount + 1);
           expect(parserSpy.lastCall.args[0]).to.equal(val);
           expect(_inputNode.value).to.equal(val);
         });

--- a/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
+++ b/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
@@ -97,7 +97,7 @@ export class LionInputAmountDropdown extends LionInputAmount {
    * For a FormControl to function properly, its modelValue, serializedValue and  viewValue/formattedValue
    * should always translate in two directions. This is expected by `_callParser` method. It guards for empty
    * viewValues. As the viewValue (`.value`) only concerns the amount part and not the currency part in
-   * InputAmountDropdown, this contract is broken. 
+   * InputAmountDropdown, this contract is broken.
    * Below, we compensate for this.
    */
   set modelValue(value) {

--- a/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
+++ b/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
@@ -100,6 +100,7 @@ export class LionInputAmountDropdown extends LionInputAmount {
    * InputAmountDropdown, this contract is broken.
    * Below, we compensate for this.
    */
+  // @ts-expect-error - modelValue is overridden as an accessor but is defined as a property in parent class
   set modelValue(value) {
     if (value) {
       this.__modelValue = /** @type {import('../types/index.js').AmountDropdownModelValue} */ (
@@ -572,7 +573,10 @@ export class LionInputAmountDropdown extends LionInputAmount {
     }
 
     // 2. Try to get the currency from user input
-    if (this.modelValue?.currency && this.allowedCurrencies?.includes(this.modelValue?.currency)) {
+    if (
+      this.modelValue?.currency &&
+      this.allowedCurrencies?.includes(/** @type {CurrencyCode} */ (this.modelValue?.currency))
+    ) {
       this.currency = this.modelValue.currency;
       return;
     }

--- a/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
+++ b/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
@@ -90,9 +90,11 @@ export class LionInputAmountDropdown extends LionInputAmount {
   _modelValue;
 
   /**
-   * The FormatMixin _syncValueUpwards method creates a hard link between this.value and this.modelValue.
-   * The amount dropdown class value and modelValue are different. Overwriting set modelValue makes sure
-   * that the modelValue remains the correct type with associated properties.
+   * For a FormControl to function properly, its modelValue, serializedValue and  viewValue/formattedValue
+   * should always translate in two directions. This is expected by `_callParser` method. It guards for empty
+   * viewValues. As the viewValue (`.value`) only concerns the amount part and not the currency part in
+   * InputAmountDropdown, this contract is broken. 
+   * Below, we compensate for this.
    */
   set modelValue(value) {
     if (value) {

--- a/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
+++ b/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
@@ -90,14 +90,16 @@ export class LionInputAmountDropdown extends LionInputAmount {
   _modelValue;
 
   /**
-   * The FormatMixin has a hard link between this.value and this.modelValue. This doesn't work for
-   * the amount dropdown class. Overwriting set modelValue makes sure that the modelValue remains the correct type with properties.
+   * The FormatMixin _syncValueUpwards method creates a hard link between this.value and this.modelValue.
+   * The amount dropdown class value and modelValue are different. Overwriting set modelValue makes sure
+   * that the modelValue remains the correct type with associated properties.
    */
   set modelValue(value) {
     if (value) {
       this._modelValue = /** @type {import('../types/index.js').AmountDropdownModelValue} */ (
         value
       );
+      // Below is needed because A1 and A2 in _callParser (FormatMixin) return values that are the wrong type.
     } else {
       this._modelValue = { currency: this.currency, amount: '' };
     }

--- a/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
+++ b/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
@@ -86,8 +86,12 @@ export class LionInputAmountDropdown extends LionInputAmount {
     };
   }
 
-  /** @type {import('../types/index.js').AmountDropdownModelValue} */
-  _modelValue;
+  /**
+   * The internal modelValue is a combination of the amount and the currency code. The amount is a number, the currency code is a string.
+   * @private
+   * @type {import('../types/index.js').AmountDropdownModelValue}
+   */
+  __modelValue;
 
   /**
    * For a FormControl to function properly, its modelValue, serializedValue and  viewValue/formattedValue
@@ -98,17 +102,17 @@ export class LionInputAmountDropdown extends LionInputAmount {
    */
   set modelValue(value) {
     if (value) {
-      this._modelValue = /** @type {import('../types/index.js').AmountDropdownModelValue} */ (
+      this.__modelValue = /** @type {import('../types/index.js').AmountDropdownModelValue} */ (
         value
       );
       // Below is needed because A1 and A2 in _callParser (FormatMixin) return values that are the wrong type.
     } else {
-      this._modelValue = { currency: this.currency, amount: '' };
+      this.__modelValue = { currency: this.currency, amount: '' };
     }
   }
 
   get modelValue() {
-    return /** @type {import('../types/index.js').AmountDropdownModelValue} */ (this._modelValue);
+    return /** @type {import('../types/index.js').AmountDropdownModelValue} */ (this.__modelValue);
   }
 
   static localizeNamespaces = [
@@ -324,7 +328,7 @@ export class LionInputAmountDropdown extends LionInputAmount {
     this.parser = parseAmount;
 
     /** @type {import('../types/index.js').AmountDropdownModelValue} */
-    this._modelValue = { currency: this.currency, amount: '' };
+    this.__modelValue = { currency: this.currency, amount: '' };
 
     /**
      * @param {import("../types/index.js").AmountDropdownModelValue} modelValue

--- a/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
+++ b/packages/ui/components/input-amount-dropdown/src/LionInputAmountDropdown.js
@@ -73,12 +73,39 @@ export class LionInputAmountDropdown extends LionInputAmount {
    * @configure LitElement
    * @type {any}
    */
-  static properties = {
-    modelValue: { type: Object, hasChanged: hasChangedAmountDropdownModelValue },
-    preferredCurrencies: { type: Array },
-    allowedCurrencies: { type: Array },
-    __dropdownSlot: { type: String },
-  };
+  static get properties() {
+    return {
+      modelValue: {
+        type: Object,
+        attribute: false,
+        hasChanged: hasChangedAmountDropdownModelValue,
+      },
+      preferredCurrencies: { type: Array },
+      allowedCurrencies: { type: Array },
+      __dropdownSlot: { type: String },
+    };
+  }
+
+  /** @type {import('../types/index.js').AmountDropdownModelValue} */
+  _modelValue;
+
+  /**
+   * The FormatMixin has a hard link between this.value and this.modelValue. This doesn't work for
+   * the amount dropdown class. Overwriting set modelValue makes sure that the modelValue remains the correct type with properties.
+   */
+  set modelValue(value) {
+    if (value) {
+      this._modelValue = /** @type {import('../types/index.js').AmountDropdownModelValue} */ (
+        value
+      );
+    } else {
+      this._modelValue = { currency: this.currency, amount: '' };
+    }
+  }
+
+  get modelValue() {
+    return /** @type {import('../types/index.js').AmountDropdownModelValue} */ (this._modelValue);
+  }
 
   static localizeNamespaces = [
     { 'lion-input-amount-dropdown': localizeNamespaceLoader },
@@ -292,6 +319,9 @@ export class LionInputAmountDropdown extends LionInputAmount {
 
     this.parser = parseAmount;
 
+    /** @type {import('../types/index.js').AmountDropdownModelValue} */
+    this._modelValue = { currency: this.currency, amount: '' };
+
     /**
      * @param {import("../types/index.js").AmountDropdownModelValue} modelValue
      * @param {import('../../localize/types/LocalizeMixinTypes.js').FormatNumberOptions} [givenOptions] Locale Options
@@ -406,7 +436,8 @@ export class LionInputAmountDropdown extends LionInputAmount {
    * @protected
    */
   _initModelValueBasedOnDropdown() {
-    if (!this._initialModelValue && !this.dirty) {
+    const { currency, amount } = this._initialModelValue || {};
+    if (!currency && !amount && !this.dirty) {
       this.__initializedCurrencyCode = this.currency;
       this._initialModelValue = { currency: this.currency };
       this.modelValue = this._initialModelValue;

--- a/packages/ui/components/input-amount-dropdown/test-suites/LionInputAmountDropdown.suite.js
+++ b/packages/ui/components/input-amount-dropdown/test-suites/LionInputAmountDropdown.suite.js
@@ -392,6 +392,7 @@ export function runInputAmountDropdownSuite({ klass } = { klass: LionInputAmount
       // @ts-ignore
       expect(el._isEmpty(), 'missing amount property').to.be.true;
 
+      // @ts-ignore
       el.modelValue = null;
       await el.updateComplete;
       // @ts-ignore

--- a/packages/ui/components/input-amount-dropdown/test/lion-input-amount-dropdown-integrations.test.js
+++ b/packages/ui/components/input-amount-dropdown/test/lion-input-amount-dropdown-integrations.test.js
@@ -8,6 +8,7 @@ describe('<lion-input-amount-dropdown> integrations', () => {
   runFormatMixinSuite({
     tagString,
     modelValueType: Object,
+    parser: value => value.replace('foo: ', ''),
     valueToggler: ({ toggleValue, viewValue }) => {
       if (viewValue) {
         return !toggleValue ? '123' : '456';
@@ -17,6 +18,10 @@ describe('<lion-input-amount-dropdown> integrations', () => {
     getExpectedInitialModelValue: el => ({ currency: /** @type {any} */ (el).currency }),
     getExpectedInitialFormattedValue: el => ({ currency: /** @type {any} */ (el).currency }),
     getExpectedInitialSerializedValue: el => ({ currency: /** @type {any} */ (el).currency }),
+    getExpectedModelValueForEmptyInputNode: el => ({
+      currency: /** @type {any} */ (el).currency,
+      amount: '',
+    }),
     valueChangeCounterOffset: 0,
   });
 });


### PR DESCRIPTION
## What I did

1. Override set modelValue and get modelValue
2. _initModelValueBasedOnDropdown checks currency and amount properties instead of modelValue itself
2. [amount-dropdown-integrations.test.js] Add parser and getExpectedModelValueForEmptyInputNode
3. [FormatMixin.suite.js] Add parser and getExpectedModelValueForEmptyInputNode to interface
4. Update tests to be more generic
