### PR TITLE
Fix/tel dropdown

### DIFF
--- a/.changeset/pretty-ideas-count.md
+++ b/.changeset/pretty-ideas-count.md
@@ -1,0 +1,5 @@
+---
+'@lion/ui': patch
+---
+
+[input-tel-dropdown] fix syncing between input with dropdown

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
@@ -36,11 +36,11 @@ const telDropdownConfig = {
 /**
  * @param {{ klass:LionInputTelDropdown, config: {} }} config
  */
-export function runInputTelDropdownParenthesesSuite({
+
+export function runInputTelDropdownParenthesesSuite(
   // @ts-ignore
-  klass = LionInputTelDropdown,
-  config = telDropdownConfig,
-}) {
+  { klass, config } = { klass: LionInputTelDropdown, config: telDropdownConfig },
+) {
   // @ts-ignore
   const tagName = defineCE(/** @type {* & HTMLElement} */ (class extends klass {}));
   const tag = unsafeStatic(tagName);

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
@@ -80,7 +80,6 @@ export function runInputTelDropdownParenthesesSuite(
         await sendKeys({
           type: '(+91) 99',
         });
-
         await sendKeys({ press: 'Backspace' });
         // @ts-ignore
         expect(input.value).to.equal('(+91) 9');

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
@@ -6,11 +6,11 @@ import { LionInputTelDropdown } from '@lion/ui/input-tel-dropdown.js';
 import { PhoneUtilManager } from '@lion/ui/input-tel.js';
 import { sendKeys, selectOption } from '@web/test-runner-commands';
 import {
-  defineCE,
   expect,
+  defineCE,
+  unsafeStatic,
   fixture as _fixture,
   html,
-  unsafeStatic,
   waitUntil,
 } from '@open-wc/testing';
 
@@ -28,19 +28,19 @@ const fixture = /** @type {(arg: string | TemplateResult) => Promise<LionInputTe
  */
 const telDropdownConfig = {
   getTelDropdownInvokerEl: el => el.querySelector('select'),
-  waitUntilDropdownMenuIsVisible: async () => true,
   selectNlOption: async () => {
     await selectOption({ selector: 'select', value: 'NL' });
   },
 };
 
 /**
- * @param {{ klass:LionInputTelDropdown, config: typeof telDropdownConfig }} config
+ * @param {{ klass:LionInputTelDropdown, config: {} }} config
  */
-export function runInputTelDropdownParenthesesSuite(
-  // @ts-expect-error
-  { klass, config } = { klass: LionInputTelDropdown, config: telDropdownConfig },
-) {
+export function runInputTelDropdownParenthesesSuite({
+  // @ts-ignore
+  klass = LionInputTelDropdown,
+  config = telDropdownConfig,
+}) {
   // @ts-ignore
   const tagName = defineCE(/** @type {* & HTMLElement} */ (class extends klass {}));
   const tag = unsafeStatic(tagName);

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
@@ -34,7 +34,7 @@ const telDropdownConfig = {
 };
 
 /**
- * @param {{ klass:LionInputTelDropdown, config: {} }} config
+ * @param {{ klass:LionInputTelDropdown, config: TelDropdownConfig }} config
  */
 
 export function runInputTelDropdownParenthesesSuite(
@@ -75,24 +75,12 @@ export function runInputTelDropdownParenthesesSuite(
         // @ts-ignore
         input.value = '';
         // @ts-ignore
-        input.value = '(+91) 99451 46400';
-        // @ts-ignore
         input.focus();
-        /*
-         * Remove characters from the input untile we get '(+91) 9'
-         */
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
-        await sendKeys({ press: 'Backspace' });
         // @ts-ignore
-        expect(input.value).to.equal('(+91) 99');
-        expect(el.activeRegion).to.equal('IN');
+        await sendKeys({
+          type: '(+91) 99',
+        });
+
         await sendKeys({ press: 'Backspace' });
         // @ts-ignore
         expect(input.value).to.equal('(+91) 9');

--- a/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
+++ b/packages/ui/components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js
@@ -1,0 +1,103 @@
+/**
+ * The tests suites for the components that have `this.formatCountryCodeStyle = 'parentheses';`
+ */
+
+import { LionInputTelDropdown } from '@lion/ui/input-tel-dropdown.js';
+import { PhoneUtilManager } from '@lion/ui/input-tel.js';
+import { sendKeys, selectOption } from '@web/test-runner-commands';
+import {
+  defineCE,
+  expect,
+  fixture as _fixture,
+  html,
+  unsafeStatic,
+  waitUntil,
+} from '@open-wc/testing';
+
+/**
+ * @typedef {import('lit').TemplateResult} TemplateResult
+ * @typedef {import('./types.js').TelDropdownConfig} TelDropdownConfig
+ */
+
+const fixture = /** @type {(arg: string | TemplateResult) => Promise<LionInputTelDropdown>} */ (
+  _fixture
+);
+
+/**
+ * @type {TelDropdownConfig}
+ */
+const telDropdownConfig = {
+  getTelDropdownInvokerEl: el => el.querySelector('select'),
+  waitUntilDropdownMenuIsVisible: async () => true,
+  selectNlOption: async () => {
+    await selectOption({ selector: 'select', value: 'NL' });
+  },
+};
+
+/**
+ * @param {{ klass:LionInputTelDropdown, config: typeof telDropdownConfig }} config
+ */
+export function runInputTelDropdownParenthesesSuite(
+  // @ts-expect-error
+  { klass, config } = { klass: LionInputTelDropdown, config: telDropdownConfig },
+) {
+  // @ts-ignore
+  const tagName = defineCE(/** @type {* & HTMLElement} */ (class extends klass {}));
+  const tag = unsafeStatic(tagName);
+
+  describe('LionInputTelDropdown suite with `parentheses`', () => {
+    /**
+     * @type {LionInputTelDropdown}
+     */
+    let el;
+    beforeEach(async () => {
+      // Wait till PhoneUtilManager has been loaded
+      await PhoneUtilManager.loadComplete;
+      el = await fixture(html` <${tag} format-country-code-style="parentheses"></${tag}> `);
+      await el.updateComplete;
+    });
+
+    describe('Dropdown value is in sync with text input', () => {
+      it('should set correct active region when selecting a country from dropdown ', async () => {
+        const dropdownInvoker = config.getTelDropdownInvokerEl(el);
+        // @ts-ignore
+        await waitUntil(() => dropdownInvoker?.checkVisibility());
+        await config.selectNlOption(el);
+        expect(el.activeRegion).to.equal('NL');
+      });
+
+      it('updates dropdown value', async () => {
+        const dropdown = config.getTelDropdownInvokerEl(el);
+        // @ts-ignore
+        await waitUntil(() => dropdown?.checkVisibility());
+        const input = el.querySelector('input');
+        expect(input).to.exist;
+        // @ts-ignore
+        input.value = '';
+        // @ts-ignore
+        input.value = '(+91) 99451 46400';
+        // @ts-ignore
+        input.focus();
+        /*
+         * Remove characters from the input untile we get '(+91) 9'
+         */
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        await sendKeys({ press: 'Backspace' });
+        // @ts-ignore
+        expect(input.value).to.equal('(+91) 99');
+        expect(el.activeRegion).to.equal('IN');
+        await sendKeys({ press: 'Backspace' });
+        // @ts-ignore
+        expect(input.value).to.equal('(+91) 9');
+        expect(el.activeRegion).to.equal('IN');
+      });
+    });
+  });
+}

--- a/packages/ui/components/input-tel-dropdown/test-suites/types.ts
+++ b/packages/ui/components/input-tel-dropdown/test-suites/types.ts
@@ -1,0 +1,6 @@
+import { LionInputTelDropdown } from '@lion/ui/input-tel-dropdown.js';
+
+export type TelDropdownConfig = {
+  getTelDropdownInvokerEl: (el: LionInputTelDropdown) => HTMLElement | null;
+  selectNlOption: (el: LionInputTelDropdown) => Promise<void>;
+};

--- a/packages/ui/components/input-tel-dropdown/test/LionInputTelDropdown.test.js
+++ b/packages/ui/components/input-tel-dropdown/test/LionInputTelDropdown.test.js
@@ -1,5 +1,8 @@
 import { mimicUserChangingDropdown } from '@lion/ui/input-tel-dropdown-test-helpers.js';
-import { runInputTelDropdownSuite } from '@lion/ui/input-tel-dropdown-test-suites.js';
+import {
+  runInputTelDropdownSuite,
+  runInputTelDropdownParenthesesSuite,
+} from '@lion/ui/input-tel-dropdown-test-suites.js';
 import { LionInputTelDropdown } from '@lion/ui/input-tel-dropdown.js';
 import { runInputTelSuite } from '@lion/ui/input-tel-test-suites.js';
 import { aTimeout, expect, fixture } from '@open-wc/testing';
@@ -63,6 +66,7 @@ class WithFormControlInputTelDropdown extends ScopedElementsMixin(LionInputTelDr
 // @ts-expect-error
 runInputTelSuite({ klass: LionInputTelDropdown });
 runInputTelDropdownSuite();
+runInputTelDropdownParenthesesSuite();
 
 describe('WithFormControlInputTelDropdown', () => {
   // @ts-expect-error

--- a/packages/ui/components/input-tel/src/LionInputTel.js
+++ b/packages/ui/components/input-tel/src/LionInputTel.js
@@ -1,4 +1,3 @@
-import { Unparseable } from '@lion/ui/form-core.js';
 import { LocalizeMixin } from '@lion/ui/localize-no-side-effects.js';
 import { LionInput } from '@lion/ui/input.js';
 
@@ -325,9 +324,7 @@ export class LionInputTel extends LocalizeMixin(LionInput) {
 
     // 2. Try to derive action region from user value
     const regex = /[+0-9]+/gi;
-    const value = !(this.modelValue instanceof Unparseable)
-      ? this.modelValue
-      : this.value.match(regex)?.join('');
+    const value = this.value.match(regex)?.join('');
     const regionDerivedFromValue =
       value && this._phoneUtil && this._phoneUtil.parsePhoneNumber(value).regionCode;
 

--- a/packages/ui/exports/input-tel-dropdown-test-suites.js
+++ b/packages/ui/exports/input-tel-dropdown-test-suites.js
@@ -1,1 +1,2 @@
 export { runInputTelDropdownSuite } from '../components/input-tel-dropdown/test-suites/LionInputTelDropdown.suite.js';
+export { runInputTelDropdownParenthesesSuite } from '../components/input-tel-dropdown/test-suites/LionInputTelDropdown--parentheses.suite.js';

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -48,7 +48,7 @@ export default {
     threshold: { statements: 95, functions: 95, branches: 95, lines: 95 },
   },
   testFramework: {
-    config: { timeout: '5000' },
+    config: { timeout: '5000000' },
   },
   testRunnerHtml: config.shouldLoadPolyfill ? testRunnerHtmlWithPolyfill : undefined,
   browsers: [

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -48,7 +48,7 @@ export default {
     threshold: { statements: 95, functions: 95, branches: 95, lines: 95 },
   },
   testFramework: {
-    config: { timeout: '5000000' },
+    config: { timeout: '5000' },
   },
   testRunnerHtml: config.shouldLoadPolyfill ? testRunnerHtmlWithPolyfill : undefined,
   browsers: [


### PR DESCRIPTION
Fix syncing between the tel dropdown value and its input. Fix allows recognize the country code for cases when the number is too short